### PR TITLE
Document Str.contains ignorecase/ignoremark

### DIFF
--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -45,11 +45,11 @@ Examples:
 
 Defined as:
 
-    multi method contains(Str:D: Cool:D $needle --> Bool:D)
-    multi method contains(Str:D: Str:D $needle --> Bool:D)
+    multi method contains(Str:D: Cool:D $needle, :i(:$ignorecase), :m(:$ignoremark) --> Bool:D)
+    multi method contains(Str:D: Str:D $needle, :i(:$ignorecase), :m(:$ignoremark) --> Bool:D)
     multi method contains(Str:D: Regex:D $needle --> Bool:D)
-    multi method contains(Str:D: Cool:D $needle, Int(Cool:D) $pos --> Bool:D)
-    multi method contains(Str:D: Str:D $needle, Int:D $pos --> Bool:D)
+    multi method contains(Str:D: Cool:D $needle, Int(Cool:D) $pos, :i(:$ignorecase), :m(:$ignoremark) --> Bool:D)
+    multi method contains(Str:D: Str:D $needle, Int:D $pos, :i(:$ignorecase), :m(:$ignoremark) --> Bool:D)
     multi method contains(Str:D: Regex:D $needle, Int:D $pos --> Bool:D)
     multi method contains(Str:D: Regex:D $needle, Cool:D $pos --> Bool:D)
 
@@ -71,13 +71,30 @@ invocant right from the start of the invocant string and returns C<True>.
 In the third case, the C<'Hello'> string is not found since we have
 started looking from the second position (index 1) in C<'Hello, World'>.
 
-The C<$needle> can also be a L<C<Regex>|/type/Regex> in which case the
-C<contains> method quickly returns whether the regex matches the string at least
-once. No L<C<Match>|/type/Match> objects are created, so this is relatively
-fast.
+Since Rakudo version 2020.02, the C<$needle> can also be
+a L<C<Regex>|/type/Regex> in which case the C<contains> method
+quickly returns whether the regex matches the string at least
+once. No L<C<Match>|/type/Match> objects are created, so this is
+relatively fast.
 
     say 'Hello, World'.contains(/\w <?before ','>/);    # OUTPUT: «True␤»
     say 'Hello, World'.contains(/\w <?before ','>/, 5); # OUTPUT: «False␤»
+
+Since Rakudo version 2020.02, if the optional named parameter
+C<:ignorecase>, or C<:i>, is specified, the search for C<$needle>
+ignores the distinction between upper case, lower case and title
+case letters.
+
+    say "Hello, World".contains("world");              # OUTPUT: «False␤»
+    say "Hello, World".contains("world", :ignorecase); # OUTPUT: «True␤»
+
+Since Rakudo version 2020.02, if the optional named parameter
+C<:ignoremark>, or C<:m>, is specified, the search for C<$needle>
+only considers base characters, and ignores additional marks such as
+combining accents.
+
+    say "abc".contains("ä");               # OUTPUT: «False␤»
+    say "abc".contains("ä", :ignoremark);  # OUTPUT: «True␤»
 
 Note that because of how a L<List|/type/List> or L<Array|/type/Array> is
 L<coerced|/type/List#method_Str> into a L<Str|/type/Str>, the results may


### PR DESCRIPTION
Refs #3229

While here note that Str.contains' Regex support is also available since
Rakudo version 2020.02.
