### PR TITLE
correct output in comment

### DIFF
--- a/doc/Language/hashmap.pod6
+++ b/doc/Language/hashmap.pod6
@@ -317,7 +317,7 @@ sleep 1;
 my $second-instant = now;
 %intervals{ $second-instant } = "Logging this Instant for spurious raisins.";
 say ($first-instant, $second-instant) ~~ %intervals.keys;       # OUTPUT: «False␤»
-say ($first-instant, $second-instant) ~~ %intervals.keys.sort;  # OUTPUT: «False␤»
+say ($first-instant, $second-instant) ~~ %intervals.keys.sort;  # OUTPUT: «True␤»
 say ($first-instant, $second-instant) === %intervals.keys.sort; # OUTPUT: «False␤»
 say $first-instant === %intervals.keys.sort[0];                 # OUTPUT: «True␤»
 


### PR DESCRIPTION
say ($first-instant, $second-instant) ~~ %intervals.keys.sort;  # OUTPUT: «False␤»
output should be True

## The problem
output in comment is False

## Solution provided
output in comment should be True
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
