### PR TITLE
Merge pull request #3195 from Raku/markdown-fix-github-org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Build Status](https://travis-ci.org/Raku/doc.svg?branch=master)](https://travis-ci.org/Raku/doc) [![artistic](https://img.shields.io/badge/license-Artistic%202.0-blue.svg?style=flat)](https://opensource.org/licenses/Artistic-2.0) [![Run Status](https://api.shippable.com/projects/591e99923f2f790700098a30/badge?branch=master)](https://app.shippable.com/github/Raku/doc) [![CircleCI](https://circleci.com/gh/Raku/doc.svg?style=shield)](https://circleci.com/gh/Raku/doc/tree/master)
 
 An HTML version of this documentation can be found
-at [https://docs.perl6.org/](https://docs.perl6.org/) and also
-at [`perl6docs.github.io`](https://perl6docs.github.io) (which is
+at [https://docs.raku.org/](https://docs.raku.org/) and also
+at [`rakudocs.github.io`](https://rakudocs.github.io) (which is
 actually updated more frequently).
 This is currently the recommended way to consume the documentation.
 
@@ -12,7 +12,7 @@ There is also a command line tool called `p6doc`, which you can use to
 browse the documentation once it's installed (see below).
 
 This documentation is updated frequently to a GitHub mirror
-https://perl6docs.github.io but that might be out of sync with the
+https://rakudocs.github.io but that might be out of sync with the
 official one.
 
 ## Docker container
@@ -89,14 +89,14 @@ documents, so that generation after the first time is sped up.
 > Building the documentation has a number of prerequisites, which is might you
 > might not want to do it yourself. However, if you need a local copy of the
 > HTML documentation, please download it by cloning
-> https://github.com/perl6docs/perl6docs.github.io
+> https://github.com/rakudocs/rakudocs.github.io
 
 These are the prerequisites you need to install to generate documentation.
 
 * perl 5.20 or later
 * node 10 or later.
 * graphviz.
-* [Documentable](https://github.com/perl6/Documentable).
+* [Documentable](https://github.com/Raku/Documentable).
 
 Please follow these instructions (in Ubuntu) to install them
 
@@ -188,7 +188,7 @@ explains briefly how to get started contributing documentation.
      implementation.
   2. Implementations' handling of embedded Pod is still
      a bit uneven; this avoids potential runtime impacts.
-  3. A separate repo in the perl6 Github account invites
+  3. A separate repo in the Raku Github account invites
      more potential contributors and editors.
 
 **Q:** Should I include methods from superclasses or roles?<br>

--- a/writing-docs/STYLEGUIDE.md
+++ b/writing-docs/STYLEGUIDE.md
@@ -47,7 +47,7 @@ Works well instead.
 
 If you have to use the full URL in the docs or elsewhere, ensure the
 subdomain is `docs` and the protocol is `https://` (as in
-`https://docs.perl6.org/blah/blah`). Other variations of the URL will
+`https://docs.raku.org/blah/blah`). Other variations of the URL will
 still work, for convenience, but they all simply redirect to the
 canonical version, so it's best to use it from the start.
 
@@ -133,8 +133,7 @@ stick to easily understandable names:
     my $ßub; # BAD; Is it a twigil? How do I type this? HELP!
 
 If you want to add some fancy characters, please stick to
-[well-known characters from our Unicode set](https://docs.perl6.org/language/unicode_ascii).
-
+[well-known characters from our Unicode set](https://docs.raku.org/language/unicode_ascii).
 ### Prefer non-ASCII syntax in examples
 
     my @infinite-sequence = 1, 3 … ∞     # GOOD


### PR DESCRIPTION
## The problem
Contributor Markdown refers to the perl6 org, not Raku

## Solution provided
Change README.md and STYLEGUIDE.md to refer to Raku.

Note that there are numerous cases of 'perl6[.]org' appearing in non-Markdown, such as in build scripts, SASS, etc. Not touching those, since those will affect doc site building. This is just for contributor-facing text.

I’m still sending this as PR so that I don’t step on others’ toes—I can’t find the umbrella “perl6(.org) → Raku(.org) migration plan” ticket if it exists...
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
