### PR TITLE
Mention :D types in the documentation for the "is required" trait

### DIFF
--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -54,6 +54,17 @@ error.
     CATCH{ default { say .^name, ': ', .Str } }
     # OUTPUT: «X::Attribute::Required: The attribute '$!a' is required, but you did not provide a value for it.␤»
 
+This trait also allows attributes to be typed with types that have a
+C<:D> smiley without giving them a default value:
+
+    class Power {
+        has Numeric:D $.base     is required;
+        has Numeric:D $.exponent is required;
+        multi method Numeric(::?CLASS:D: --> Numeric:D) {
+            $!base ** $!exponent
+        }
+    }
+
 B<Available as of 6.d language version> (early implementation exists in Rakudo
 compiler 2018.08+): You can specify a reason why the attribute is required:
 


### PR DESCRIPTION
## The problem
`X::Syntax::Variable::MissingInitializer` gets thrown at compile-time when you attempt to type an attribute with a `:D` type normally. As it stands now, the exception's message makes it seem like you need to give it a default value in order for it to be typed like that, but `is required` also works.

## Solution provided
See title.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
