### PR TITLE
P6-101 text refinement + expansion of assignment operators section; closes: #2920

### DIFF
--- a/doc/Language/101-basics.pod6
+++ b/doc/Language/101-basics.pod6
@@ -241,20 +241,33 @@ The program then counts the number of sets each player has won:
 %sets{$p2} += $r2;
 =end code
 
-The C<+=> assignment operator is a shortcut for:
+The above two statements involve the C<+=> compound assignment operator. They
+are a variant of the following two statements that use the simple assignment
+operator C<=> and that may be easier to understand at first sight:
 
 =begin code :preamble<my %sets;my $p1;my $p2;my $r1;my $r2>
 %sets{$p1} = %sets{$p1} + $r1;
 %sets{$p2} = %sets{$p2} + $r2;
 =end code
 
+For your program, the shorthand version using the C<+=> compound assignment
+operator is preferred over the longhand version using the simple assignment
+operator C<=>. This is so not only because the shorter version requires less
+typing, but also because the C<+=> operator silently initializes undefined
+values of the hash's key-value pairs to zero. In other words: by using C<+=>,
+there is no need to include a separate statement like C<%sets{$p1} = 0> before
+you can meaningfully add C<$r1> to it. We'll look at this is behavior in a bit
+more detail below.
+
+
 =head3 X<C<Any>| Any (Basics)> and X<C<+=>>
 
-C<+= $r1> means I<increase the value in the variable on the left by $r1>. In
-the first iteration C<%sets{$p1}> is not yet set, so it defaults to a special
-value called C<Any>. The addition and incrementing operators treat C<Any> as a
-number with the value of zero; the strings get automatically converted to
-numbers, as addition is a numeric operation.
+C<+= $r1> means I<increase the value in the variable on the left by $r1>. In the
+first iteration C<%sets{$p1}> is not yet defined, so it defaults to a special
+value called C<Any>. The C<+=> operator conveniently treats the undefined value
+C<Any> as a number with the value C<0>, allowing it to sensibly add some other
+value to it. To perform the addition, the strings C<$r1>, C<$r2>, etc. are
+automatically converted to numbers, as addition is a numeric operation.
 
 =head3 X<C<fat arrow>>,  X<C<pair>> and X<C<autovivification>>
 
@@ -280,11 +293,11 @@ autovivified by the increment operation.
 
 =head3 X<C<postincrement>> and X<C<preincrement>>
 
-C<$thing++> is short for C<$thing += 1> or C<$thing = $thing + 1>, with the
-small exception that the return value of the expression is C<$thing> I<before>
-the increment, not the incremented value. As in many other
-programming languages, you can use C<++> as a prefix. Then it returns the
-incremented value; C<my $x = 1; say ++$x> prints C<2>.
+C<$thing++> is a variant of C<$thing += 1>; it differs from the latter in that
+the return value of the expression is C<$thing> I<before> the increment, and not
+the incremented value. As in many other programming languages, you can use C<++>
+as a prefix. Then it returns the incremented value: C<my $x = 1; say ++$x>
+prints C<2>.
 
 =begin code :preamble<my @names;my %sets;my %matches>
 my @sorted = @names.sort({ %sets{$_} }).sort({ %matches{$_} }).reverse;

--- a/doc/Language/101-basics.pod6
+++ b/doc/Language/101-basics.pod6
@@ -252,7 +252,7 @@ operator C<=> and that may be easier to understand at first sight:
 
 For your program, the shorthand version using the C<+=> compound assignment
 operator is preferred over the longhand version using the simple assignment
-operator C<=>. This is so not only because the shorter version requires less
+operator C<=>. This is not only because the shorter version requires less
 typing, but also because the C<+=> operator silently initializes undefined
 values of the hash's key-value pairs to zero. In other words: by using C<+=>,
 there is no need to include a separate statement like C<%sets{$p1} = 0> before

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -34,10 +34,11 @@ associativity. As the two operators are I<left associative>, operations are
 grouped from the left like this: C<(100 / 2) * 10>. The expression thus
 evaluates to C<500>, rather than to C<5>.
 
-The following table summarizes the associativities (column labeled C<A>) and
-precedence levels (column labeled C<Level>) offered by Raku, listing them in
-order from high to low precedence. For each precedence level, some exemplary
-operators are listed.
+The following table summarizes the precedence levels (column labeled C<Level>)
+offered by Raku, listing them in order from high to low precedence. For each
+precedence level the table also indicates the associativity of the operators
+assigned to that level (column labeled C<A>), and some exemplary operators
+(column labeled C<Examples>).
 
 =begin table
 
@@ -74,10 +75,9 @@ operators are listed.
 =end table
 
 The following table further clarifies the meaning of the associativity symbols
-(C<L R N C X>) specified above in column C<A>, and uses a generic C<!> operator
-symbol representing a binary operator to illustrate how the associativities
-affect the interpretation of an expression involving two binary operators of
-equal precedence:
+(C<L R N C X>) specified above in column C<A>. Using a fictitious C<!> binary
+operator symbol, it shows how each associativity affects the interpretation of
+of an expression involving two such operators of equal precedence:
 
 =begin table
 
@@ -91,7 +91,7 @@ equal precedence:
 
 =end table
 
-For unary operators generically represented by a C<!> symbol the
+For unary operators generically represented by a C<!> symbol, the
 associativites C<L R N> lead to the following interpretations:
 
 =begin table
@@ -254,10 +254,11 @@ value untouched and instead returns the resultant string.
 Raku has a variety of assignment operators, which can be roughly classified as
 simple assignment operators and compound assignment operators.
 
-The simple assignment operator symbol is C<=>. It is 'overloaded' since it can
-mean either L<item assignment|/language/operators#infix_=_(item_assignment)> or
-L<list assignment|/language_operators#infix_=_(list_assignment)> depending on
-the context in which it is used:
+The simple assignment operator symbol is C<=>. It is 'overloaded' in the sense
+that it can mean either L<item
+assignment|/language/operators#infix_=_(item_assignment)> or L<list
+assignment|/language_operators#infix_=_(list_assignment)> depending on the
+context in which it is used:
 
     my $x = 1;        # item assignment; $x = 1
     my @x = 1,2,3;    # list assignment; @x = [1,2,3]
@@ -302,7 +303,7 @@ assigned value:
 
 In the first example, the assignment expression C<my $y = fac(100)> declares
 C<$y>, assigns the value C<fac(100)> to it, and finally returns the assigned
-value C<fac(100)>; the returned value is then taken into account for
+value C<fac(100)>. The returned value is then taken into account for
 constructing the List. In the second example the compound-assignment expression
 C<$i += 1> assigns the value C<$i + 1> to C<$i>, and subsequently evaluates to
 the assigned value C<$i+1>, thus allowing the returned value to be used for
@@ -311,27 +312,32 @@ judging the while loop condition.
 In dealing with simple and compound assignment operators, it is tempting to
 think that for instance the following two statements are (always) equivalent:
 
-    expression1 += expression2;
-    expression1  = expression1 + expression2;
+    =for code :skip-test<pseudo code>
+    expression1 += expression2;                     # compound assignment
+    expression1  = expression1 + expression2;       # simple assignment
 
 They are not, however, for two reasons. Firstly, C<expression1> in the compound
-assignment is evaluated only once, whereas C<expression1> in the simple
-assignment is evaluated twice. Secondly, the compound assignment may, depending
-on the infix operator in question, effectively initialize an undefined variable
-appearing in C<expression1>, i.e. in the left operand. Such initialization will
-not occur for an undefined variable in the left operand of the simple
-assignment.
+assignment statement is evaluated only once, whereas C<expression1> in the
+simple assignment statement is evaluated twice. Secondly, the compound
+assignment statement may, depending on the infix operator in question,
+implicitly initialize C<expression1> if it is a variable with an undefined
+value. Such initialization will not occur for C<expression1> in the simple
+assignment statement.
 
-The first difference pointed out above is common amongst programming languages
-and mostly self-explanatory. In the compound assignment, C<expression1> is
-explicitly specified to serve both as a term of the addition to be performed and
-as the location where the result of the addition, the sum, is to be stored.
-There is thus no need to evaluate it twice. The simple assignment, in contrast,
-is more generic in the sense that C<expression1> as a term of the addition need
-not necessarily be the same as C<expression1> that defines the location where
-the sum must be stored. The two expressions are therefore evaluated separately.
-In cases where the evaluation of C<expression1> has side effects that change the
-state of variables, this distinction is relevant:
+The aforementioned two differences between the simple and compound assignment
+statements are briefly elucidated below.
+
+The first difference is common amongst programming languages and mostly
+self-explanatory. In the compound assignment, there is only one C<expression1>
+that is explicitly specified to serve both as a term of the addition to be
+performed and as the location where the result of the addition, the sum, is to
+be stored. There is thus no need to evaluate it twice. The simple assignment, in
+contrast, is more generic in the sense that the value of the C<expression1> that
+serves as a term of the addition need not necessarily be the same as the value
+of the C<expression1> that defines the location where the sum must be stored.
+The two expressions are therefore evaluated separately. The distinction is
+particularly relevant in cases where the evaluation of C<expression1> has side
+effects in the form of changes to one or more variables:
 
     my @arr = [10, 20, 30];
     my $i = 0;
@@ -340,10 +346,10 @@ state of variables, this distinction is relevant:
         @arr[++$i] += 1;                # @arr = [10,21,30]
     } else {
         @arr[++$i] = @arr[++$i] + 1;    # @arr = [10,31,30] (or [10,20,21]?)
-    }                                   # the result may be implementation specific
+    }                                   # the result may be implementation-specific
     say @arr;
 
-The second difference pointed out above is related to the common practice of
+The second difference pointed out above is related to the widespread practice of
 using compound assignment operators in I<accumulator patterns>. Such patterns
 involve a so-called I<accumulator>: a variable that calculates the sum or a
 product of a series of values in a loop. To obviate the need for explicit


### PR DESCRIPTION
## The problem

The P6-101 page included imprecise statements about the operation of compound assignment operators, and the actual behavior was not documented anywhere else.

## Solution provided

The relevant text of the P6-101 page has been corrected, and the 'Assignment operators' section of the Operators page has been expanded with more detailed information about the relation between simple and compound assignment operators, and the implicit initializing behavior of compound assignment operators.

Closes #2920