### PR TITLE
Proofread IO::Socket::Async::ListenSocket docs and pass make xtest

### DIFF
--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -140,40 +140,19 @@ made.
 
     method listen(Str $host, Int $port --> Supply)
 
-Creates a listening socket on the specified C<$host> and C<$port>, returning a
-L<Supply|/type/Supply> to which the accepted client L<IO::Socket::Async|/type/IO::Socket::Async>s will
-be C<emit>ted. This L<Supply|/type/Supply> should be tapped start listening for
-client connections. You can use C<$port = 0> if you want the operating system to
-find one for you.
+Creates a listening socket on the specified C<$host> and C<$port>,
+returning a L<Supply|/type/Supply> to which the accepted client
+L<IO::Socket::Async|/type/IO::Socket::Async>s will be emitted. This
+L<Supply|/type/Supply> should be tapped start listening for client
+connections.  You can set C<$port> to C<0> if you want the operating
+system to find one for you.
 
-To close the underlying listening socket, the
-L<IO::Socket::Async::ListenSocket|/type/IO::Socket::Async::ListenSocket>
-returned by tapping the listener should be C<close>d.
-
-For example, when using C<tap>:
-
-=begin code
-my $listener = IO::Socket::Async.listen('127.0.0.1', 8080);
-my $tap = $listener.tap({ ... });
-
-# When you want to close the listener
-$tap.close;
-=end code
-
-Or when using C<whenever>:
-
-=begin code
-my $listener = IO::Socket::Async.listen('127.0.0.1', 5000);
-my $tap;
-react {
-    $tap = do whenever $listener -> $conn { ... }
-}
-
-# When you want to close the listener, you can still use:
-$tap.close;
-=end code
-
-The C<IO::Socket::Async::ListenSocket> returned by tapping also provides L<socket-host|/type/IO::Socket::Async::ListenSocket#method_socket-host> and L<socket-post|/type/IO::Socket::Async::ListenSocket#method_socker-port> methods. These allow for the discovery of the exact local host and port number the socket is listening on.
+The L<IO::Socket::Async::ListenSocket|/type/IO::Socket::Async::ListenSocket>
+returned by calling the L<tap|/type/Supply#method_tap> method on the supply
+returned represents the underlying listening TCP socket, which can be closed
+using its L<close|/type/Tap#method_close> method. If C<$port> was set to C<0>,
+you can get the port the socket ended up with using its
+C<socket-port|/type/IO::Socket::Async::ListenSocket#method_socket-port> method.
 
 =head2 method udp
 

--- a/doc/Type/IO/Socket/Async/ListenSocket.pod6
+++ b/doc/Type/IO/Socket/Async/ListenSocket.pod6
@@ -2,66 +2,65 @@
 
 =TITLE class IO::Socket::Async::ListenSocket
 
-=SUBTITLE A tap for listening sockets
+=SUBTITLE A tap for listening TCP sockets
 
     class IO::Socket::Async::ListenSocket is Tap {}
 
-C<IO::Socket::Async::ListenSocket> is returned by the C<tap
-method|/type/Supply#method_tap> when called on the L<Supply|/type/Supply>
-returned by calling the L<listen method|/type/IO::Socket::Async#method_listen>
-of L<IO::Socket::Async|/type/IO::Socket::Async>:
+C<IO::Socket::Async::ListenSocket> is returned by the
+C<tap|/type/Supply#method_tap> method when called on the
+L<Supply|/type/Supply> returned by calling the
+L<listen|/type/IO::Socket::Async#method_listen> method of
+L<IO::Socket::Async|/type/IO::Socket::Async>, which represents a listening TCP
+socket:
 
 =begin code
-my $listener = IO::Socket::Async.listen('127.0.0.1', 0).tap: -> $peer {
-    $peer.print: "Hello. Good-bye\n";
-    $peer.close;
-}
+my IO::Socket::Async::ListenSocket:D $server =
+    IO::Socket::Async.listen('127.0.0.1', 0).tap(-> $peer {
+        await $peer.print: "Hello. Goodbye!\r\n";
+        $peer.close;
+    });
 
-my $host = await $tap.socket-host;
-my $port = await $tap.socket-port;
-
+my (Str:D $host, Int:D $port) = await $server.socket-host, $server.socket-port;
 say "The rude service is listening on $host:$port for the next 10 seconds...";
-
-sleep 10;
-$listener.close;
-
+await Promise.in(10).then({ $server.close });
 say "I'm done now.";
 =end code
 
-Alternatively, by using the C<do> prefix to C<whenever>, you can also get it while inside a C<react> block:
+Alternatively, by using the C<do> prefix with C<whenever>, you can also use it
+from within a C<react> block:
 
-=begin code
-my $listener;
+=for code
 react {
-    $listener = do whenever IO::Socket::Async.listen('127.0.0.1', 0) -> $peer {
-        $peer.print: "Hello. Good-bye\n";
-        $peer.close;
-    }
+    my IO::Socket::Async::ListenSocket:D $server =
+        do whenever IO::Socket::Async.listen('127.0.0.1', 0) -> IO::Socket::Async:D $connection {
+            await $connection.print: "Hello. Goodbye!\r\n";
+            $connection.close;
+            QUIT { $server.close; .rethrow }
+        };
+    # Use $server here somehow.
 }
 
-$listener.close;
-=end code
-
 =head1 Methods
-
-This object cannot be constructed. It is only returned when tapping the L<Supply|/type/Supply> returned by the L<listen method|/type/IO::Socket::Async#method_listen>.
 
 =head2 method socket-host
 
     method socket-host(--> Promise)
 
-Returns a L<Promise|/type/Promise> that will be kept with a string containing the local listening host name.
+Returns a L<Promise|/type/Promise> that will be kept with a C<Str|/type/Str>
+containing the address of the listening socket.
 
 =head2 method socket-port
 
     method socket-port(--> Promise)
 
-Returns a L<Promise|/type/Promise> that will be kept with the port number of the listening socket.
+Returns a L<Promise|/type/Promise> that will be kept with an C<Int|/type/Int>
+containing the port of the listening socket.
 
-=head2 method close
+=head2 method native-descriptor
 
-    method close()
+    method native-descriptor(--> Int)
 
-Closes the listening socket as well as closing the tap.
+Returns the corresponding file descriptor (C<SOCKET> on Windows) for the
+listening socket.
 
 =end pod

--- a/xt/code.pws
+++ b/xt/code.pws
@@ -331,6 +331,7 @@ libmysql
 libsomething
 libxxhash
 listofstuff
+listensocket
 listoid
 littleendian
 lmao


### PR DESCRIPTION
## The problem
The new `IO::Socket::Async::ListenSocket` docs contain some misinformation about what it's for and how it's used, as well as lack documentation for their `native-descriptor` method. However, the code examples it gives are better than the related ones in `IO::Socket::Async`'s page, which they make redundant.

## Solution provided
- don't say `IO::Socket::Async::ListenSocket` can't be constructed (it's possible, but impractical to do and irrelevant to how it would normally be used)
- correct its `socket-host` method documentation
- document its `native-descriptor` method
- brush up the code examples provided a bit
- remove the now redundant examples from `IO::Socket::Async`'s page and refer to `IO::Socket::Async::ListenSocket` for more information instead
- add `listensocket` as a word to `xt/code.pws`

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
