### PR TITLE
Meaningless entry in Glossary

### DIFF
--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -838,8 +838,8 @@ X<|Perl>
 
 The Perl programming language in its many forms.
 
-X<|Perl 6>
-=head1 Perl 6
+X<|Perl 6>
+=head1 Perl 6
 
 The name used for Raku before October 2019.
 

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -903,12 +903,6 @@ X<|QAST>
 
 Successor to L<#PAST> ('Q' being the next letter after 'P').
 
-X<|Raku>
-=head1 Raku
-
-C<Raku> is an alternative name for C<Raku> language and can be used
-interchangeably.
-
 X<|Rakudo>
 =head1 Rakudo
 

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -838,6 +838,11 @@ X<|Perl>
 
 The Perl programming language in its many forms.
 
+X<|Perl 6>
+=head1 Perl 6
+
+The name used for Raku before October 2019.
+
 X<|PERL>
 =head1 PERL
 


### PR DESCRIPTION
## The problem
[The entry 'Raku'](https://github.com/Raku/doc/blob/master/doc/Language/glossary.pod6#L906) is looking strange. The renaming process probably caused this.

## Solution provided
Remove the entry 'Raku' from glossary.

Maybe we should rename this entry to Perl 6 and explaing the relation between Raku and Perl 6. What do you think?