### PR TITLE
Docs for \c, \C, \x and \X

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -282,6 +282,51 @@ Examples of word characters:
     0409 Љ CYRILLIC CAPITAL LETTER LJE
     =end code
 
+=head3 X<C<\c> and C<\C>|regex,\c;regex,\C>
+
+C<\c> takes a parameter delimited by square-brackets which is the name
+of a Unicode character as it appears in the
+L<Unicode Character Database (UCD)|https://unicode.org/ucd/> and matches
+that specific character. For example:
+
+    'a.b' ~~ /\c[FULL STOP]/ and say ~$/;    # OUTPUT: «.»
+
+C<\C> matches a single character that is not the named Unicode character.
+
+Note that the word "character" is used, here, in the sense that the UCD
+does, but because Perl 6 uses L<NFG|/language/glossary#NFG>, combining
+code points and the base characters to which they are attached,
+will generally not match individually. For example if you compose
+C<"ü"> as C<"u\x[0308]">, that works just fine, but matching may surprise
+you:
+
+     say "u\x[0308]" ~~ /u/;    # OUTPUT: «Nil»
+
+To match the unmodified character, you can use the
+L<C<:ignoremark>|#regex adverb,:ignoremark> adverb.
+
+=head3 C<C<\x> and C<\X>|regex,\x;regex,\X>
+
+C<\x> takes a paramter delimited by square-brackets which is the
+hexadecimal representation of the Unicode codepoint representing the
+character to be matched. For example:
+
+    'a.b' ~~ /\x[2E]/ and say ~$/;    # OUTPUT: «.»
+
+C<\X> matches a single character that is not the given Unicode codepoint.
+
+In addition, C<\x> and C<\X> can be used without brackets, in which case, any
+characters that follow the C<x> or C<X> that are valid hexadecimal digits will
+be consumed. This means that all of these are equivalent:
+
+    /\x2e/ and /\x002e/ and /\x00002e/
+
+But this format can be ambiguous, so the use of surrounding whitespace is
+highly recommended.
+
+For additional provisos with respect to combining codepoints, see
+L<C<\c> and C<\C>|#regex,\c>.
+
 =head2 Predefined character classes
 
 =begin table

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -322,7 +322,7 @@ be consumed. This means that all of these are equivalent:
     /\x2e/ and /\x002e/ and /\x00002e/
 
 But this format can be ambiguous, so the use of surrounding whitespace is
-highly recommended.
+highly recommended in non-trivial expressions.
 
 For additional provisos with respect to combining codepoints, see
 L<C<\c> and C<\C>|#regex,\c>.

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -300,7 +300,7 @@ will generally not match individually. For example if you compose
 C<"ü"> as C<"u\x[0308]">, that works just fine, but matching may surprise
 you:
 
-     say "u\x[0308]" ~~ /u/;    # OUTPUT: «Nil»
+     say "u\x[0308]" ~~ /\c[LATIN SMALL LETTER U]/;    # OUTPUT: «Nil»
 
 To match the unmodified character, you can use the
 L<C<:ignoremark>|#regex adverb,:ignoremark> adverb.

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -305,7 +305,7 @@ you:
 To match the unmodified character, you can use the
 L<C<:ignoremark>|#regex adverb,:ignoremark> adverb.
 
-=head3 C<C<\x> and C<\X>|regex,\x;regex,\X>
+=head3 X<C<\x> and C<\X>|regex,\x;regex,\X>
 
 C<\x> takes a paramter delimited by square-brackets which is the
 hexadecimal representation of the Unicode codepoint representing the


### PR DESCRIPTION
These sequences were only documented within enumerated character classes, but can appear just like `\w` and friends as top-level atoms, and so should be documented with them. Also, the documentation even within character classes was pretty thin, so this seeks to rectify that situation.

**Note** I'm having trouble with the build system, so I can verify that they pass through the parser, but can't actually get to the stage of writing html...
