### PR TITLE
Clarify how control flow is handled in CATCH blocks

### DIFF
--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -69,11 +69,11 @@ to match in the same manner, they must implement the given role. Just
 existing in the same namespace will make them look alike but won't match
 in a C<CATCH> block.
 
-A X<C<CATCH>|CATCH> block places any exception thrown in its topic
-variable (C<$_>), thus it's possible to catch and handle various
-categories of exceptions inside a C<when> block. To handle all
-exceptions, use a C<default> statement. This example prints out almost
-the same information as the normal backtrace printer:
+A C<CATCH> block places any exception thrown in its topic variable
+(C<$_>), thus it's possible to catch and handle various categories of
+exceptions inside a C<when> block. To handle all exceptions, use a
+C<default> statement. This example prints out almost the same
+information as the normal backtrace printer:
 
     CATCH {
          default {

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -66,8 +66,8 @@ will probably be the console by default.
 
 Note that the match target is a role. To allow user defined exceptions
 to match in the same manner, they must implement the given role. Just
-existing in the same namespace will look alike but won't match in a
-C<CATCH> block.
+existing in the same namespace will make them look alike but won't match
+in a C<CATCH> block.
 
 A X<C<CATCH>|CATCH> block places any exception thrown in its topic
 variable (C<$_>), thus it's possible to catch and handle various

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -47,7 +47,8 @@ problem.
 
 =head1 Catching exceptions
 
-It's possible to handle exceptional circumstances by supplying a C<CATCH> block:
+It's possible to handle exceptional circumstances by supplying a
+C<CATCH> block:
 
     die X::IO::DoesNotExist.new(:path("foo/bar"), :trying("zombie copy"));
 
@@ -57,18 +58,22 @@ It's possible to handle exceptional circumstances by supplying a C<CATCH> block:
 
     # OUTPUT: «some kind of IO exception was caught!»
 
-Here, we are saying that if any exception of type C<X::IO> occurs, then the
-message C<some kind of IO exception was caught!> will be sent to I<stderr>,
-which is what C<$*ERR.say> does, getting displayed on whatever constitutes the
-standard error device in that moment, which will probably be the console by
-default.
+Here, we are saying that if any exception of type C<X::IO> occurs, then
+the message C<some kind of IO exception was caught!> will be sent to
+I<stderr>, which is what C<$*ERR.say> does, getting displayed on
+whatever constitutes the standard error device in that moment, which
+will probably be the console by default.
 
-A X<C<CATCH>|CATCH> block uses smartmatching similar to how C<given/when>
-smartmatches on options, thus it's possible to catch and handle various
-categories of exceptions inside a C<when> block.
+Note that the match target is a role. To allow user defined exceptions
+to match in the same manner, they must implement the given role. Just
+existing in the same namespace will look alike but won't match in a
+C<CATCH> block.
 
-To handle all exceptions, use a C<default> statement. This example prints out
-almost the same information as the normal backtrace printer.
+A X<C<CATCH>|CATCH> block places any exception thrown in its topic
+variable (C<$_>), thus it's possible to catch and handle various
+categories of exceptions inside a C<when> block. To handle all
+exceptions, use a C<default> statement. This example prints out almost
+the same information as the normal backtrace printer:
 
     CATCH {
          default {
@@ -81,9 +86,18 @@ almost the same information as the normal backtrace printer.
          }
     }
 
-Note that the match target is a role. To allow user defined exceptions to match
-in the same manner, they must implement the given role. Just existing in the
-same namespace will look alike but won't match in a C<CATCH> block.
+While this is a very common pattern, it is not strictly necessary to use
+C<default> or C<when> in a C<CATCH> block. This is done to prevent the
+control flow in one from reaching its end where, unless the exception
+has been L<resumed|#Resuming_of_exceptions>, the exception will continue
+to be thrown.  Allowing this can be used for logging purposes, for
+instance:
+
+=for code :skip-test<creates a file>
+# In the outermost block of a script...
+my IO::Handle:D $log = open sprintf('logs/%d-%d.txt', $*INIT-INSTANT, $*PID), :a;
+CATCH { $log.printf: "[%d] Died with %s: %s$?NL", now, .^name, .message }
+END   { $log.close }
 
 =head2 Exception handlers and enclosing blocks
 

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -88,10 +88,10 @@ information as the normal backtrace printer:
 
 While this is a very common pattern, it is not strictly necessary to use
 C<default> or C<when> in a C<CATCH> block. This is done to prevent the
-control flow in one from reaching its end where, unless the exception
-has been L<resumed|#Resuming_of_exceptions>, the exception will continue
-to be thrown.  Allowing this can be used for logging purposes, for
-instance:
+control flow from reaching the end of the block where, unless the
+exception has been L<resumed|#Resuming_of_exceptions>, the exception
+will continue to be thrown.  Allowing this can be used for logging
+purposes, for instance:
 
 =for code :skip-test<creates a file>
 # In the outermost block of a script...


### PR DESCRIPTION
## The problem

The documentation on catching exceptions is rather unclear:
- A paragraph explaining how a role is used in an example is placed after what's presumably another example added later on.
- How exceptions are handled in `CATCH` is explained in terms of `given`/`when`, even though it's not particularly special when it comes to blocks.
- What happens when control flow is allowed to reach the end of a `CATCH` block isn't very clear, despite it being useful not to use `default` or `when` in one in some cases.

## Solution provided

- Move that paragraph to the correct place.
- Describe `CATCH` in terms of blocks.
- Explain what happens when you allow the control flow to reach the end of a `CATCH` block and provide an example of when this can be useful.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
