### PR TITLE
Document how `is raw` behaves with slurpy list parameters

### DIFF
--- a/doc/Type/Parameter.pod6
+++ b/doc/Type/Parameter.pod6
@@ -174,6 +174,17 @@ their sigil in code.
         $x = 5;
     }
 
+When used with slurpy list parameters, the C<is raw> trait will cause the list
+of arguments given to be packed into a C<List> instead of an C<Array>, which
+prevents them from being containerized with C<Scalar>. This is the default
+behavior when using C<+> with a sigilless parameter:
+
+    my @types is List = Mu, Any;
+    say -> *@l { @l }(@types)[0] =:= @types[0];        # OUTPUT: «False␤»
+    say -> +@l { @l }(@types)[0] =:= @types[0];        # OUTPUT: «False␤»
+    say -> +l { l }(@types)[0] =:= @types[0];          # OUTPUT: «True␤»
+    say -> *@l is raw { @l }(@types)[0] =:= @types[0]; # OUTPUT: «True␤»
+
 =head2 method capture
 
 Defined as:


### PR DESCRIPTION
## The problem
`is raw` has special behaviour for slurpy lists, but this is undocumented.

## Solution provided
Document it.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
