### PR TITLE
Be more specific in selecting href to "external" sites

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -580,7 +580,7 @@ div.highlight span.c-Singleline, div.highlight span.c {
     }
 }
 
-a[href*="//"]:not([href*="perl6.org"])::after,
+a[href*="://"]:not([href*="perl6.org"])::after,
 [href="https://perl6.org"]::after,
 [href="/webchat.html"]::after,
 [href="/examples.html"]::after {


### PR DESCRIPTION
...and thus avoid selecting the "internal" link to language/operators#infix_//
as seen in doc/Language/typesystem.pod6

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
