### PR TITLE
Fix index entries and descriptions of (cont), ∋ and ∌

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -2412,9 +2412,9 @@ C«∉» is codepoint U+2209 (NOT AN ELEMENT OF).
     multi sub infix:<(cont)>($a,$b --> Bool:D)
     multi sub infix:<∋>($a,$b --> Bool:D)
 
-X<Membership operator>.
+X<Containing operator>.
 
-Returns C<True> if C<$a> is an B<element> of C<$b>.
+Returns C<True> if C<$a> B<contains> C<$b>.
 
     =begin code
     say (1,2,3) (cont) 2; # OUTPUT: «True␤»
@@ -2427,9 +2427,9 @@ C«∋» is equivalent to C«(cont)», at codepoint U+220B (CONTAINS AS MEMBER).
 
     multi sub infix:<∌>($a,$b --> Bool:D)
 
-X<Non-membership operator>.
+X<Non-containing operator>.
 
-Returns C<True> if C<$a> is B<not> an B<element> of C<$b>.  Equivalent to
+Returns C<True> if C<$a> does B<not> B<contain> C<$b>.  Equivalent to
 C<!(cont)>.
 
     =begin code


### PR DESCRIPTION
## The problem
The (cont), ∋ and ∌ sections look a lot like the (elem), ∈ and ∉ones and may need a few corrections.
