### PR TITLE
Also split TEST_FILES on newlines

### DIFF
--- a/lib/Test-Files.pm6
+++ b/lib/Test-Files.pm6
@@ -7,7 +7,7 @@ method files() {
         @files = @*ARGS;
     } else {
         if %*ENV<TEST_FILES> {
-            @files = %*ENV<TEST_FILES>.trim.split(' ').grep(*.IO.e);
+            @files = %*ENV<TEST_FILES>.trim.split(/ \n/).grep(*.IO.e);
         } else {
             @files = qx<git ls-files>.lines;
         }

--- a/lib/Test-Files.pm6
+++ b/lib/Test-Files.pm6
@@ -7,7 +7,7 @@ method files() {
         @files = @*ARGS;
     } else {
         if %*ENV<TEST_FILES> {
-            @files = %*ENV<TEST_FILES>.trim.split(/ \n/).grep(*.IO.e);
+            @files = %*ENV<TEST_FILES>.trim.split(/ \s /).grep(*.IO.e);
         } else {
             @files = qx<git ls-files>.lines;
         }


### PR DESCRIPTION
This allows multiple files to be set in TEST_FILES environment variable
from a shell command substitution, hence with embedded newlines