### PR TITLE
Document how to write named arguments that do not create any symbols

### DIFF
--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -885,6 +885,16 @@ say alias-named(color => "red", style => "A");
 say alias-named(colour => "green", variety => "B");
 say alias-named(color => "white", class => "C");
 
+Using argument aliases, you can create named arguments that do not
+create any symbols. This is useful when using named arguments as
+sentinels:
+
+=for code
+multi sub trait_mod:<is>(Routine:D $r is raw, :timestamped($)!) {
+    $r does role timestamped { has Instant:D @.timestamps };
+    $r.wrap: -> | { ENTER $r.timestamps.push: now; callsame };
+}
+
 X<|optional argument>
 =head2 Optional and mandatory arguments
 

--- a/xt/words.pws
+++ b/xt/words.pws
@@ -1292,6 +1292,9 @@ tiebreaking
 timespec
 timezoneclash
 timezones
+timestamp
+timestamps
+timestamped
 timtoady
 timtowtdi
 titlecase


### PR DESCRIPTION
## The problem
Named arguments can be used like sentinels. In this case, there's no point in there being any symbols for them, as they're unused.

## Solution provided
See title.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
