### PR TITLE
Document Str.index ignorecase/ignoremark

### DIFF
--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -1361,13 +1361,13 @@ their components for obvious reasons.
 
 Defined as:
 
-    multi sub index(Cool $s, Cool $needle, Cool $pos = 0)
+    multi sub index(Cool $s, Cool $needle, Cool $pos = 0, :i(:$ignorecase), :m(:$ignoremark))
     method    index(Cool:D: |c)
 
 Coerces the first two arguments (in method form, also counting the invocant) to
 a L<Str|/type/Str>, and searches for C<$needle> in the string C<$s> starting
-from C<$startpos>. It returns the offset into the string where C<$needle> was
-found, and an undefined value if it was not found.
+from C<$pos>. It returns the offset into the string where C<$needle> was
+found, and C<Nil> if it was not found.
 
 See L<the documentation in type Str|/type/Str#routine_index> for examples.
 

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -216,26 +216,41 @@ a string by calling a method that returns the size of the C<Blob> on it:
 say "þor".encode.bytes; # OUTPUT: «4␤»
 say "þor".encode.elems; # OUTPUT: «4␤»
 
-=head2 routine index
+=head2 method index
 
-    multi method index(Str:D: Cool:D $needle --> Int:D)
-    multi method index(Str:D: Str:D $needle --> Int:D)
-    multi method index(Str:D: Cool:D $needle, Cool:D $pos --> Int:D)
-    multi method index(Str:D: Str:D $needle, Int:D $pos --> Int:D)
+    multi method index(Str:D: Cool:D $needle, :i(:$ignorecase), :m(:$ignoremark) --> Int:D)
+    multi method index(Str:D: Str:D $needle, :i(:$ignorecase), :m(:$ignoremark) --> Int:D)
+    multi method index(Str:D: Cool:D $needle, Cool:D $pos, :i(:$ignorecase), :m(:$ignoremark) --> Int:D)
+    multi method index(Str:D: Str:D $needle, Int:D $pos, :i(:$ignorecase), :m(:$ignoremark) --> Int:D)
 
 Searches for C<$needle> in the string starting from C<$pos> (if present). It
 returns the offset into the string where C<$needle> was found, and C<Nil> if it
 was not found.
 
+Since Rakudo version 2020.02, if the optional named parameter
+C<:ignorecase>, or C<:i>, is specified, the search for C<$needle> ignores
+the distinction between upper case, lower case and title case letters.
+
+since Rakudo version 2020.02, if the optional named parameter
+C<:ignoremark>, or C<:m>, is specified, the search for C<$needle>
+only considers base characters, and ignores additional marks such as
+combining accents.
+
 Examples:
 
-    say index "Camelia is a butterfly", "a";     # OUTPUT: «1␤»
-    say index "Camelia is a butterfly", "a", 2;  # OUTPUT: «6␤»
-    say index "Camelia is a butterfly", "er";    # OUTPUT: «17␤»
-    say index "Camelia is a butterfly", "Camel"; # OUTPUT: «0␤»
-    say index "Camelia is a butterfly", "Onion"; # OUTPUT: «Nil␤»
+    say "Camelia is a butterfly".index("a");     # OUTPUT: «1␤»
+    say "Camelia is a butterfly".index("a", 2);  # OUTPUT: «6␤»
+    say "Camelia is a butterfly".index("er");    # OUTPUT: «17␤»
+    say "Camelia is a butterfly".index("Camel"); # OUTPUT: «0␤»
+    say "Camelia is a butterfly".index("Onion"); # OUTPUT: «Nil␤»
 
-    say index("Camelia is a butterfly", "Onion").defined ?? 'OK' !! 'NOT'; # OUTPUT: «NOT␤»
+    say "Camelia is a butterfly".index("Onion").defined ?? 'OK' !! 'NOT'; # OUTPUT: «NOT␤»
+
+    say "Hello, World".index("world");              # OUTPUT: «Nil␤»
+    say "Hello, World".index("world", :ignorecase); # OUTPUT: «7␤»
+
+    say "abc".index("ä");               # OUTPUT: «Nil␤»
+    say "abc".index("ä", :ignoremark);  # OUTPUT: «0␤»
 
 Other forms of index, including a sub, are
 L<inherited from C<Cool>|/type/Cool#routine_index>. Check them there.


### PR DESCRIPTION
while here:
- Str.index is a method: adjust section heading and use it in examples
- revisit Cool.index description

Refs #3229 