### PR TITLE
Document X::Cannot::Lazy

### DIFF
--- a/doc/Type/X/Cannot/Lazy.pod6
+++ b/doc/Type/X/Cannot/Lazy.pod6
@@ -1,0 +1,28 @@
+=begin pod :kind("Type") :subkind("class") :category("exception")
+
+=TITLE class X::Cannot::Lazy
+
+=SUBTITLE Error due to inappropriate usage of a lazy list
+
+    class X::Cannot::Lazy is Exception { }
+
+Error thrown (or wrapped in a C<Failure>) when inappropriately using a
+list that C<.is-lazy>. Such a list can be infinite which would make it
+impossible to iterate over all values.
+
+=head1 Methods
+
+=head2 method action
+
+    method action()
+
+Verbal description of the inappropriate action.
+
+=head2 method what
+
+    method what()
+
+Returns the type that was the target of the action, if it was not the
+lazy list itself.
+
+=end pod


### PR DESCRIPTION
Documentation of class `X::Cannot::Lazy` is referenced by the documentation of class `Seq` but did not yet exist.