### PR TITLE
Corrects minor mistakes on DEPRECATED Attributes

### DIFF
--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -347,7 +347,7 @@ If an attribute is marked as C<DEPRECATED>, then calling the C<DEPRECATED>
 method is possible and will return C<"something else"> (if no specific reason
 was specified) or the string that was specified with the C<DEPRECATED> trait.
 
-If an attribute is B<not> marked as DEPRECATED, one cannot B<not> call the
+If an attribute is B<not> marked as DEPRECATED, one B<cannot> call the
 C<DEPRECATED> method.  Therefore, the C<.?method> syntax should be used.
 
     class Hangout {
@@ -360,7 +360,7 @@ C<DEPRECATED> method.  Therefore, the C<.?method> syntax should be used.
         say "Table is deprecated with '$text'";
         # OUTPUT:
     }
-    with $attr-table.?DEPRECATED -> $text {
+    with $attr-bar.?DEPRECATED -> $text {
         say "Bar is deprecated with '$text'";
         # OUTPUT: «Bar is deprecated with 'the patio'"␤»
     }


### PR DESCRIPTION
## The problem

The previous phrasing made it sound like calling `DEPRECATED` was somehow mandatory for attributes marked as such, which is probably not what is meant.

The code example also uses the same variable twice with different results.

## Solution provided

This patch corrects the phrasing and the name of the variable used in the example.
