### PR TITLE
Document @(code) interpolation in regex

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1894,6 +1894,9 @@ pattern, which may be summarized as follows:
 
 =end table
 
+Instead of the C<$> sigil, you may use the C<@> sigil for array interpolation.
+See below for how this works.
+
 X<|regex, $variable>X<|regex, $(code)>
 Let's start with the first two syntactical forms: C«$variable» and C«$(code)».
 These forms will interpolate the stringified value of the variable or the
@@ -2016,6 +2019,11 @@ regexes. Just as with ordinary C<|> interpolation, the longest match succeeds:
 
     my @a = '2', 23, rx/a.+/;
     say ('b235' ~~ /  b @a /).Str;      # OUTPUT: «b23»
+
+You may use C<@(code)> to interpolate any expression that evaluates to a list:
+
+    my %h = a => 1, b => 2;
+    say S:g/@(%h.keys)/%h{$/}/ given 'abc';    # OUTPUT: «12c>
 
 The use of hashes in regexes is reserved.
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -2020,10 +2020,14 @@ regexes. Just as with ordinary C<|> interpolation, the longest match succeeds:
     my @a = '2', 23, rx/a.+/;
     say ('b235' ~~ /  b @a /).Str;      # OUTPUT: «b23»
 
-You may use C<@(code)> to interpolate any expression that evaluates to a list:
+If you have an expression that evaluates to a list, but you do not want to
+assign it to an @-sigiled variable first, you can interpolate it with
+C<@(code)>. In this example, both regexes are equivalent:
 
     my %h = a => 1, b => 2;
+    my @a = %h.keys;
     say S:g/@(%h.keys)/%h{$/}/ given 'abc';    # OUTPUT: «12c>
+    say S:g/@a/%h{$/}/ given 'abc';            # OUTPUT: «12c>
 
 The use of hashes in regexes is reserved.
 


### PR DESCRIPTION
## The problem

$(code) interpolation was documented, but @(code) was not.

## Solution provided

Document @(code) interpolation, with an example that uses the keys  of a hash and substitutes the corresponding values.