### PR TITLE
Use better word than 'exposition' and reword the paragraph

### DIFF
--- a/writing-docs/STYLEGUIDE.md
+++ b/writing-docs/STYLEGUIDE.md
@@ -71,11 +71,9 @@ Try to avoid abbreviations. For example, “RHS” is short, but
 “right-hand side” is much clearer for beginners.
 
 In general, try to put yourself in the shoes of someone with no
-previous exposition to the language (or computer science
-altogether). Although it might seem obvious to
-you that only the first line can in fact initialize a hash, the
-documentation is targeted at people with no previous exposure to the
-language.
+previous exposure to the language or computer science. Although it
+might seem obvious to you that only the first line can in fact
+initialize a hash, the documentation is targeted at such novices.
 
 ### 'say' vs 'put'
 


### PR DESCRIPTION
## The problem

The paragraph as written uses an incorrect word ("exposition" instead of
"exposure").

## Solution provided

The word was corrected and the paragraph reworded to remove redundancy 
and improve the overall wording.