### PR TITLE
Reorganize and add Trait::Traced to the debugging programs page

### DIFF
--- a/doc/Programs/01-debugging.pod6
+++ b/doc/Programs/01-debugging.pod6
@@ -4,35 +4,9 @@
 
 =SUBTITLE Modules and applications used to debug Raku programs
 
-There are at least two useful debuggers available for Rakudo, the Raku
-compiler:
+=head1 Core debugging features
 
-=head2 L<Debugger::UI::CommandLine|https://modules.raku.org/repo/Debugger::UI::CommandLine>
-
-A command-line debugger frontend for Rakudo. This module installs the
-C<perl6-debug-m> command-line utility, and is bundled with the Rakudo
-Star distributions. Please check
-L<its repository|https://github.com/jnthn/rakudo-debugger>
-for instructions and a tutorial.
-
-=head2 L<Grammar::Debugger|https://modules.raku.org/repo/Grammar::Debugger> (and C<Grammar::Tracer> in the same distribution)
-
-Simple tracing and debugging support for Raku grammars.
-
-Please see the documentation for these programs for further information.
-
-Historically others have existed and others are likely to be written in
-the future, check the L<Raku Modules|https://modules.raku.org/>
-website.
-
-There are also environment variables that can be set to aid debugging
-various aspects of your program.  See L<Raku Environment
-Variables|https://github.com/rakudo/rakudo/wiki/dev-env-vars> and
-L<Running rakudo from the command
-line|https://github.com/rakudo/rakudo/wiki/Running-rakudo-from-the-command-line>
-for more information.
-
-=head2 C<trace> pragma
+=head2 The C<trace> pragma
 
 The C<trace> pragma causes the program to print out step-by-step which
 lines get executed:
@@ -49,16 +23,16 @@ lines get executed:
     # say "hi"
     # hi
 
-
 X<|dd> X<|dumper>
-=head2 Dumper function C<dd>
+=head1 Dumper function (C<dd>)
 
 N<This routine is a Rakudo-specific debugging feature and not
 standard Raku.>
 
 The I<Tiny Data Dumper>: This function takes the input list of variables
 and C<note>s them (on C<$*ERR>) in an easy to read format, along with
-the C<name> of the variable.  Thus,
+the C<name> of the variable.  For example, this prints to the standard
+error stream the variables passed as arguments:
 
 =begin code :ok-test<dd>
 my $a = 42;
@@ -70,8 +44,6 @@ dd %hash, $a;
     Int $a = 42
 )
 =end code
-
-prints to the standard error stream the variables passed as argument.
 
 Please note that C<dd> will ignore named parameters. You can use a
 C<Capture> or C<Array> to force it to dump everything passed to it.
@@ -106,6 +78,35 @@ a string:
     #   in sub inner at /tmp/script.p6 line 2
     #   in sub outer at /tmp/script.p6 line 3
     #   in block <unit> at /tmp/script.p6 line 4
+
+=head2 Environment variables
+
+See L<Raku Environment
+Variables|https://github.com/rakudo/rakudo/wiki/dev-env-vars> and
+L<Running rakudo from the command
+line|https://github.com/rakudo/rakudo/wiki/Running-rakudo-from-the-command-line>
+for more information.
+
+=head1 Ecosystem debugging modules
+
+There are at least two useful debuggers available for Rakudo (the Raku compiler).
+For more information on these modules, please refer to their documentation.
+
+Historically other modules have existed and others are likely to be
+written in the future. Please check the L<Raku
+Modules|https://modules.raku.org/> website for more modules like these.
+
+=head2 L<Debugger::UI::CommandLine|https://modules.raku.org/repo/Debugger::UI::CommandLine>
+
+A command-line debugger frontend for Rakudo. This module installs the
+C<perl6-debug-m> command-line utility, and is bundled with the Rakudo
+Star distributions. Please check
+L<its repository|https://github.com/jnthn/rakudo-debugger>
+for instructions and a tutorial.
+
+=head2 L<Grammar::Debugger|https://modules.raku.org/repo/Grammar::Debugger> (and C<Grammar::Tracer> in the same distribution)
+
+Simple tracing and debugging support for Raku grammars.
 
 =end pod
 

--- a/doc/Programs/01-debugging.pod6
+++ b/doc/Programs/01-debugging.pod6
@@ -97,7 +97,7 @@ Historically other modules have existed and others are likely to be
 written in the future. Please check the L<Raku
 Modules|https://modules.raku.org/> website for more modules like these.
 
-=head2 L<Debugger::UI::CommandLine|https://modules.raku.org/repo/Debugger::UI::CommandLine>
+=head2 L<C<Debugger::UI::CommandLine>|https://modules.raku.org/repo/Debugger::UI::CommandLine>
 
 A command-line debugger frontend for Rakudo. This module installs the
 C<perl6-debug-m> command-line utility, and is bundled with the Rakudo
@@ -105,11 +105,11 @@ Star distributions. Please check
 L<its repository|https://github.com/jnthn/rakudo-debugger>
 for instructions and a tutorial.
 
-=head2 L<Grammar::Debugger|https://modules.raku.org/repo/Grammar::Debugger> (and C<Grammar::Tracer> in the same distribution)
+=head2 L<C<Grammar::Debugger>|https://modules.raku.org/repo/Grammar::Debugger> (and C<Grammar::Tracer> in the same distribution)
 
 Simple tracing and debugging support for Raku grammars.
 
-=head2 L<Trait::Traced|https://modules.raku.org/repo/Trait::Traced>
+=head2 L<C<Trait::Traced>|https://modules.raku.org/repo/Trait::Traced>
 
 This provides the C<is traced> trait, which automatically traces usage of
 features of whatever the trait is applied to. What features of whatever the

--- a/doc/Programs/01-debugging.pod6
+++ b/doc/Programs/01-debugging.pod6
@@ -89,8 +89,9 @@ for more information.
 
 =head1 Ecosystem debugging modules
 
-There are at least two useful debuggers available for Rakudo (the Raku compiler).
-For more information on these modules, please refer to their documentation.
+There are at least two useful debuggers and two tracers available for Rakudo
+(the Raku compiler).  For more information on these modules, please refer to
+their documentation.
 
 Historically other modules have existed and others are likely to be
 written in the future. Please check the L<Raku
@@ -107,6 +108,13 @@ for instructions and a tutorial.
 =head2 L<Grammar::Debugger|https://modules.raku.org/repo/Grammar::Debugger> (and C<Grammar::Tracer> in the same distribution)
 
 Simple tracing and debugging support for Raku grammars.
+
+=head2 L<Trait::Traced|https://modules.raku.org/repo/Trait::Traced>
+
+This provides the C<is traced> trait, which automatically traces usage of
+features of whatever the trait is applied to. What features of whatever the
+trace is applied to get traced and how traces are handled are customizable.
+Refer to its documentation for more information on how this works.
 
 =end pod
 

--- a/xt/words.pws
+++ b/xt/words.pws
@@ -249,6 +249,7 @@ curdir
 currentthreadscheduler
 curriedrolehow
 curupdir
+customizable
 cwd
 cygwin
 daenerys


### PR DESCRIPTION
## The problem
- The debugging programs page is a bit disorganized. More emphasis is placed on ecosystem modules than core features, and what paragraphs pertain to which section isn't entirely clear to me at first glance.
- Albeit a somewhat new module, `Trait::Traced` offers broader support for tracing than other ecosystem modules out there (to my knowledge). I may be a bit biased since it's my own module though 😉.

## Solution provided
- Reorganize the debugging programs page.
- Add `Trait::Traced` to the ecosystem modules section.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
