### PR TITLE
Fix description of Ruby case-when in rb-nutshell

### DIFF
--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -637,9 +637,10 @@ it does not allow for an C<elsif> or C<else> clause.
 =head3 C<case>-C<when>
 
 The Raku C<given>-C<when> construct is like a chain of C<if>-C<elsif>-C<else>
-statements or like the C<case>-C<when> construct in Ruby. A big difference is
-that Ruby uses the C<==> comparison for each condition, but Raku uses the
-more general smartmatch C<~~> operator.
+statements, and its direct analog is Ruby's C<case>-C<when> construct.
+Just as Ruby uses the C<===> (case equality) operator for each condition in a
+C<case>-C<when> expression, Raku, likewise, uses the smartmatch C<~~> operator
+with C<given>-C<when>.
 
 It has the
 general structure:


### PR DESCRIPTION
## The problem

Ruby uses the case equality operator (`===`) in  `case` expressions ⁠—not `==`.
This is incorrectly noted in the rb-nutshell doc.

(Ruby's `===` operates very similarly to Raku's smartmatch, as far as I can tell)

## Solution provided

Updated the paragraph that has the error.
I didn't create an issue first, but I checked to see if there was one (there wasn't).
