### PR TITLE
Document a few 2020.02 additions

### DIFF
--- a/doc/Type/Match.pod6
+++ b/doc/Type/Match.pod6
@@ -249,6 +249,19 @@ Returns the part of the original string following the match.
     "abc123def" ~~ m:g/\d/;
     say $/.[1].postmatch;     # OUTPUT: «3def␤»
 
+=head2 method replace-with
+
+Defined as:
+
+    multi method replace-with(Match:D: Str() $replacement --> Str:D)
+
+Returns the invocant string where the C«Match» object is replaced by
+C«$replacement».
+
+    my Str $some-string = "Some foo";
+    my Match $match = $some-string.match(/foo/);
+    my $another-string = $match.replace-with("string"); # «Some string»
+
 =head2 method infix:<eqv>
 
 Defined as:

--- a/doc/Type/Parameter.pod6
+++ b/doc/Type/Parameter.pod6
@@ -290,6 +290,45 @@ If the parameter has a
 L<sub-signature|/type/Signature#Destructuring_Parameters>,
 returns a C<Signature> object for it.  Otherwise returns C<Any>.
 
+=head2 method prefix
+
+Defined as:
+
+    method prefix(Parameter:D: --> Str:D)
+
+If the parameter is L«slurpy|/type/Signature#Slurpy_(A.K.A._variadic)_parameters»,
+returns the marker (e.g., C«*», C«**», or C«+») the parameter was declared
+with. Otherwise, returns an empty string.
+
+    my Signature $flat-slurpy = :($a, *@b);
+    say $flat-slurpy.params[0].prefix; # OUTPUT:«""␤»
+    say $flat-slurpy.params[1].prefix; # OUTPUT:«*␤»
+
+    my Signature $unflat-slurpy = :($a, **@b);
+    say $unflat-slurpy.params[0].prefix; # OUTPUT:«""␤»
+    say $unflat-slurpy.params[1].prefix; # OUTPUT:«**␤»
+
+    my Signature $sar-slurpy = :($a, +@b);
+    say $sar-slurpy.params[0].prefix; # OUTPUT:«""␤»
+    say $sar-slurpy.params[1].prefix; # OUTPUT:«+␤»
+
+=head2 method suffix
+
+Defined as:
+
+    method suffix(Parameter:D: --> Str:D)
+
+Returns the C«?» or «!» marker a parameter was declared with, if any. Otherwise,
+returns the empty string.
+
+    my Signature $pos-sig = :($a, $b?);
+    say $pos-sig.params[0].suffix; # OUTPUT: «""␤»
+    say $pos-sig.params[1].suffix; # OUTPUT: «?␤»
+
+    my Signature $named-sig = :(:$a!, :$b);
+    say $named-sig.params[0].suffix; # OUTPUT: «!␤»
+    say $named-sig.params[1].suffix; # OUTPUT: «""␤»
+
 =head1 Runtime creation of Parameter objects (6.d, 2019.03 and later)
 
    Parameter.new( ... )

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -633,10 +633,11 @@ Returns C<True> if the invocant is identical to or ends with C<$needle>.
 
 =head2 method subst
 
-    multi method subst(Str:D: $matcher, $replacement, *%opts)
+    multi method subst(Str:D: $matcher, $replacement = "", *%options)
 
 Returns the invocant string where C<$matcher> is replaced by C<$replacement>
-(or the original string, if no match was found).
+(or the original string, if no match was found). If no C<$replacement> is
+provided, the empty string is used (i.e., matched string(s) are removed).
 
 There is an in-place syntactic variant of C<subst> spelled
 C<s/matcher/replacement/> and with
@@ -653,6 +654,8 @@ objects (if multi-match options like C<:g> are used).
     my $some-string = "Some foo";
     my $another-string = $some-string.subst(/foo/, "string"); # gives 'Some string'
     $some-string.=subst(/foo/, "string"); # in-place substitution. $some-string is now 'Some string'
+
+    say "multi-hyphenate".subst("-"); # OUTPUT: «multihyphenate␤»
 
 =head3 Callable
 
@@ -707,6 +710,8 @@ Here are other examples of usage:
 
     my $str = "Hey foo foo foo";
     $str.subst(/foo/, "bar", :g); # global substitution - returns Hey bar bar bar
+
+    $str.subst(/\s+/, :g); # global substitution - returns Heyfoofoofoo
 
     $str.subst(/foo/, "no subst", :x(0)); # targeted substitution. Number of times to substitute. Returns back unmodified.
     $str.subst(/foo/, "bar", :x(1)); #replace just the first occurrence.


### PR DESCRIPTION
* Added prefix and suffix methods to Parameter class which return textual prefix and suffix of the parameter
* The Match class now has a replace-with method
* Cool.subst doesn't need a replacement string anymore

<!--
## The problem


## Solution provided

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
