### PR TITLE
Add search command for p6doc

### DIFF
--- a/bin/p6doc
+++ b/bin/p6doc
@@ -99,6 +99,9 @@ sub USAGE() {
     say "          $PROGRAM-NAME path/to/file";
     say "\nSet the POD_TO_TEXT_ANSI if you want to use ANSI escape sequences to enhance text";
 
+    say "\nYou can search for references to a particular term:";
+    say "          $PROGRAM-NAME search comb";
+
     say "\nYou can list some top level documents:";
     say "          $PROGRAM-NAME -l";
 
@@ -152,6 +155,38 @@ multi sub MAIN($docee, Bool :$f!, Bool :$n) {
 
 multi sub MAIN(Str $file where $file.IO ~~ :e, Bool :$n) {
     show-docs($file, :no-pager($n));
+}
+
+
+multi sub MAIN('search', $term = '') {
+    exit note "Missing search term" unless $term;
+    say "searching for $term";
+    sub dirtree($d) {
+      return Empty unless $d.IO.d;
+      gather {
+        for dir($d) -> $f {
+          if $f.d {
+            .take for dirtree($f)
+          } else {
+            take $f
+          }
+        }
+      }
+    }
+
+    my @paths = search-paths() X~ <Type/ Language/>;
+    my regex delim { '#' | '/' | '|' | '<' | '>' }
+    my @found = @paths.race.map: -> $dir {
+      |dirtree($dir).race.grep( { .lines.first( /:i <&delim> $term <&delim> / ) } )
+    }
+    exit note "no results found"  unless @found;
+    my %labels = @found.map: { .basename.subst('.pod6','') => "$_" }
+    my @choose = %labels.keys.sort;
+    for @choose {
+        say ++$ ~ ") $_";
+    }
+    my $which = prompt "Choose: " or exit;
+    show-docs(%labels{ @choose[$which - 1] });
 }
 
 # index related


### PR DESCRIPTION
## The problem

It's hard to search the documentation from the command line

## Solution provided

Add a `search` option to `p6doc` that looks for references to a particular term.

Examples:

```
$ bin/p6doc search comb
searching for comb
1) 5to6-perlfunc
2) Cool
3) Str
Choose: ^C
$ bin/p6doc search zip
searching for zip
1) List
Choose: ^C
$ bin/p6doc search leave
searching for leave
1) Async
2) Channel
3) Handle
4) Lock
5) independent-routines
6) phasers
7) traps
Choose: ^C
$
```