### PR TITLE
Substitute Perl 6 with Raku

### DIFF
--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -924,7 +924,7 @@ smartmatches against C<$where> through the C<&filter>. With the default
 filter (first character to upper case, rest to lower) and matcher (which
 accepts everything), this title-cases each word:
 
-    say "perl 6 programming".wordcase;      # OUTPUT: «Raku Programming␤»
+    say "raku programming".wordcase;        # OUTPUT: «Raku Programming␤»
 
 With a matcher:
 
@@ -956,8 +956,8 @@ If C<$string> is longer than
 C<$pattern>, the case information from the last character of C<$pattern> is
 applied to the remaining characters of C<$string>.
 
-    say "perL 6".samecase("A__a__"); # OUTPUT: «Raku␤»
-    say "pERL 6".samecase("Ab");     # OUTPUT: «Raku␤»
+    say "raKu".samecase("A_a_"); # OUTPUT: «Raku␤»
+    say "rAKU".samecase("Ab");   # OUTPUT: «Raku␤»
 
 =head2 routine uniprop
 


### PR DESCRIPTION
Handle irregular cases (pun intended) and whitespace to complete #3054.
These were probably missed by d41ea22d13ff2b91a9fb2be9cbc8aa8db848e587.