### PR TITLE
Add textwidth=72 vim setting for all POD6 documentation files

### DIFF
--- a/doc/404.pod6
+++ b/doc/404.pod6
@@ -19,4 +19,4 @@
 
 =end Html
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/HomePage.pod6
+++ b/doc/HomePage.pod6
@@ -65,4 +65,4 @@ Raku compiler developers may also be interested in
 
 =end Html
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/101-basics.pod6
+++ b/doc/Language/101-basics.pod6
@@ -501,4 +501,4 @@ for $file.lines -> $line {
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -1903,4 +1903,4 @@ live on GitHub. An online converter may become available at some point.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/5to6-overview.pod6
+++ b/doc/Language/5to6-overview.pod6
@@ -70,4 +70,4 @@ be better than losing the information about a real need.
 =end pod
 
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -2504,4 +2504,4 @@ C<tr///>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/5to6-perlop.pod6
+++ b/doc/Language/5to6-perlop.pod6
@@ -389,4 +389,4 @@ Left shift and right shift are C<< +< >> and C<< +> >>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/5to6-perlsyn.pod6
+++ b/doc/Language/5to6-perlsyn.pod6
@@ -199,4 +199,4 @@ Details on Raku-style pod is at L<https://design.raku.org/S26.html>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/5to6-perlvar.pod6
+++ b/doc/Language/5to6-perlvar.pod6
@@ -529,4 +529,4 @@ totally unconfirmed.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/about.pod6
+++ b/doc/Language/about.pod6
@@ -164,4 +164,4 @@ Notice that text after a pipe ('|') has no formatting. Also note that
 B<V< C<> >> preserves spaces and treats text as verbatim.
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -906,4 +906,4 @@ it in a narrative way.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/community.pod6
+++ b/doc/Language/community.pod6
@@ -300,4 +300,4 @@ the channels above to keep up to date.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/concurrency.pod6
+++ b/doc/Language/concurrency.pod6
@@ -847,4 +847,4 @@ is not necessary.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/containers.pod6
+++ b/doc/Language/containers.pod6
@@ -418,4 +418,4 @@ captures|/type/Signature#Type_captures> to work with types in Raku.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/contexts.pod6
+++ b/doc/Language/contexts.pod6
@@ -256,4 +256,4 @@ L<that is a method inherited from C<Mu>|/type/Mu#method_item>, objects of any
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -1274,4 +1274,4 @@ loop {
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/create-cli.pod6
+++ b/doc/Language/create-cli.pod6
@@ -463,4 +463,4 @@ then the support for the old interface can be removed from the module.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/enumeration.pod6
+++ b/doc/Language/enumeration.pod6
@@ -58,4 +58,4 @@ for $dirs -> $dir {
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -399,4 +399,4 @@ Any unhandled control exception is converted to a normal exception.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/experimental.pod6
+++ b/doc/Language/experimental.pod6
@@ -169,4 +169,4 @@ L<the description of the trait|https://docs.raku.org/routine/is%20cached> for ad
 =end pod
 
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -1127,4 +1127,4 @@ print $current;
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -1181,4 +1181,4 @@ for your script.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -1273,4 +1273,4 @@ L<here in MoarVM|https://github.com/MoarVM/MoarVM/tree/master/src/6model>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/grammar_tutorial.pod6
+++ b/doc/Language/grammar_tutorial.pod6
@@ -717,4 +717,4 @@ tokens.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -735,4 +735,4 @@ in C<token TOP>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/hashmap.pod6
+++ b/doc/Language/hashmap.pod6
@@ -549,4 +549,4 @@ say ''; # OUTPUT: «a => 1; bb => 2;»␤
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -563,4 +563,4 @@ answer yet, that will be better than losing the information about a real need.
 =end pod
 
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/io-guide.pod6
+++ b/doc/Language/io-guide.pod6
@@ -332,4 +332,4 @@ L«C<indir> routine|/routine/indir» for that purpose.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/io.pod6
+++ b/doc/Language/io.pod6
@@ -235,4 +235,4 @@ rmdir "newdir" or die "$!";
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/ipc.pod6
+++ b/doc/Language/ipc.pod6
@@ -102,4 +102,4 @@ Use the C<write> method to pass data into the program.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/iterating.pod6
+++ b/doc/Language/iterating.pod6
@@ -149,4 +149,4 @@ possible, functional and concurrent iterating constructs.
 I<Note:> Since version 6.d loops can produce a list of values from the values of last statements.
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/js-nutshell.pod6
+++ b/doc/Language/js-nutshell.pod6
@@ -921,4 +921,4 @@ L<IDNA::Punycode|https://github.com/FROGGS/p6-IDNA-Punycode> modules on CPAN.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -793,4 +793,4 @@ creature should never be passed back to unsuspecting users.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/math.pod6
+++ b/doc/Language/math.pod6
@@ -517,4 +517,4 @@ L<https://perlgeek.de/blog-en/perl-6/physical-modelling.html>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/modules-core.pod6
+++ b/doc/Language/modules-core.pod6
@@ -32,4 +32,4 @@ to be used (at least until version 6.c) by the final user.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/modules-extra.pod6
+++ b/doc/Language/modules-extra.pod6
@@ -48,4 +48,4 @@ or skeletons.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -957,4 +957,4 @@ L<https://github.com/perl6/toolchain-bikeshed>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/mop.pod6
+++ b/doc/Language/mop.pod6
@@ -224,4 +224,4 @@ convenience that ordinary Raku code offers.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -1205,4 +1205,4 @@ AF_INET6 SOCK_RAW
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/nativetypes.pod6
+++ b/doc/Language/nativetypes.pod6
@@ -233,4 +233,4 @@ Which would print the five elements of the array, as it should be expected.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/newline.pod6
+++ b/doc/Language/newline.pod6
@@ -54,4 +54,4 @@ and also C<\v>, as well as any class that includes whitespace.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/numerics.pod6
+++ b/doc/Language/numerics.pod6
@@ -773,4 +773,4 @@ types get autoboxed and have the same infectiousness as their boxed variant.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -1330,4 +1330,4 @@ protocol|/language/mop>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/opener-chars.pod6
+++ b/doc/Language/opener-chars.pod6
@@ -115,4 +115,4 @@ Char | Hex | Char | Hex | Char | Hex | Char | Hex
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -3561,4 +3561,4 @@ say [%] ();  # OUTPUT: «(exit code 1) No zero-arg meaning for infix:<%>␤
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/optut.pod6
+++ b/doc/Language/optut.pod6
@@ -68,4 +68,4 @@ what enables the use of any kind of codepoint to refer to them.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/packages.pod6
+++ b/doc/Language/packages.pod6
@@ -258,4 +258,4 @@ are actually process globals.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/performance.pod6
+++ b/doc/Language/performance.pod6
@@ -273,4 +273,4 @@ Thanks. :)
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/phasers.pod6
+++ b/doc/Language/phasers.pod6
@@ -458,4 +458,4 @@ with C<--doc>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -870,4 +870,4 @@ Pod::Heading.new(level => 2, config => {}, contents => [Pod::Block::Para.new(con
 Pod::Block::Para.new(config => {}, contents => ["Here some text for the subsection."]);
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/pragmas.pod6
+++ b/doc/Language/pragmas.pod6
@@ -301,4 +301,4 @@ compiler get shown. Enabled by default.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -763,4 +763,4 @@ in the C<user_input> variable. This is similar to L<prompt|/routine/prompt> in R
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -532,4 +532,4 @@ expression documentation|/language/regexes>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -1208,4 +1208,4 @@ answer yet, that will be better than losing the information about a real need.
 =end pod
 
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/regexes-best-practices.pod6
+++ b/doc/Language/regexes-best-practices.pod6
@@ -201,4 +201,4 @@ won't match a string like C<"\n \n">, because there's a blank between the
 two newlines. To allow such input strings, replace C<\n+> with C<\n\s*>.
 
 =end pod
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -2818,4 +2818,4 @@ provides useful information on how to avoid common pitfalls when writing regexes
 and grammars.
 
 =end pod
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/setbagmix.pod6
+++ b/doc/Language/setbagmix.pod6
@@ -221,4 +221,4 @@ L<Wikipedia definition|https://en.wikipedia.org/wiki/Empty_set>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/statement-prefixes.pod6
+++ b/doc/Language/statement-prefixes.pod6
@@ -256,4 +256,4 @@ to other module.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/structures.pod6
+++ b/doc/Language/structures.pod6
@@ -484,4 +484,4 @@ extensively.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -1115,4 +1115,4 @@ the object for the first time.  Should return the invocant.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -1025,4 +1025,4 @@ You can also wrap a unary operator with a hyper operator.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/system.pod6
+++ b/doc/Language/system.pod6
@@ -88,4 +88,4 @@ if you want to use those functions already in Raku.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/tables.pod6
+++ b/doc/Language/tables.pod6
@@ -312,4 +312,4 @@ r0c0  |  r0c1
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/terms.pod6
+++ b/doc/Language/terms.pod6
@@ -328,4 +328,4 @@ a L«C<BEGIN> phaser|/language/phasers#BEGIN» instead, for clarity.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=raku
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=raku

--- a/doc/Language/testing.pod6
+++ b/doc/Language/testing.pod6
@@ -211,4 +211,4 @@ L<C<diag>|/type/Test#diag> will print a (possibly) informative message.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=raku
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=raku

--- a/doc/Language/traits.pod6
+++ b/doc/Language/traits.pod6
@@ -110,4 +110,4 @@ routines.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -1991,4 +1991,4 @@ say @a.grep( 2 ~~ *.Int ); # OUTPUT: «(2)␤»
 =end code
 
 =end pod
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=raku
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=raku

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -979,4 +979,4 @@ subset C where ::('YourModule::C');
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -172,4 +172,4 @@ commas to separate different codepoints/sequences inside the same C<\c> sequence
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/unicode_ascii.pod6
+++ b/doc/Language/unicode_ascii.pod6
@@ -156,4 +156,4 @@ X<|»=»>X<|«=«>X<|«=»>X<|»=«>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -372,4 +372,4 @@ Or to specify the elements in a list from C<1> up to C<k>:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -1732,4 +1732,4 @@ words, such like C<add_method>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Native/int.pod6
+++ b/doc/Native/int.pod6
@@ -15,4 +15,4 @@ the section on L<native numerics|/language/numerics#Native_numerics>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Programs/01-debugging.pod6
+++ b/doc/Programs/01-debugging.pod6
@@ -118,4 +118,4 @@ Refer to its documentation for more information on how this works.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Programs/02-reading-docs.pod6
+++ b/doc/Programs/02-reading-docs.pod6
@@ -77,4 +77,4 @@ included with the installed distribution.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Programs/03-environment-variables.pod6
+++ b/doc/Programs/03-environment-variables.pod6
@@ -163,4 +163,4 @@ by Reini Urban, Moritz Lenz and the Rakudo contributors.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/AST.pod6
+++ b/doc/Type/AST.pod6
@@ -16,4 +16,4 @@ part of the work on macros.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -1522,4 +1522,4 @@ It will fail if any of the elements cannot be converted to a number.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -373,4 +373,4 @@ order to get correct information.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Associative.pod6
+++ b/doc/Type/Associative.pod6
@@ -109,4 +109,4 @@ C<Associative> role.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -367,4 +367,4 @@ C<DEPRECATED> method.  Therefore, the C<.?method> syntax should be used.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Backtrace.pod6
+++ b/doc/Type/Backtrace.pod6
@@ -211,4 +211,4 @@ Returns the backtrace same as L<list|#method_list>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Bag.pod6
+++ b/doc/Type/Bag.pod6
@@ -149,4 +149,4 @@ L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/BagHash.pod6
+++ b/doc/Type/BagHash.pod6
@@ -147,4 +147,4 @@ L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Baggy.pod6
+++ b/doc/Type/Baggy.pod6
@@ -463,4 +463,4 @@ L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Blob.pod6
+++ b/doc/Type/Blob.pod6
@@ -450,4 +450,4 @@ C<BigEndian>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Block.pod6
+++ b/doc/Type/Block.pod6
@@ -54,4 +54,4 @@ Bare blocks are automatically executed in the order they appear:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -139,4 +139,4 @@ Coerces its argument to C<Bool>, has looser precedence than C<< prefix:<?> >>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Buf.pod6
+++ b/doc/Type/Buf.pod6
@@ -486,4 +486,4 @@ C<BigEndian>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/CallFrame.pod6
+++ b/doc/Type/CallFrame.pod6
@@ -141,4 +141,4 @@ Negative levels may result in an exception.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Callable.pod6
+++ b/doc/Type/Callable.pod6
@@ -64,4 +64,4 @@ Throws C<X::Cannot::Capture>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Cancellation.pod6
+++ b/doc/Type/Cancellation.pod6
@@ -30,4 +30,4 @@ Cancels the scheduled execution of a task before normal completion.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Capture.pod6
+++ b/doc/Type/Capture.pod6
@@ -204,4 +204,4 @@ Returns the number of positional elements in the Capture.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Channel.pod6
+++ b/doc/Type/Channel.pod6
@@ -210,4 +210,4 @@ Since 6.d, it no longer blocks a thread while waiting.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -189,4 +189,4 @@ Returns the line number in which the code object was declared.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Collation.pod6
+++ b/doc/Type/Collation.pod6
@@ -74,4 +74,4 @@ Returns the state of the quaternary collation level.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/CompUnit.pod6
+++ b/doc/Type/CompUnit.pod6
@@ -68,4 +68,4 @@ Returns the version information with which the C<CompUnit> object was created
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/CompUnit/PrecompilationRepository.pod6
+++ b/doc/Type/CompUnit/PrecompilationRepository.pod6
@@ -80,3 +80,5 @@ Delete an individual precompilation.
 
 Delete all precompilations for a particular compiler.
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/CompUnit/Repository.pod6
+++ b/doc/Type/CompUnit/Repository.pod6
@@ -38,4 +38,4 @@ Returns all L<CompUnit|/type/CompUnit>s this repository has loaded.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/CompUnit/Repository/FileSystem.pod6
+++ b/doc/Type/CompUnit/Repository/FileSystem.pod6
@@ -92,4 +92,4 @@ Returns the repo short-id, which for this repository is C<file>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/CompUnit/Repository/Installation.pod6
+++ b/doc/Type/CompUnit/Repository/Installation.pod6
@@ -118,4 +118,4 @@ Returns the repo short-id, which for this repository is C<inst>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Compiler.pod6
+++ b/doc/Type/Compiler.pod6
@@ -62,4 +62,4 @@ See Also: L<Systemic|/type/Systemic>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Complex.pod6
+++ b/doc/Type/Complex.pod6
@@ -230,4 +230,4 @@ either argument can be equal to zero.
     say 0i ** 0i; # OUTPUT: «1+0i␤»
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/ComplexStr.pod6
+++ b/doc/Type/ComplexStr.pod6
@@ -123,4 +123,4 @@ coerce to the C<Complex> or C<Str> values first:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -1464,4 +1464,4 @@ Coerces the invocant to L<IO::Path|/type/IO::Path>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/CurrentThreadScheduler.pod6
+++ b/doc/Type/CurrentThreadScheduler.pod6
@@ -13,4 +13,4 @@ finished executing.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -364,4 +364,4 @@ L«C<Date>|/type/Date» object.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -498,4 +498,4 @@ Compares the equivalent instant, returns a C<Bool>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -225,4 +225,4 @@ L<DateTime|/type/DateTime> object.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Distribution.pod6
+++ b/doc/Type/Distribution.pod6
@@ -36,4 +36,4 @@ or C<resources/foo.txt>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Distribution/Hash.pod6
+++ b/doc/Type/Distribution/Hash.pod6
@@ -37,4 +37,4 @@ or C<resources/foo.txt>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Distribution/Locally.pod6
+++ b/doc/Type/Distribution/Locally.pod6
@@ -28,4 +28,4 @@ L<Distribution#method_prefix|/type/Distribution#method_prefix>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Distribution/Path.pod6
+++ b/doc/Type/Distribution/Path.pod6
@@ -37,4 +37,4 @@ or C<resources/foo.txt>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Distro.pod6
+++ b/doc/Type/Distro.pod6
@@ -29,4 +29,4 @@ the release information could not be established.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Duration.pod6
+++ b/doc/Type/Duration.pod6
@@ -21,4 +21,4 @@ unspecified.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Encoding.pod6
+++ b/doc/Type/Encoding.pod6
@@ -54,4 +54,4 @@ Windows).
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Encoding/Registry.pod6
+++ b/doc/Type/Encoding/Registry.pod6
@@ -40,4 +40,4 @@ C<Encoding::Decoder>, depending on what had been registered.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Endian.pod6
+++ b/doc/Type/Endian.pod6
@@ -30,4 +30,4 @@ the named values instead.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Exception.pod6
+++ b/doc/Type/Exception.pod6
@@ -215,4 +215,4 @@ throw an exception.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Failure.pod6
+++ b/doc/Type/Failure.pod6
@@ -161,4 +161,4 @@ the failure as handled.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/FatRat.pod6
+++ b/doc/Type/FatRat.pod6
@@ -32,4 +32,4 @@ when given to L<EVAL|/routine/EVAL>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/ForeignCode.pod6
+++ b/doc/Type/ForeignCode.pod6
@@ -65,4 +65,4 @@ Returns the name of the code by calling C<name>.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Grammar.pod6
+++ b/doc/Type/Grammar.pod6
@@ -139,4 +139,4 @@ are passed on to L<method parse|/routine/parse>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -505,4 +505,4 @@ empty angle brackets in which case all the keys and values will be listed:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/HyperSeq.pod6
+++ b/doc/Type/HyperSeq.pod6
@@ -81,4 +81,4 @@ Sinks the underlying data structure, producing any side effects.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/HyperWhatever.pod6
+++ b/doc/Type/HyperWhatever.pod6
@@ -52,4 +52,4 @@ L<Whatever|/type/Whatever> is not permitted.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO.pod6
+++ b/doc/Type/IO.pod6
@@ -14,4 +14,4 @@ L<IO::Path|/type/IO::Path>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/ArgFiles.pod6
+++ b/doc/Type/IO/ArgFiles.pod6
@@ -93,4 +93,4 @@ for instance.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/CatHandle.pod6
+++ b/doc/Type/IO/CatHandle.pod6
@@ -883,4 +883,4 @@ L<tell Rakudo developers about it|https://webchat.freenode.net/?channels=#raku-d
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -1140,4 +1140,4 @@ See also the related role L<IO|/type/IO> and the related class L<IO::Path|/type/
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -1110,4 +1110,4 @@ argument.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Path/Cygwin.pod6
+++ b/doc/Type/IO/Path/Cygwin.pod6
@@ -36,4 +36,4 @@ object was created, by default.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Path/QNX.pod6
+++ b/doc/Type/IO/Path/QNX.pod6
@@ -36,4 +36,4 @@ object was created, by default.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Path/Unix.pod6
+++ b/doc/Type/IO/Path/Unix.pod6
@@ -36,4 +36,4 @@ object was created, by default.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Path/Win32.pod6
+++ b/doc/Type/IO/Path/Win32.pod6
@@ -36,4 +36,4 @@ object was created, by default.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Pipe.pod6
+++ b/doc/Type/IO/Pipe.pod6
@@ -48,3 +48,5 @@ Defined as:
 Returns the L<Proc|/type/Proc> object from which the pipe originates.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Spec.pod6
+++ b/doc/Type/IO/Spec.pod6
@@ -26,4 +26,4 @@ L«C<IO::Path>|/type/IO::Path», to do that.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Spec/Cygwin.pod6
+++ b/doc/Type/IO/Spec/Cygwin.pod6
@@ -143,4 +143,4 @@ Attempts to locate a system's temporary directory by checking several typical di
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Spec/QNX.pod6
+++ b/doc/Type/IO/Spec/QNX.pod6
@@ -40,4 +40,4 @@ the routine does not access the filesystem, so no symlinks are followed.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Spec/Unix.pod6
+++ b/doc/Type/IO/Spec/Unix.pod6
@@ -363,4 +363,4 @@ Returns a string representing the directory one up from current:
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Spec/Win32.pod6
+++ b/doc/Type/IO/Spec/Win32.pod6
@@ -318,4 +318,4 @@ Attempts to locate a system's temporary directory by checking several typical di
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IO/Special.pod6
+++ b/doc/Type/IO/Special.pod6
@@ -138,3 +138,5 @@ object.
 The mode for the filehandle, it always returns L<Nil|/type/Nil>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Instant.pod6
+++ b/doc/Type/Instant.pod6
@@ -100,4 +100,4 @@ Coerces the invocant to L<DateTime|/type/DateTime>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -246,4 +246,4 @@ Does an integer division, rounded down.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/IntStr.pod6
+++ b/doc/Type/IntStr.pod6
@@ -110,4 +110,4 @@ coerce to an C<Int> or C<Str> value first:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -169,4 +169,4 @@ See L«C<hyper>|/routine/hyper» for an explanation of C<:$batch> and C<:$degree
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Iterator.pod6
+++ b/doc/Type/Iterator.pod6
@@ -420,4 +420,4 @@ how many values it can still produce without actually producing them.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Junction.pod6
+++ b/doc/Type/Junction.pod6
@@ -353,4 +353,4 @@ Junction with the same number of elements.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Kernel.pod6
+++ b/doc/Type/Kernel.pod6
@@ -116,4 +116,4 @@ kernel represented by the Kernel object.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Label.pod6
+++ b/doc/Type/Label.pod6
@@ -126,4 +126,4 @@ Terminate the execution of the loop associated with the label.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -1399,4 +1399,4 @@ longer.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Lock.pod6
+++ b/doc/Type/Lock.pod6
@@ -173,4 +173,4 @@ L<https://en.wikipedia.org/wiki/Monitor_%28synchronization%29> for background.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Lock/Async.pod6
+++ b/doc/Type/Lock/Async.pod6
@@ -204,4 +204,4 @@ has already been called and the lock has been placed on the recursion list.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Macro.pod6
+++ b/doc/Type/Macro.pod6
@@ -12,4 +12,4 @@ the calling location.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -262,4 +262,4 @@ The returned C<Capture> will not contain any positional arguments.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Match.pod6
+++ b/doc/Type/Match.pod6
@@ -274,4 +274,4 @@ undefined.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Metamodel/Mixins.pod6
+++ b/doc/Type/Metamodel/Mixins.pod6
@@ -197,4 +197,4 @@ no mixin attribute exists on the mixin generated before returning.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Method.pod6
+++ b/doc/Type/Method.pod6
@@ -96,4 +96,4 @@ C<samewith> was called):
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Mix.pod6
+++ b/doc/Type/Mix.pod6
@@ -161,4 +161,4 @@ L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/MixHash.pod6
+++ b/doc/Type/MixHash.pod6
@@ -158,4 +158,4 @@ L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Mixy.pod6
+++ b/doc/Type/Mixy.pod6
@@ -34,4 +34,4 @@ L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -677,4 +677,4 @@ this example reads better as:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/NFC.pod6
+++ b/doc/Type/NFC.pod6
@@ -12,4 +12,4 @@ L<Unicode TR15|https://www.unicode.org/reports/tr15/>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/NFD.pod6
+++ b/doc/Type/NFD.pod6
@@ -10,4 +10,4 @@ A Codepoint string in the "D" L<Unicode Normalization Form|https://www.unicode.o
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/NFKC.pod6
+++ b/doc/Type/NFKC.pod6
@@ -11,4 +11,4 @@ followed by Canonical Composition. For more information on what this means, see
 L<Unicode TR15|https://www.unicode.org/reports/tr15/>.
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/NFKD.pod6
+++ b/doc/Type/NFKD.pod6
@@ -11,4 +11,4 @@ For more information on what this means, see L<Unicode TR15|https://www.unicode.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -189,4 +189,4 @@ Warns the user that they tried to numify a C<Nil>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Num.pod6
+++ b/doc/Type/Num.pod6
@@ -133,4 +133,4 @@ L<denominator|/routine/denominator> and C<1>, C<-1>, or C<0> L<numerator|/routin
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/NumStr.pod6
+++ b/doc/Type/NumStr.pod6
@@ -110,4 +110,4 @@ coerce to a C<Num> or C<Str> value first:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Numeric.pod6
+++ b/doc/Type/Numeric.pod6
@@ -162,4 +162,4 @@ Returns the number decremented by one (predecessor).
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/ObjAt.pod6
+++ b/doc/Type/ObjAt.pod6
@@ -31,4 +31,4 @@ is the same.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Order.pod6
+++ b/doc/Type/Order.pod6
@@ -23,4 +23,4 @@ Specialized form for Int.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -368,4 +368,4 @@ Returns the invocant Pair object.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Parameter.pod6
+++ b/doc/Type/Parameter.pod6
@@ -422,4 +422,4 @@ parameter to deconstruct it.  By default, no signature is to be applied.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Perl.pod6
+++ b/doc/Type/Perl.pod6
@@ -11,4 +11,4 @@ L<Raku> class.  Only maintained for historical reasons.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Pod/Block/Declarator.pod6
+++ b/doc/Type/Pod/Block/Declarator.pod6
@@ -30,4 +30,4 @@ Returns the code object or metaobject to which the Pod block is attached to
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Pod/Defn.pod6
+++ b/doc/Type/Pod/Defn.pod6
@@ -16,4 +16,4 @@ Class for definition lists in a Pod document.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Pod/FormattingCode.pod6
+++ b/doc/Type/Pod/FormattingCode.pod6
@@ -20,4 +20,4 @@ Class for formatting codes in a Pod document.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Positional.pod6
+++ b/doc/Type/Positional.pod6
@@ -61,4 +61,4 @@ See L<Methods to implement for positional subscripting|/language/subscripts#Meth
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/PositionalBindFailover.pod6
+++ b/doc/Type/PositionalBindFailover.pod6
@@ -69,4 +69,4 @@ C<PositionalBindFailover> provides an C<iterator> method.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/PredictiveIterator.pod6
+++ b/doc/Type/PredictiveIterator.pod6
@@ -51,4 +51,4 @@ Defined as:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -213,4 +213,4 @@ C<0> or an undefined value otherwise.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -333,4 +333,4 @@ list containing the results of awaiting each item in turn.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Proxy.pod6
+++ b/doc/Type/Proxy.pod6
@@ -38,4 +38,4 @@ the new value) when a new value is stored in the container.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/PseudoStash.pod6
+++ b/doc/Type/PseudoStash.pod6
@@ -24,4 +24,4 @@ at runtime.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/QuantHash.pod6
+++ b/doc/Type/QuantHash.pod6
@@ -82,4 +82,4 @@ role.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/RaceSeq.pod6
+++ b/doc/Type/RaceSeq.pod6
@@ -81,4 +81,4 @@ Sinks the underlying data structure, producing any side effects.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Raku.pod6
+++ b/doc/Type/Raku.pod6
@@ -38,4 +38,4 @@ L<Systemic|/type/Systemic>, L<Compiler|/type/Compiler>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -504,4 +504,4 @@ L<Positional|/type/Positional>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Rat.pod6
+++ b/doc/Type/Rat.pod6
@@ -55,4 +55,4 @@ when given to L<EVAL|/routine/EVAL>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/RatStr.pod6
+++ b/doc/Type/RatStr.pod6
@@ -119,4 +119,4 @@ coerce to the C<Rat> or C<Str> values first:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Rational.pod6
+++ b/doc/Type/Rational.pod6
@@ -159,4 +159,4 @@ Returns a L<Range object|/type/Range> that represents the range of values suppor
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -176,4 +176,4 @@ For reverse operation, see L«C<parse-base>|/routine/parse-base»
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Regex.pod6
+++ b/doc/Type/Regex.pod6
@@ -69,4 +69,4 @@ C<False> for no match.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Routine.pod6
+++ b/doc/Type/Routine.pod6
@@ -381,4 +381,4 @@ say @zipi;  # OUTPUT: «[zape pantuflo]␤»
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Routine/WrapHandle.pod6
+++ b/doc/Type/Routine/WrapHandle.pod6
@@ -31,4 +31,4 @@ Unwraps a wrapped routine and returns C<Bool::True> on success.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Scalar.pod6
+++ b/doc/Type/Scalar.pod6
@@ -289,4 +289,4 @@ never terminate.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Scheduler.pod6
+++ b/doc/Type/Scheduler.pod6
@@ -62,4 +62,4 @@ to cancel the (possibly repeated) cueing of the code.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Semaphore.pod6
+++ b/doc/Type/Semaphore.pod6
@@ -77,4 +77,4 @@ get access after that.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Seq.pod6
+++ b/doc/Type/Seq.pod6
@@ -154,4 +154,4 @@ number of values have been discarded.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Sequence.pod6
+++ b/doc/Type/Sequence.pod6
@@ -95,4 +95,4 @@ L<cached|/type/PositionalBindFailover#method_cache> sequence.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Set.pod6
+++ b/doc/Type/Set.pod6
@@ -125,4 +125,4 @@ L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/SetHash.pod6
+++ b/doc/Type/SetHash.pod6
@@ -140,4 +140,4 @@ L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -273,4 +273,4 @@ L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -1164,4 +1164,4 @@ there is a slurpy positional parameter.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Slip.pod6
+++ b/doc/Type/Slip.pod6
@@ -91,4 +91,4 @@ C<Empty> is a C<Slip> of the empty C<List>.
 =end pod
 
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Stash.pod6
+++ b/doc/Type/Stash.pod6
@@ -39,4 +39,4 @@ class itself, via C<.can> and C<.^methods>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -1263,4 +1263,4 @@ B<Note>: Available since version 6.e (2020.01 and later).
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/StrDistance.pod6
+++ b/doc/Type/StrDistance.pod6
@@ -67,4 +67,4 @@ Returns an C<after> string value.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Stringy.pod6
+++ b/doc/Type/Stringy.pod6
@@ -10,4 +10,4 @@ Common role for string types (such as Str).
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Sub.pod6
+++ b/doc/Type/Sub.pod6
@@ -93,4 +93,4 @@ to it (or even themselves) and we can apply traits to objects at runtime.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Submethod.pod6
+++ b/doc/Type/Submethod.pod6
@@ -36,4 +36,4 @@ Returns the name of the submethod.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Supplier.pod6
+++ b/doc/Type/Supplier.pod6
@@ -79,4 +79,4 @@ This is meant for shutting down a supply with an error.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -850,4 +850,4 @@ IO::Notification.watch-path(".").act( { say "$^file changed" } );
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Systemic.pod6
+++ b/doc/Type/Systemic.pod6
@@ -66,4 +66,4 @@ Instance method returning the name of the object.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Tap.pod6
+++ b/doc/Type/Tap.pod6
@@ -28,4 +28,4 @@ Closes the tap.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Telemetry.pod6
+++ b/doc/Type/Telemetry.pod6
@@ -204,4 +204,4 @@ between snapshots.  If not specified, it will default to B<0.1> seconds.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Telemetry/Instrument/Thread.pod6
+++ b/doc/Type/Telemetry/Instrument/Thread.pod6
@@ -40,4 +40,4 @@ The number of times a thread was yielded (B<t>hreads-B<y>ieldeB<d>).
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Telemetry/Instrument/ThreadPool.pod6
+++ b/doc/Type/Telemetry/Instrument/ThreadPool.pod6
@@ -60,4 +60,4 @@ The number of timer workers (B<t>imer-B<w>orkers).
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Telemetry/Instrument/Usage.pod6
+++ b/doc/Type/Telemetry/Instrument/Usage.pod6
@@ -73,4 +73,4 @@ documentation for their exact meaning:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Telemetry/Period.pod6
+++ b/doc/Type/Telemetry/Period.pod6
@@ -29,4 +29,4 @@ two big values of the C<Telemetry> objects from which it was created).
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Telemetry/Sampler.pod6
+++ b/doc/Type/Telemetry/Sampler.pod6
@@ -52,4 +52,4 @@ any snap taking.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Test.pod6
+++ b/doc/Type/Test.pod6
@@ -865,4 +865,4 @@ diag "Yay!  The tests got to here!";
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Thread.pod6
+++ b/doc/Type/Thread.pod6
@@ -161,4 +161,4 @@ Required for implementing some lock-free data structures and algorithms.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/ThreadPoolScheduler.pod6
+++ b/doc/Type/ThreadPoolScheduler.pod6
@@ -24,4 +24,4 @@ maintain.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/UInt.pod6
+++ b/doc/Type/UInt.pod6
@@ -36,4 +36,4 @@ Some examples of its behavior and uses:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Uni.pod6
+++ b/doc/Type/Uni.pod6
@@ -61,4 +61,4 @@ Returns the number of codepoints in the invocant.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/VM.pod6
+++ b/doc/Type/VM.pod6
@@ -40,4 +40,4 @@ of the VM object is installed.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/ValueObjAt.pod6
+++ b/doc/Type/ValueObjAt.pod6
@@ -36,4 +36,4 @@ then be enough of a differentiator to prevent collisions.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Variable.pod6
+++ b/doc/Type/Variable.pod6
@@ -114,4 +114,4 @@ Returns the name of the variable, including the sigil.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Version.pod6
+++ b/doc/Type/Version.pod6
@@ -121,4 +121,4 @@ Throws C<X::Cannot::Capture>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/Whatever.pod6
+++ b/doc/Type/Whatever.pod6
@@ -133,4 +133,4 @@ Throws C<X::Cannot::Capture>.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/WhateverCode.pod6
+++ b/doc/Type/WhateverCode.pod6
@@ -77,4 +77,4 @@ to type:
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/X/Comp.pod6
+++ b/doc/Type/X/Comp.pod6
@@ -36,3 +36,5 @@ The column number of location where the compilation error occurred.
 (Rakudo does not implement that yet).
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/X/IO/Chdir.pod6
+++ b/doc/Type/X/IO/Chdir.pod6
@@ -26,3 +26,5 @@ Failed to change the working directory to '/home/other': permission denied
 Returns the path that was passed to the failed C<chdir> call.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/X/IO/Mkdir.pod6
+++ b/doc/Type/X/IO/Mkdir.pod6
@@ -25,3 +25,5 @@ Returns the path that the L<mkdir|/routine/mkdir> operation failed to create.
 Returns the permissions mask of the failed L<mkdir|/routine/mkdir> operation as an L<Int|/type/Int>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/X/IO/Move.pod6
+++ b/doc/Type/X/IO/Move.pod6
@@ -24,3 +24,5 @@ Returns the source of the failed L<move|/routine/move> operation
 Returns the destination of the failed L<move|/routine/move> operation
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/X/IO/Symlink.pod6
+++ b/doc/Type/X/IO/Symlink.pod6
@@ -25,3 +25,5 @@ Returns the path that L<symlink|/routine/symlink> failed to create.
 Returns the path that L<symlink|/routine/symlink> failed to create a link to.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/X/Numeric/Real.pod6
+++ b/doc/Type/X/Numeric/Real.pod6
@@ -36,3 +36,5 @@ Returns the type to which the coercion was attempted.
 Returns the reason that the conversion failed.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/X/OutOfRange.pod6
+++ b/doc/Type/X/OutOfRange.pod6
@@ -46,3 +46,5 @@ returned from C<.got>.
 Returns an additional comment that is included in the error message.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/X/Proc/Async/BindOrUse.pod6
+++ b/doc/Type/X/Proc/Async/BindOrUse.pod6
@@ -21,4 +21,4 @@ should flow C<:out> and the other one C<:w> to work correctly.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/X/Syntax/Signature/InvocantMarker.pod6
+++ b/doc/Type/X/Syntax/Signature/InvocantMarker.pod6
@@ -23,3 +23,5 @@ Can only use : as invocant marker in a signature after the first parameter
 See also: L<Signature|/type/Signature>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/X/TypeCheck/Splice.pod6
+++ b/doc/Type/X/TypeCheck/Splice.pod6
@@ -41,3 +41,5 @@ Returns a verbal description of the action that triggered the error,
 C<"macro application"> or C<"unquote evaluation">.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/atomicint.pod6
+++ b/doc/Type/atomicint.pod6
@@ -321,4 +321,4 @@ Synonym for ⚛-= using U+2212 minus.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/independent-routines.pod6
+++ b/doc/Type/independent-routines.pod6
@@ -1137,4 +1137,4 @@ called within the C<supply> block.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6

--- a/doc/Type/utf8.pod6
+++ b/doc/Type/utf8.pod6
@@ -14,4 +14,4 @@ encoded text.
 
 =end pod
 
-# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 textwidth=72 ft=perl6


### PR DESCRIPTION
This allows documentation to be formatted to have the correct line
length as per the style guide with gq in vim.