### PR TITLE
Object: Inheritance: Add parent direct call with $obj.Parent::method

### DIFF
--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -598,6 +598,14 @@ $test.frob;          # calls the frob method of Child rather than Parent
 # OUTPUT: «the child's somewhat more fancy frob is called␤»
 =end code
 
+If you want to explicitly call the parent method on a child object,
+refer to its full name in the parent namespace:
+
+=begin code
+$test.Parent::frob;  # calls the frob method of Parent
+# OUTPUT: «the parent class frobs␤»
+=end code
+
 X<|delegation (trait handles)>
 =head2 Delegation
 


### PR DESCRIPTION
## The problem

How to __call parent method__ when get a variable on the child object ? (And no control on the class method implementation)

## Solution provided

This belongs to objects/inheritance
The solution (present in roles) is `$child.Parent::method`
I just couldn't find it, asked in the IRC