### PR TITLE
Fix URL mixin with absolute path

### DIFF
--- a/doc/Type/Metamodel/Mixins.pod6
+++ b/doc/Type/Metamodel/Mixins.pod6
@@ -179,7 +179,7 @@ of the roles in C<@roles>. This is then composed and has its mixin
 attribute set (if any exists) before getting returned.
 
 While this generates a new mixin type, this doesn't actually mix it into
-C<$obj>; if that is what you intend to do, use the L<mixin> metamethod
+C<$obj>; if that is what you intend to do, use the L<mixin|/routine/mixin> metamethod
 instead.
 
 =head2 method mixin


### PR DESCRIPTION
Make the URL of mixin meta method absolute: because it is then embeded in some type: like `type/Metamodel::EnumHOW`.

PS: No more broken link