### PR TITLE
how to flatten itemized sublists on an Iterable

### DIFF
--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -312,8 +312,8 @@ into lists of pairs.
     say ((1, 2), (3), %(:42a)).flat; # OUTPUT: «(1 2 3 a => 42)␤»
 
 Note that L<Arrays|/type/Array> containerize their elements by default, and so
-C<flat> will not flatten them. You can use
-L<hyper method call|/language/operators#index-entry-postfix_».> to call
+C<flat> will not flatten them. You can use the
+L<hyper method call|/language/operators#index-entry-postfix_».> to call the
 L«C<.List>|/routine/List» method on all the inner L<Iterables|/type/Iterable>
 and so de-containerize them, so that C<flat> can flatten them:
 

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -76,8 +76,8 @@ itemized sublists:
 
     say ($('a', 'b'), 'c').perl;    # OUTPUT: «($("a", "b"), "c")␤»
 
-You can use L<hyper method call|/language/operators#index-entry-postfix_».> to
-call L«C<.List>|/routine/List» method on all the inner itemized sublists
+You can use the L<hyper method call|/language/operators#index-entry-postfix_».> to
+call the L«C<.List>|/routine/List» method on all the inner itemized sublists
 and so de-containerize them, so that C<flat> can flatten them:
 
     say ($('a', 'b'), 'c')>>.List.flat.elems;    # OUTPUT: «3␤»

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -76,6 +76,12 @@ itemized sublists:
 
     say ($('a', 'b'), 'c').perl;    # OUTPUT: «($("a", "b"), "c")␤»
 
+You can use L<hyper method call|/language/operators#index-entry-postfix_».> to
+call L«C<.List>|/routine/List» method on all the inner itemized sublists
+and so de-containerize them, so that C<flat> can flatten them:
+
+    say ($('a', 'b'), 'c')>>.List.flat.elems;    # OUTPUT: «3␤»
+
 =head2 method lazy
 
 Defined as:


### PR DESCRIPTION
## The problem
I looked up the method [flat on Iterable](https://docs.raku.org/type/Iterable#method_flat) which, unlike on [Any](https://docs.raku.org/type/Any#method_flat), does not show how to flat itemized sublists

## Solution provided
Copy and adapt that part from the documentation of `Any.flat`.