### PR TITLE
Fixing a very small error in Baggy

### DIFF
--- a/doc/Type/Baggy.pod6
+++ b/doc/Type/Baggy.pod6
@@ -337,7 +337,7 @@ weights, i.e. L<Bag|/type/Bag> and L<BagHash|/type/BagHash>.
     say $breakfast.kxxv.sort;                         # OUTPUT: «(bacon eggs spam spam spam)␤»
 
     my $n = ("a" => 0, "b" => 1, "b" => 2).BagHash;
-    say $n.kxxv;                                      # OUTPUT: «(b b b)␤»
+    say $n.kxxv;                                      # OUTPUT: «(a b b)␤»
 
 =head2 method elems
 


### PR DESCRIPTION
## The problem

The example output shows `(b b b)`, but it ought to be `(a b b)`  or some permutation of that.

## Solution provided

I changed the example output to `(a b b)`. This is still slightly misleading as that's only one of 3 possible outcomes, but it's better than `(b b b)` which is none of the possible outcomes.