### PR TITLE
Explicit mention behavior with negative values for interval.

### DIFF
--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -303,7 +303,7 @@ Creates a supply that emits a value every C<$interval> seconds, starting
 C<$delay> seconds from the call. The emitted value is an integer, starting from
 0, and is incremented by one for each value emitted.
 
-Implementations may treat too-small values as lowest resolution they support,
+Implementations may treat too-small and negative values as lowest resolution they support,
 possibly warning in such situations; e.g. treating C<0.0001> as C<0.001>.
 For 6.d language version, the minimal value specified is C<0.001>.
 


### PR DESCRIPTION
Closes 'Promise.in/.at and Supply.interval work with zero and negative values' in #2632 