### PR TITLE
Document passing arguments to `use-ok`

### DIFF
--- a/doc/Type/Test.pod6
+++ b/doc/Type/Test.pod6
@@ -518,7 +518,12 @@ Defined as:
 Marks a test as passed if the given C<$module> loads correctly.
 
 =for code :preamble<use Test;>
-    use-ok 'Full::Qualified::ModuleName';
+use-ok 'Full::Qualified::ModuleName';
+    
+Since C<$code> is being turned into an C<EVAL>, you can also pass arguments:
+
+=for code :preamble<use Test;>
+use-ok 'Full::Qualified::ModuleName :my-argument';
 
 =head2 sub dies-ok
 


### PR DESCRIPTION
Not sure if this is the way it should be, or if `use-ok` should be augmented with another argument.

Also unindented code because the rest of the file didn't seem to indent its bits.