### PR TITLE
[WIP] Begin documenting HOW archetypes and document parameterization

### DIFF
--- a/doc/Language/mop.pod6
+++ b/doc/Language/mop.pod6
@@ -222,6 +222,82 @@ the subtleties of Raku in order to avoid pitfalls when working with the MOP,
 and can't expect the same L<"do what I mean"|/language/glossary#DWIM>
 convenience that ordinary Raku code offers.
 
+X<|Archetypes>
+
+=head1 Archetypes
+
+Typically, when multiple kinds of types share a property, it is
+implemented with a metarole to be mixed into their metaclasses. However,
+not all common properties of types can be implemented as mixins. One
+example of this is parameterization; while roles are the only kind in
+Rakudo that support this (ordinarily), types requiring arguments in
+order to be complete is not a concept unique to roles. Properties like
+this are known as I<archetypes>.
+
+HOWs should provide a C<archetypes> metamethod that takes no arguments
+and returns a C<Metamodel::Archetypes> instance. This is used by the
+compiler to determine what archetypes are supported by a metaobject.
+The rest of this section will cover how each of the archetypes that
+exist in Rakudo work.
+
+X<|Parameterization>
+
+=head2 Parameterization
+
+Parametric types are incomplete types that may have an arbitrary
+number of type parameters. When parameterized with type arguments,
+these will produce a complete type.
+
+If a HOW supports parameterization, it should have the parametric
+archetype and must provide a C<parameterize> metamethod. The
+C<parameterize> metamethod must accept a metaobject and may accept
+any number of type parameters as arguments, returning a metaobject.
+For example, a C<parameterize> metamethod that allows a type to be
+parameterized with any type arguments may have this signature:
+
+    method parameterize(Mu $obj is raw, |parameters --> Mu)
+
+=head3 Parametric classes and grammars
+
+Because of how the parametric archetype is implemented, it's possible
+for classes and grammars to be augmented with support for
+parameterization by giving them a C<parameterize> metamethod. This can
+be useful in cases where the features of roles make them inappropriate
+to use for a parametric type.
+
+One scenario where parametric classes and grammars are useful is when
+parameterizations of a type should override or add multiple dispatch
+candidates to existing methods or regexes on the original parametric
+type. This is the case with parameterizations of types like
+L<Array|/type/Array> and L<Hash|/type/Hash>, which may optionally be
+parameterized to mix in more type-safe versions of their methods that
+work with instances' values directly. In Rakudo, these are implemented
+as parametric classes using the metamethods provided by
+L<Metamodel::Mixins|/type/Metamodel::Mixins> and
+L<Metamodel::Naming|/type/Metamodel::Naming> to create a mixin of the
+metaobject given and reset its name before returning it.
+
+=for comment
+An example of parameterizations creating mixins is needed here.
+
+Parametric classes can also be used to simulate support for
+parameterization on other kinds. For instance, the
+L<Failable|https://modules.raku.org/dist/Failable:cpan:KAIEPI> ecosystem
+module is a parametric class that produces a subset upon
+parameterization. While the module does more work than this, a basic
+version of it can be implemented like so:
+
+=begin code
+class Failable {
+    method ^parameterize(Failable:U $this is raw, Mu $obj is raw --> Mu) {
+        Metamodel::SubsetHOW.new_type:
+            name       => $this.^name ~ '[' ~ $obj.^name ~ ']',
+            refinee    => Metamodel::Primitives.is_type($obj, Any) ?? Any !! Mu,
+            refinement => $obj | Failure
+    }
+}
+=end code
+
 =end pod
 
 # vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/mop.pod6
+++ b/doc/Language/mop.pod6
@@ -228,27 +228,28 @@ X<|Archetypes>
 
 Typically, when multiple kinds of types share a property, it is
 implemented with a metarole to be mixed into their metaclasses. However,
-not all common properties of types can be implemented as mixins. One
-example of this is parameterization; while roles are the only kind in
-Rakudo that support this (ordinarily), types requiring arguments in
-order to be complete is not a concept unique to roles. Properties like
-this are known as I<archetypes>.
+not all common properties of types can be implemented as mixins. Certain
+properties are common to various kinds of types, but do not share enough
+behaviour to be possible to implement as mixins. These properties are
+known as I<archetypes>.
 
 HOWs should provide a C<archetypes> metamethod that takes no arguments
 and returns a C<Metamodel::Archetypes> instance. This is used by the
-compiler to determine what archetypes are supported by a metaobject.
+compiler to determine what archetypes are supported by metaobjects.
 The rest of this section will cover how each of the archetypes that
 exist in Rakudo work.
 
 X<|Parameterization>
 
-=head2 Parameterization
+=head2 parametric
 
-Parametric types are incomplete types that may have an arbitrary
-number of type parameters. When parameterized with type arguments,
-these will produce a complete type.
+Parametric types are incomplete types that may have an arbitrary number
+of type parameters. Here, type parameters refer to parameters of the
+type itself; these may be any object that a signature allows you to
+include, not just types alone. When parameterized with type arguments,
+parametric types will produce a more complete type of some sort.
 
-If a HOW supports parameterization, it should have the parametric
+If a HOW supports parameterization, it should have the C<parametric>
 archetype and must provide a C<parameterize> metamethod. The
 C<parameterize> metamethod must accept a metaobject and may accept
 any number of type parameters as arguments, returning a metaobject.
@@ -261,9 +262,10 @@ parameterized with any type arguments may have this signature:
 
 Because of how the parametric archetype is implemented, it's possible
 for classes and grammars to be augmented with support for
-parameterization by giving them a C<parameterize> metamethod. This can
-be useful in cases where the features of roles make them inappropriate
-to use for a parametric type.
+parameterization by giving them a C<parameterize> metamethod, despite
+the type not having the C<parametric> archetype. This can be useful in
+cases where the features of roles make them inappropriate to use for a
+parametric type.
 
 One scenario where parametric classes and grammars are useful is when
 parameterizations of a type should override or add multiple dispatch
@@ -275,17 +277,44 @@ work with instances' values directly. In Rakudo, these are implemented
 as parametric classes using the metamethods provided by
 L<Metamodel::Mixins|/type/Metamodel::Mixins> and
 L<Metamodel::Naming|/type/Metamodel::Naming> to create a mixin of the
-metaobject given and reset its name before returning it.
+metaobject given and reset its name before returning it. This technique
+can be used to write extensible grammars when used in combination with
+multi tokens, for instance:
 
-=for comment
-An example of parameterizations creating mixins is needed here.
+=begin code
+grammar Bot::Grammar {
+    token TOP { <topic> || .+ }
+
+    proto token topic {*}
+    multi token topic:sym<command> { <command> <.ws> <command-args> }
+
+    token command      { '$' <!ws>+ }
+    token command-args { <!ws>+ % <.ws> }
+
+    method ^parameterize(::?CLASS:U $this is raw, +roles) {
+        my Str:D $name   = self.name: $this;
+        my Mu    $mixin := $this.^mixin: |roles;
+        $mixin.^set_name: [~] $name, '[', roles.map(*.^name).join(','), ']';
+        $mixin
+    }
+}
+
+role Greetings[Str:D $name] {
+    multi token topic:sym<greeting> { ^ [ 'hi' | 'hello' | 'hey' | 'sup' ] <.ws> $name }
+}
+
+my constant GreetBot = Bot::Grammar[Greetings['GreetBot']];
+GreetBot.parse: 'sup GreetBot';
+say ~$/; # OUTPUT: «sup GreetBot␤»
+=end code
 
 Parametric classes can also be used to simulate support for
 parameterization on other kinds. For instance, the
 L<Failable|https://modules.raku.org/dist/Failable:cpan:KAIEPI> ecosystem
 module is a parametric class that produces a subset upon
-parameterization. While the module does more work than this, a basic
-version of it can be implemented like so:
+parameterization. While the module itself does some caching to ensure no
+more type objects are made than what's necessary, a more basic version
+of it can be implemented like so:
 
 =begin code
 class Failable {

--- a/xt/words.pws
+++ b/xt/words.pws
@@ -379,6 +379,7 @@ facename
 facenamedoublesize
 facesize
 fagner
+Failable
 failover
 fallbacks
 fallthru
@@ -867,6 +868,7 @@ parallelize
 param
 parameterization
 parameterizations
+parameterize
 parameterized
 parameterizing
 parameterless
@@ -1025,6 +1027,7 @@ redispatch
 redispatcher
 reducecheck
 reentrant
+refinee
 regex
 regexes
 reification
@@ -1218,6 +1221,7 @@ subscripting
 subsep
 subsequence
 subsetting
+SubsetHOW
 subst
 substr
 substring


### PR DESCRIPTION
## The problem
See https://github.com/Raku/doc/issues/3132

## Solution provided
Parametricity is an archetype; archetypes are currently undocumented. This begins the process of documenting them, documents how parameterization works, and provides some examples of how parametric classes can be used.

I'm having some trouble coming up with a practical example of using mixins with the `parameterize` metamethod. My `Kind` ecosystem module does this, but it doesn't make a very good example because of the reasoning behind its use.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
