### PR TITLE
Adaptation of .batch description; closes #2969

### DIFF
--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -1109,10 +1109,13 @@ Defined As:
     multi method batch(Int:D $batch --> Seq)
     multi method batch(Int:D :$elems --> Seq)
 
-Returns a C<Seq> of the elements in batches of C<:$elems> or C<$batch>,
-respectively. If the number of elements is not a multiple of C<$batch>, the
-last batch may have less than C<$batch> elements, similar to
-C<.rotor($batch, :partial)>.
+Returns a sequence of lists, wherein each list with the exception of the last
+one is guaranteed to comprise a number of elements equal to the batch size
+specified by C<$batch> or C<$elems>, respectively. If the invocant has a number
+of elements that is not an integer multiple of the batch size, the last list in
+the returned sequence will contain any remaining elements and thus have less
+than C<$batch> or C<$elems> elements. Accordingly, C<.batch($batch)> is
+shorthand for C<.rotor($batch, :partial)>.
 
 =head2 routine cross
 


### PR DESCRIPTION
## The problem

.batch($batch) was imprecisely explained to be "similar" to .rotor($batch, :partial).
See #2969 

## Solution provided

Description of .batch rewritten to explain that .batch($batch) is shorthand for .rotor($batch, :partial), given that .rotor($batch, :partial) is implemented as .batch($batch,1):
https://github.com/rakudo/rakudo/blob/master/src/core.c/Any-iterable-methods.pm6#L2075