### PR TITLE
Some Raku<->Perl6 changes, some misc editing also

### DIFF
--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -308,8 +308,9 @@ X<|Data::Dumper (FAQ)>
 Typical options are to use the L<say|/routine/say> routine that uses
 the L<gist|/routine/gist> method which gives the "gist" of the object being
 dumped. More detailed output can be obtained by calling the
-L<perl|/routine/perl> method that typically returns an object's representation
-in L<EVAL|/routine/EVAL>-able code.
+L<perl|/routine/perl> method (soon to be deprecated in favor of C<$obj.raku>,
+available since the Rakudo 2019.11 release) that typically returns an object's
+representation in L<EVAL|/routine/EVAL>-able code.
 
 If you're using the L<rakudo|https://rakudo.org> implementation, you can use
 the L«rakudo-specific C<dd> routine|/programs/01-debugging#Dumper_function_dd»
@@ -677,8 +678,8 @@ about the object deemed unimportant to understanding the essence of the object.
 
 Or phrased differently, C<$obj.Str> gives a string representation,
 C<$obj.gist> provides a short summary of that object suitable for
-fast recognition by a human, and C<$obj.perl> gives a Rakuish representation
-from which the object could be re-created.
+fast recognition by a human, and C<$obj.perl> (C<$obj.raku>) gives a Rakuish
+representation from which the object could be re-created.
 
 For example, when the C<Str> method is invoked on a type object, also known
 as an "undefined value", the type is stringified to an empty string
@@ -694,8 +695,8 @@ say $x;         # OUTPUT: «(Date)␤»
 
 If you'd like to show a debugging version of an object, it is probably better
 to use the L«rakudo-specific C<dd> routine|/programs/01-debugging#Dumper_function_dd».
-It essentially does a C<$obj.perl> and shows that on STDERR rather than STDOUT,
-so it won't interfere with any "normal" output of your program.
+It essentially does a C<$obj.perl> (C<$obj.raku>) and shows that on STDERR rather than
+STDOUT, so it won't interfere with any "normal" output of your program.
 
 In short, C<say> is optimized for casual human interpretation, C<dd> is optimized
 for casual debugging output and C<print> and C<put> are more generally suitable

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -6,8 +6,8 @@
 
 =head1 General
 
-X<|Rakudo, Raku and Raku (FAQ)>
-=head2 What's the difference between Raku, Rakudo and Raku?
+X<|Rakudo, Raku and Perl 6 (FAQ)>
+=head2 What's the difference between Raku, Rakudo and Perl 6?
 
 Properly speaking, L<Rakudo|https://rakudo.org/> is an implementation of Raku.
 It's currently the one that's being developed, but there have been other
@@ -23,7 +23,7 @@ The Rakudo 2015.12 implementation version was released on December 25th 2015.
 =head2 Is there a Raku version 6.0.0?
 
 No. The first stable language specification version is v6.c
-("Christmas"). Future versions of the spec may have point releases (e.g.
+("Christmas"). Future versions of the spec may have point releases (e.g.,
 v6.d.2) or major releases (e.g., v6.e).
 
 Running C<perl6 -v> will display the language version your compiler
@@ -81,8 +81,8 @@ X<|rakudobrew (FAQ)>
 
 An option is to clone L<the repository|https://github.com/rakudo/rakudo> and
 build it. This will install work in progress which is minimally-tested and
-may contain severe bugs. If you're interested in contributing to Rakudo
-Raku compiler, you may find
+may contain severe bugs. If you're interested in contributing to the Rakudo
+Raku compiler, you may find the
 L<Z-Script helper tool|https://github.com/zoffixznet/z> useful.
 
 To install the last official monthly release, check out the tag visible
@@ -114,8 +114,8 @@ Anything published before December, 2015 likely describes a pre-release
 version of Raku.
 
 You can always
-L<get help from a live human in our help chat|https://webchat.freenode.net/?channels=#perl6>
-or L<search the chat logs|https://colabti.org/irclogger/irclogger_log_search/perl6>
+L<get help from a live human in our help chat|https://webchat.freenode.net/?channels=#raku>
+or L<search the chat logs|https://colabti.org/irclogger/irclogger_log_search/raku>
 to find previous conversations and discussions.
 
 X<|Books>
@@ -131,17 +131,17 @@ Here are some available books, in alphabetical order:
 =item L<Metagenomics|https://www.gitbook.com/book/kyclark/metagenomics/details>,
 by Ken Youens-Clark
 
-=item L<Parsing with Raku Regexes and Grammars|https://smile.amazon.com/dp/1484232275/>, by Moritz Lenz
+=item L<Parsing with Perl 6 Regexes and Grammars|https://smile.amazon.com/dp/1484232275/>, by Moritz Lenz
 
-=item L<Raku at a Glance|https://deeptext.media/perl6-at-a-glance/>,
+=item L<Perl 6 at a Glance|https://deeptext.media/perl6-at-a-glance/>,
 by Andrew Shitov
 
-=item L<Raku Fundamentals|https://www.apress.com/us/book/9781484228982>,
+=item L<Perl 6 Fundamentals|https://www.apress.com/us/book/9781484228982>,
 by Moritz Lenz
 
-=item L<Raku Deep Dive|https://www.packtpub.com/application-development/perl-6-deep-dive">, by Andrew Shitov
+=item L<Perl 6 Deep Dive|https://www.packtpub.com/application-development/perl-6-deep-dive>, by Andrew Shitov
 
-=item L<Think Raku: How to Think Like a Computer Scientist|https://greenteapress.com/wp/think-perl-6/>, by Laurent Rosenfeld.
+=item L<Think Perl 6: How to Think Like a Computer Scientist|https://greenteapress.com/wp/think-perl-6/>, by Laurent Rosenfeld.
 
 A list of books published or in progress is maintained in
 L<C<raku.org>|https://raku.org/resources/>.
@@ -295,7 +295,7 @@ have to know what B means when we parse A, which is clearly an
 infinite loop.
 
 Note that Raku has no “1 file = 1 class” limitation, and circular
-dependencies within a single compilation unit (e.g. file) are possible
+dependencies within a single compilation unit (e.g., file) are possible
 through stubbing. Therefore another possible solution is to move
 classes into the same compilation unit.
 
@@ -559,7 +559,7 @@ You can force list context with C<@( ... )> or by calling the
 C<.list> method on an expression, and item context with
 C<$( ... )> or by calling the C<.item> method on an expression.
 
-See the L«I<Raku: Sigils, Variables, and Containers>|https://perl6advent.wordpress.com/2017/12/02/» article to learn more.
+See the L«I<Perl 6: Sigils, Variables, and Containers>|https://perl6advent.wordpress.com/2017/12/02/» article to learn more.
 
 X<|Sigils (FAQ)>
 =head2 Why sigils? Couldn't you do without them?
@@ -588,7 +588,7 @@ my $foo = "abc";
 say "$foo<html-tag>";
 =end code
 
-Raku thinks C<$foo> to be a Hash and C«<html-tag>» to be a string literal
+Raku thinks C<$foo> is a Hash and C«<html-tag>» is a string literal
 hash key. Use a closure to help it to understand you.
 
 =begin code
@@ -668,7 +668,7 @@ view is read-only by default, and you can still access it internally with C<$!x>
 The most obvious difference is that C<say> and C<put> append
 a newline at the end of the output, and C<print> does not.
 
-But there's another difference: C<print> and C<put> convert its
+But there's another difference: C<print> and C<put> convert their
 arguments to a string by calling the C<Str> method on each item
 passed to them while C<say> uses the C<gist> method. The C<gist> method,
 which you can also create for your own classes, is intended to create a
@@ -677,7 +677,7 @@ about the object deemed unimportant to understanding the essence of the object.
 
 Or phrased differently, C<$obj.Str> gives a string representation,
 C<$obj.gist> provides a short summary of that object suitable for
-fast recognition by a human, and C<$obj.perl> gives a Perlish representation
+fast recognition by a human, and C<$obj.perl> gives a Rakuish representation
 from which the object could be re-created.
 
 For example, when the C<Str> method is invoked on a type object, also known
@@ -796,7 +796,7 @@ However, the currently available compilers do not support creating a standalone
 executable yet.
 
 If you wish to help out, the I<Rakudo> compiler on I<MoarVM> backend has
-L<https://github.com/MoarVM/MoarVM/issues/875> Issue opened as a place to
+L<https://github.com/MoarVM/MoarVM/issues/875> issue opened as a place to
 discuss this problem.
 
 X<|Raku Distribution (FAQ)>
@@ -810,7 +810,7 @@ announcements L<posted on rakudo.org|https://rakudo.org/posts>.
 
 =head1 Metaquestions and advocacy
 
-=head2 Why is Raku called Perl?
+=head2 Why was Raku originally called Perl 6?
 
 … As opposed to some other name that didn't imply all the things
 that the higher number might indicate on other languages.


### PR DESCRIPTION
Some "Perl 6"s which look like they had accidentally been changed to "Raku" changed back. Some "Perl 6"-ish words changed to their "Raku"-ish equivalent. Some misc editing fixes.