### PR TITLE
Io socket async listensocket

### DIFF
--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -146,8 +146,9 @@ be C<emit>ted. This L<Supply|/type/Supply> should be tapped start listening for
 client connections. You can use C<$port = 0> if you want the operating system to
 find one for you.
 
-To close the underlying listening socket, the L<Tap|/type/Tap> returned by
-tapping the listener should be C<close>d.
+To close the underlying listening socket, the
+L<IO::Socket::Async::ListenSocket|/type/IO::Socket::Async::ListenSocket>
+returned by tapping the listener should be C<close>d.
 
 For example, when using C<tap>:
 
@@ -171,6 +172,8 @@ react {
 # When you want to close the listener, you can still use:
 $tap.close;
 =end code
+
+The C<IO::Socket::Async::ListenSocket> returned by tapping also provides L<socket-host|/type/IO::Socket::Async::ListenSocket#method_socket-host> and L<socket-post|/type/IO::Socket::Async::ListenSocket#method_socker-port> methods. These allow for the discovery of the exact local host and port number the socket is listening on.
 
 =head2 method udp
 
@@ -268,8 +271,10 @@ Close the connected client L<IO::Socket::Async|/type/IO::Socket::Async> which wi
 obtained from the C<listen> L<Supply|/type/Supply> or the C<connect>
 L<Promise|/type/Promise>.
 
-In order to close the underlying listening socket created by C<listen> you
-can C<close> the L<Tap|/type/Tap>. See C<listen> for examples.
+In order to close the underlying listening socket created by C<listen> you can
+C<close> the
+L<IO::Socket::Async::ListenSocket/type/IO::Socket::Async::ListenSocket>. See
+L<listen|#method_listen> for examples.
 
 =head2 method socket-host
 

--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -6,7 +6,7 @@
 
     class IO::Socket::Async {}
 
-C<IO::Socket::Async|/type/IO::Socket::Async> provides asynchronous sockets, for both the
+C<IO::Socket::Async> provides asynchronous sockets, for both the
 server and the client side.
 
 Here is a simple example of a simple "hello world" HTTP server that

--- a/doc/Type/IO/Socket/Async/ListenSocket.pod6
+++ b/doc/Type/IO/Socket/Async/ListenSocket.pod6
@@ -1,0 +1,67 @@
+=begin pod :kind("Type") :subkind("class") :category("domain-specific")
+
+=TITLE class IO::Socket::Async::ListenSocket
+
+=SUBTITLE A tap for listening sockets
+
+    class IO::Socket::Async::ListenSocket is Tap {}
+
+C<IO::Socket::Async::ListenSocket> is returned by the C<tap
+method|/type/Supply#method_tap> when called on the L<Supply|/type/Supply>
+returned by calling the L<listen method|/type/IO::Socket::Async#method_listen>
+of L<IO::Socket::Async|/type/IO::Socket::Async>:
+
+=begin code
+my $listener = IO::Socket::Async.listen('127.0.0.1', 0).tap: -> $peer {
+    $peer.print: "Hello. Good-bye\n";
+    $peer.close;
+}
+
+my $host = await $tap.socket-host;
+my $port = await $tap.socket-port;
+
+say "The rude service is listening on $host:$port for the next 10 seconds...";
+
+sleep 10;
+$listener.close;
+
+say "I'm done now.";
+=end code
+
+Alternatively, by using the C<do> prefix to C<whenever>, you can also get it while inside a C<react> block:
+
+=begin code
+my $listener;
+react {
+    $listener = do whenever IO::Socket::Async.listen('127.0.0.1', 0) -> $peer {
+        $peer.print: "Hello. Good-bye\n";
+        $peer.close;
+    }
+}
+
+$listener.close;
+=end code
+
+=head1 Methods
+
+This object cannot be constructed. It is only returned when tapping the L<Supply|/type/Supply> returned by the L<listen method|/type/IO::Socket::Async#method_listen>.
+
+=head2 method socket-host
+
+    method socket-host(--> Promise)
+
+Returns a L<Promise|/type/Promise> that will be kept with a string containing the local listening host name.
+
+=head2 method socket-port
+
+    method socket-port(--> Promise)
+
+Returns a L<Promise|/type/Promise> that will be kept with the port number of the listening socket.
+
+=head2 method close
+
+    method close()
+
+Closes the listening socket as well as closing the tap.
+
+=end pod


### PR DESCRIPTION
## The problem
The documentation lists that you can set `$port = 0` when listening to allow the OS to pick your port number for you. However, this presents a serious problem, which is that now you have a listener, but have no idea what port number it is listening on. Fortunately, Raku provides a special object during `tap` that provides a `socket-host` and `socket-port` for learning this information. This is not documented in the official docs.

## Solution provided
I added documentation of the `IO::Socket::Async::ListenSocket` object returned during tapping and then make mention of it in the documentation for the `listen` method.
