### PR TITLE
Change .perl to .raku in language documents, ref #3309

### DIFF
--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -402,7 +402,7 @@ X<| defined - perlfunc>
 
 Probably does what you expect, but technically it returns C<False> on
 the type object, and C<True> otherwise. This may make more sense when
-you realize that C<$num.perl> is the type C<Any> if you haven't assigned
+you realize that C<$num.raku> is the type C<Any> if you haven't assigned
 anything to it, and the assigned value if you have. Can, of course be
 used as a method: C<$num.defined>.  And any newly created class can have
 its own C<.defined> method, thereby deciding how and when it should be

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -829,13 +829,13 @@ C<GeekCook>.
 
 The call C<$o.^name> tells us the type of C<$o>: in this case C<Programmer>.
 
-C<$obj.perl> (C<$obj.raku>) returns a string that can be executed as Raku code,
-and reproduces the original object C<$o>. While this does not work perfectly in
+C<$o.raku> returns a string that can be executed as Raku code, and
+reproduces the original object C<$o>. While this does not work perfectly in
 all cases, it is very useful for debugging simple objects.
 N<For example, closures cannot easily be reproduced this way; if you
 don't know what a closure is don't worry. Also current implementations have
 problems with dumping cyclic data structures this way, but they are expected
-to be handled correctly by C<$obj.perl> (C<$obj.raku>) at some point.>
+to be handled correctly by C<.raku> at some point.>
 X<|^methods>
 C<$o.^methods(:local)> produces a list of L<Method|/type/Method>s that can be
 called on C<$o>. The C<:local> named argument limits the returned methods to

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -829,13 +829,13 @@ C<GeekCook>.
 
 The call C<$o.^name> tells us the type of C<$o>: in this case C<Programmer>.
 
-C<$o.perl> returns a string that can be executed as Perl code, and
-reproduces the original object C<$o>. While this does not work perfectly in
+C<$obj.perl> (C<$obj.raku>) returns a string that can be executed as Raku code,
+and reproduces the original object C<$o>. While this does not work perfectly in
 all cases, it is very useful for debugging simple objects.
 N<For example, closures cannot easily be reproduced this way; if you
 don't know what a closure is don't worry. Also current implementations have
 problems with dumping cyclic data structures this way, but they are expected
-to be handled correctly by C<.perl> at some point.>
+to be handled correctly by C<$obj.perl> (C<$obj.raku>) at some point.>
 X<|^methods>
 C<$o.^methods(:local)> produces a list of L<Method|/type/Method>s that can be
 called on C<$o>. The C<:local> named argument limits the returned methods to
@@ -856,7 +856,7 @@ unsurprisingly returns the class name.
 Introspection is very useful for debugging and for learning the language
 and new libraries. When a function or method returns an object you don't
 know about, by finding its type with C<.^name>, seeing a construction recipe
-for it with C<.perl>, and so on, you'll get a good idea of what its return
+for it with C<.raku>, and so on, you'll get a good idea of what its return
 value is. With C<.^methods>, you can learn what you can do with the class.
 
 But there are other applications too. For instance, a routine that serializes

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -709,8 +709,8 @@ my $cook = Cook.new(
 );
 
 $cook.cook( 'pizza' );       # OUTPUT: «Cooking pizza␤»
-say $cook.utensils.perl;     # OUTPUT: «["spoon", "ladle", "knife", "pan"]␤»
-say $cook.cookbooks.perl;    # OUTPUT: «["The Joy of Cooking"]␤»
+say $cook.utensils.raku;     # OUTPUT: «["spoon", "ladle", "knife", "pan"]␤»
+say $cook.cookbooks.raku;    # OUTPUT: «["The Joy of Cooking"]␤»
 say $cook.salary;            # OUTPUT: «40000␤»
 
 my $baker = Baker.new(
@@ -720,8 +720,8 @@ my $baker = Baker.new(
 );
 
 $baker.cook('brioche');      # OUTPUT: «Baking a tasty brioche␤»
-say $baker.utensils.perl;    # OUTPUT: «["self cleaning oven"]␤»
-say $baker.cookbooks.perl;   # OUTPUT: «["The Baker's Apprentice"]␤»
+say $baker.utensils.raku;    # OUTPUT: «["self cleaning oven"]␤»
+say $baker.cookbooks.raku;   # OUTPUT: «["The Baker's Apprentice"]␤»
 say $baker.salary;           # OUTPUT: «50000␤»
 =end code
 
@@ -807,7 +807,7 @@ my Programmer $o .= new;
 if $o ~~ Employee { say "It's an employee" };
 say $o ~~ GeekCook ?? "It's a geeky cook" !! "Not a geeky cook";
 say $o.^name;
-say $o.perl;
+say $o.raku;
 say $o.^methods(:local)».name.join(', ');
 =end code
 

--- a/doc/Language/containers.pod6
+++ b/doc/Language/containers.pod6
@@ -326,7 +326,7 @@ self-referential structures.
 
     my @a;
     @a[0] = @a;
-    put @a.perl;
+    put @a.raku;
     # OUTPUT: «((my @Array_75093712) = [@Array_75093712,])␤»
 
 Although Raku does not prevent you from creating and using self-referential

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -387,7 +387,7 @@ As with C<unless>, you may use C<without> to check for undefinedness,
 but you may not add an C<else> clause:
 
     my $answer = Any;
-    without $answer { warn "Got: {$_.perl}" }
+    without $answer { warn "Got: {$_.raku}" }
 
 There are also C<with> and C<without> statement modifiers:
 

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -333,7 +333,7 @@ first convert the string to a L<Blob|/type/Blob> with L<.encode|/routine/encode>
 say "I ❤ 🦋".encode>>.base(16);  OUTPUT: «(49 20 E2 9D A4 20 F0 9F A6 8B)␤»
 =end code
 
-Note that L<.gist|/routine/gist> or L<.raku|/routine/perl> methods can be useful for variable introspection:
+Note that L<.gist|/routine/gist> or L<.raku|/routine/raku> methods can be useful for variable introspection:
 
 =begin code
 say "I ❤ 🦋".encode.raku;  # OUTPUT: «utf8.new(73,32,226,157,164,32,240,159,166,139)␤»
@@ -385,7 +385,7 @@ representation in L<EVAL|/routine/EVAL>-able code.
 
 If you're using the L<rakudo|https://rakudo.org> implementation, you can use
 the L«rakudo-specific C<dd> routine|/programs/01-debugging#Dumper_function_dd»
-for dumping, whose output is similar to L<perl|/routine/perl>, but
+for dumping, whose output is similar to L<raku|/routine/raku>, but
 with more information.
 
 Examples:

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -392,7 +392,7 @@ Examples:
 
 =begin code :ok-test<dd>
 my $foo = %( foo => 'bar' );
-say $foo.perl;   # OUTPUT: «${:foo("bar")}␤»
+say $foo.raku;   # OUTPUT: «${:foo("bar")}␤»
 say $foo;        # OUTPUT: «{foo => bar}␤»
 
 # non-standard routine available in rakudo implementation:

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -203,7 +203,7 @@ L<Capture|/type/Capture>. Destructuring can be used to untangle multiple return
 values.
 
     sub a { 42, 'answer' };
-    put a.perl;
+    put a.raku;
     # OUTPUT: «(42, "answer")␤»
 
     my ($n, $s) = a;
@@ -211,7 +211,7 @@ values.
     # OUTPUT: «answer 42␤»
 
     sub b { <a b c>.Capture };
-    put b.perl;
+    put b.raku;
     # OUTPUT: «\("a", "b", "c")␤»
 
 =head2 Return type constraints
@@ -644,11 +644,11 @@ pragma C<use soft;> to prevent inlining to allow wrapping at runtime.
     }
 
     sub wrap-to-debug(&c){
-        say "wrapping {&c.name} with arguments {&c.signature.perl}";
+        say "wrapping {&c.name} with arguments {&c.signature.raku}";
         &c.wrap: sub (|args){
             note "calling {&c.name} with {args.gist}";
             my \ret-val := callwith(|args);
-            note "returned from {&c.name} with return value {ret-val.perl}";
+            note "returned from {&c.name} with return value {ret-val.raku}";
             ret-val
         }
     }
@@ -1081,7 +1081,7 @@ say Version.new('1.0.2') # OUTPUT: v1.0.2
 =begin code
 class LoggedVersion is Version {
     method new(|c) {
-        note "New version object created with arguments " ~ c.perl;
+        note "New version object created with arguments " ~ c.raku;
         nextsame;
     }
 }

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -392,7 +392,7 @@ C<defined($instance)> is C<True>.
     }
 
     my $an_instance = A.new;
-    say $an_instance.defined.perl;# defined($an_instance) works too.
+    say $an_instance.defined.raku;# defined($an_instance) works too.
 
 To put things another way, a class contains the blueprints of methods
 and attributes, and an instance carries it into the real world.
@@ -1127,7 +1127,7 @@ codes. For example:
 =begin pod
 C<foo>
 =end pod
-say $=pod[0].contents[0].contents.perl;
+say $=pod[0].contents[0].contents.raku;
 =end code
 
 The output will be:

--- a/doc/Language/grammar_tutorial.pod6
+++ b/doc/Language/grammar_tutorial.pod6
@@ -103,9 +103,9 @@ grammar G {
 }
 
 my $match = G.parse("Þor is mighty");
-say $match.perl;     # OUTPUT: «Match.new(made => Any, pos => 13, orig => "Þor is mighty",...»
-say $/.perl;         # OUTPUT: «Match.new(made => Any, pos => 13, orig => "Þor is mighty",...»
-say $/<thingy>.perl;
+say $match.raku;     # OUTPUT: «Match.new(made => Any, pos => 13, orig => "Þor is mighty",...»
+say $/.raku;         # OUTPUT: «Match.new(made => Any, pos => 13, orig => "Þor is mighty",...»
+say $/<thingy>.raku;
 # OUTPUT: «Match.new(made => Any, pos => 3, orig => "Þor is mighty", hash => Map.new(()), list => (), from => 0)␤»
 =end code
 

--- a/doc/Language/io-guide.pod6
+++ b/doc/Language/io-guide.pod6
@@ -43,9 +43,9 @@ on it:
 
 It may seem like something is missing here—there is no volume or absolute
 path involved—but that information is actually present in the object. You can
-see it by using L«C<.perl>|/routine/perl» method:
+see it by using L«C<.raku>|/routine/raku» method:
 
-    say 'my-file.txt'.IO.perl;
+    say 'my-file.txt'.IO.raku;
     # OUTPUT: «IO::Path.new("my-file.txt", :SPEC(IO::Spec::Unix), :CWD("/home/camelia"))␤»
 
 The two extra attributes—C<SPEC> and C<CWD>—specify what type of operating

--- a/doc/Language/iterating.pod6
+++ b/doc/Language/iterating.pod6
@@ -31,7 +31,7 @@ class DNA does Iterable {
 };
 
 my @longer-chain =  DNA.new('ACGTACGTT');
-say @longer-chain.perl;
+say @longer-chain.raku;
 # OUTPUT: «[("A", "C", "G"), ("T", "A", "C"), ("G", "T", "T")]␤»
 
 say  @longer-chain».join("").join("|"); #OUTPUT: «ACG|TAC|GTT␤»

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -620,12 +620,12 @@ C<@>-sigiled variable has an element type of C<Mu>, however its default value is
 an undefined C<Any>:
 
     my @a;
-    @a.of.perl.say;                 # OUTPUT: «Mu␤»
-    @a.default.perl.say;            # OUTPUT: «Any␤»
+    @a.of.raku.say;                 # OUTPUT: «Mu␤»
+    @a.default.raku.say;            # OUTPUT: «Any␤»
     @a[0].say;                      # OUTPUT: «(Any)␤»
     my Numeric @n is default(Real);
-    @n.of.perl.say;                 # OUTPUT: «Numeric␤»
-    @n.default.perl.say;            # OUTPUT: «Real␤»
+    @n.of.raku.say;                 # OUTPUT: «Numeric␤»
+    @n.default.raku.say;            # OUTPUT: «Real␤»
     @n[0].say;                      # OUTPUT: «(Real)␤»
 
 
@@ -639,11 +639,11 @@ kind of C<Array> will default to C<Any>. The shape can be accessed at runtime
 via the C<shape> method.
 
     my @a[2,2];
-    say @a.perl;
+    say @a.raku;
     # OUTPUT: «Array.new(:shape(2, 2), [Any, Any], [Any, Any])␤»
     say @a.shape;         # OUTPUT: «(2 2)␤»
     my @just-three[3] = <alpha beta kappa>;
-    say @just-three.perl;
+    say @just-three.raku;
     # OUTPUT: «Array.new(:shape(3,), ["alpha", "beta", "kappa"])␤»
 
 Shape will control the amount of elements that can be assigned by dimension:
@@ -659,7 +659,7 @@ Arrays (making then mutable in the process).
     my @a[2;2] = (1,2; 3,4);
     say @a.Array; # OUTPUT: «[1 2 3 4]␤»
     @a[1;1] = 42;
-    say @a.perl;
+    say @a.raku;
     # OUTPUT: «Array.new(:shape(2, 2), [1, 2], [3, 42])␤»
 
 As the third statement shows, you can assign directly to an element in a shaped
@@ -686,11 +686,11 @@ firm understanding of.
 
 First, be aware that because itemization in Arrays is assumed, it essentially
 means that C<$(…)>s are being put around everything that you assign to an
-array, if you do not put them there yourself.  On the other side, Array.perl
-does not put C<$> to explicitly show scalars, unlike List.perl:
+array, if you do not put them there yourself.  On the other side, Array.raku
+does not put C<$> to explicitly show scalars, unlike List.raku:
 
-    ((1, 2), $(3, 4)).perl.say; # says "((1, 2), $(3, 4))"
-    [(1, 2), $(3, 4)].perl.say; # says "[(1, 2), (3, 4)]"
+    ((1, 2), $(3, 4)).raku.say; # says "((1, 2), $(3, 4))"
+    [(1, 2), $(3, 4)].raku.say; # says "[(1, 2), (3, 4)]"
                                 # ...but actually means: "[$(1, 2), $(3, 4)]"
 
 It was decided all those extra dollar signs and parentheses were more of an
@@ -701,14 +701,14 @@ Second, remember that these invisible dollar signs also protect against
 flattening, so you cannot really flatten the elements inside of an Array
 with a normal call to C<flat> or C<.flat>.
 
-    ((1, 2), $(3, 4)).flat.perl.say; # OUTPUT: «(1, 2, $(3, 4)).Seq␤»
-    [(1, 2), $(3, 4)].flat.perl.say; # OUTPUT: «($(1, 2), $(3, 4)).Seq␤»
+    ((1, 2), $(3, 4)).flat.raku.say; # OUTPUT: «(1, 2, $(3, 4)).Seq␤»
+    [(1, 2), $(3, 4)].flat.raku.say; # OUTPUT: «($(1, 2), $(3, 4)).Seq␤»
 
 Since the square brackets do not themselves protect against flattening,
 you can still spill the elements out of an Array into a surrounding list
 using C<flat>.
 
-    (0, [(1, 2), $(3, 4)], 5).flat.perl.say; # OUTPUT: «(0, $(1, 2), $(3, 4), 5).Seq␤»
+    (0, [(1, 2), $(3, 4)], 5).flat.raku.say; # OUTPUT: «(0, $(1, 2), $(3, 4), 5).Seq␤»
 
 ...the elements themselves, however, stay in one piece.
 

--- a/doc/Language/nativetypes.pod6
+++ b/doc/Language/nativetypes.pod6
@@ -88,7 +88,7 @@ they can be shaped:
 
 =begin code
 my str @letter-pairs[10] = 'a'..'j' Z~ 'A'..'J';
-say @letter-pairs.perl;
+say @letter-pairs.raku;
 # OUTPUT: «array[str].new(:shape(10,), ["aA", "bB", "cC", "dD", "eE", "fF", "gG", "hH", "iI", "jJ"])␤»
 =end code
 
@@ -103,7 +103,7 @@ class Foo {
     submethod BUILD( :$!numillo = 3.5e0 ) {}
 };
 my $foo = Foo.new;
-say $foo.perl; # OUTPUT: «Foo.new(numillo => 3.5e0)␤»
+say $foo.raku; # OUTPUT: «Foo.new(numillo => 3.5e0)␤»
 
 
 X<|int8>X<|int16>X<|int32>X<|int64>X<|uint8>X<|uint16>X<|uint32>X<|uint64>
@@ -159,7 +159,7 @@ valid type, you can use it in expressions:
 
      use NativeCall;
      my void $nothing;
-     say $nothing.perl; # OUTPUT: «NativeCall::Types::void␤»
+     say $nothing.raku; # OUTPUT: «NativeCall::Types::void␤»
 
 In practice, it is an C<Uninstantiable> type that can rarely be used by itself,
 and in fact it is
@@ -171,7 +171,7 @@ pointer in C.
 =begin code :preamble<use NativeCall;>
 sub malloc( int32 $size --> Pointer[void] ) is native { * };
 my Pointer[void] $for-malloc = malloc( 32 );
-say $for-malloc.perl;
+say $for-malloc.raku;
 =end code
 
 You can also L<nativecast|/routine/nativecast> L<Blob|/type/Blob>s to this kind

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -856,7 +856,7 @@ Here some text for the subsection.
 
 for $=pod -> $pod-item {
     for $pod-item.contents -> $pod-block {
-      $pod-block.perl.say;
+      $pod-block.raku.say;
     }
 }
 =end code

--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -350,13 +350,13 @@ The Raku version above is slightly different in that when it slurps in the
 arguments into @args, one level of nesting, if any, is automatically removed:
 
 =for code
-sub foo(*@args) { say @args.perl }
+sub foo(*@args) { say @args.raku }
 foo([1, [2, 3], 4], 5, [6, 7]);   # [1, [2, 3], 4, 5, 6, 7]
 
 To preserve the structure of the arguments, you can use C<**>:
 
 =for code
-sub foo(**@args) { say @args.perl }
+sub foo(**@args) { say @args.raku }
 foo([1, [2, 3], 4], 5, [6, 7]);  # [[1, [2, 3], 4], 5, [6, 7]]
 
 You might want to expand an array into a set of arguments. In Raku this is

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -79,15 +79,15 @@ Hash subscripts do not do the same thing as C«=>».  The default C<Hash>
 has been made to behave the way new users have come to expect
 from using other languages, and for general ease of use.  On a
 default C<Hash>, subscripts coerce keys into strings, as long as
-those keys produce something C<Cool>.  You can use C<.perl> on a
+those keys produce something C<Cool>.  You can use C<.raku> on a
 collection to be sure whether the keys are strings or objects:
 
-    ( 1  => 1 ).perl.say;            # OUTPUT: «1 => 1␤»
-    my %h; %h{1}   = 1; say %h.perl; # OUTPUT: «{ "1" => 1 }␤»
-    ( 1/2 => 1 ).perl.say;           # OUTPUT: «0.5 => 1␤»
-    my %h; %h{1/2} = 1; say %h.perl; # OUTPUT: «{ "0.5" => 1 }␤»
-    ( pi => 1 ).perl.say;            # OUTPUT: «:pi(1)␤»
-    my %h; %h{pi}  = 1; say %h.perl; # OUTPUT: «{ "3.14159265358979" => 1 }␤»
+    ( 1  => 1 ).raku.say;            # OUTPUT: «1 => 1␤»
+    my %h; %h{1}   = 1; say %h.raku; # OUTPUT: «{ "1" => 1 }␤»
+    ( 1/2 => 1 ).raku.say;           # OUTPUT: «0.5 => 1␤»
+    my %h; %h{1/2} = 1; say %h.raku; # OUTPUT: «{ "0.5" => 1 }␤»
+    ( pi => 1 ).raku.say;            # OUTPUT: «:pi(1)␤»
+    my %h; %h{pi}  = 1; say %h.raku; # OUTPUT: «{ "3.14159265358979" => 1 }␤»
 
 While the invisible quotes around single names is built into C«=>»,
 string conversion is not built into the curly braces: it is a behavior
@@ -96,11 +96,11 @@ do so:
 
 =for code
 my %h := MixHash.new;
-%h{pi} = 1; %h.perl.say;         # OUTPUT: «(3.14159265358979e0=>1).MixHash␤»
+%h{pi} = 1; %h.raku.say;         # OUTPUT: «(3.14159265358979e0=>1).MixHash␤»
 
 (Any name that C«=>» would convert to a string can also be used to build
 a pair using "adverbial notation" and will appear that way when viewed
-through C<.perl>, which is why we see C<:pi(1)> above.)
+through C<.raku>, which is why we see C<:pi(1)> above.)
 
 
 =head2 Applying subscripts
@@ -203,7 +203,7 @@ For positional slices, you can mix normal indices with
 L<from-the-end|#From the end> ones:
 
     my @alphabet = 'a' .. 'z';
-    say @alphabet[15, 4, *-9, 11].perl;  # OUTPUT: «("p", "e", "r", "l")␤»
+    say @alphabet[15, 4, *-9, 11].raku;  # OUTPUT: «("p", "e", "r", "l")␤»
 
 In the C<*-number> construct above, C<*> indicates the end of the
 array as explained above in the L<From the end|#From the end>
@@ -416,7 +416,7 @@ my $beatles;
 
 $beatles{"White Album"}[0] = "Back in the U.S.S.R.";  # autovivification!
 
-say $beatles.perl;  # OUTPUT: «${"White Album" => $["Back in the U.S.S.R."]}␤»
+say $beatles.raku;  # OUTPUT: «${"White Album" => $["Back in the U.S.S.R."]}␤»
 =end code
 
 C<$beatles> started out undefined, but became a L<Hash|/type/Hash> object
@@ -753,7 +753,7 @@ behavior, can be indexed like a hash:
     $request.header{'Accept-' X~ <Charset Encoding Language>} = <utf-8 gzip en>;
     $request.header.push('Accept-Language' => "fr");  # like .push on a Hash
 
-    say $request.header<Accept-Language>.perl;  # OUTPUT: «["en", "fr"]␤»
+    say $request.header<Accept-Language>.raku;  # OUTPUT: «["en", "fr"]␤»
 
     my $rawheader = $request.header.Str;  # stringify according to HTTP spec
     =end code

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -725,16 +725,16 @@ clone and flatten it. If you want an C<Array> with just 1 element that
 is an C<Iterable>, ensure to use a comma after it:
 
     my @a = 1, 2;
-    say [@a].perl;  # OUTPUT: «[1, 2]␤»
-    say [@a,].perl; # OUTPUT: «[[1, 2],]␤»
+    say [@a].raku;  # OUTPUT: «[1, 2]␤»
+    say [@a,].raku; # OUTPUT: «[[1, 2],]␤»
 
 The C<Array> constructor does not flatten other types of contents. Use
 the L<Slip|/type/Slip> prefix operator (C<|>) to flatten the needed
 items:
 
     my @a = 1, 2;
-    say [@a, 3, 4].perl;  # OUTPUT: «[[1, 2], 3, 4]␤»
-    say [|@a, 3, 4].perl; # OUTPUT: «[1, 2, 3, 4]␤»
+    say [@a, 3, 4].raku;  # OUTPUT: «[[1, 2], 3, 4]␤»
+    say [|@a, 3, 4].raku; # OUTPUT: «[1, 2, 3, 4]␤»
 
 L<List|/type/List> type can be explicitly created from an array
 literal declaration without a coercion from Array, using B<is>

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -269,7 +269,7 @@ L«sub-signatures|/type/Signature#Sub-signatures» are supported.
 
     class Magic {
         method FALLBACK ($name, |c(Int, Str)) {
-        put "$name called with parameters {c.perl}"  }
+        put "$name called with parameters {c.raku}"  }
     };
     Magic.new.simsalabim(42, "answer");
 
@@ -401,7 +401,7 @@ methods to provide an interface for introspection and coercion to basic types.
     class A {
         multi method from-a(){ 'A::from-a' }
     }
-    say A.new.^parents(:all).perl;
+    say A.new.^parents(:all).raku;
     # OUTPUT: «(Any, Mu)␤»
 
     class B {
@@ -794,7 +794,7 @@ the keys.
 
     enum E <one two>;
     my @keys = E::.values;
-    say @keys.map: *.perl;
+    say @keys.map: *.raku;
     # OUTPUT: «(E::one E::two)␤»
 
 With the use of B<()> parentheses, an enum can be defined using any


### PR DESCRIPTION
Once this PR is merged, we can have these marked as complete:
- Pod6 (pod.pod6)
- Classes and objects (classtut.pod6)
- Lists, sequences, and arrays (list.pod6)
- Iterating (iterating.pod6)
- Glossary (glossary.pod6)
- Functions (functions.pod6)
- FAQ (faq.pod6)
- Control flow (control.pod6)
- Grammar tutorial (grammar_tutorial.pod6)
- Input/Output the definitive guide (io-guide.pod6)
- Containers (containers.pod6)
- Ruby to Raku - nutshell (rb-nutshell.pod6)
- Subscripts (subscripts.pod6)
- Perl to Raku guide - functions (5to6-perlfunc.pod6)
- Raku native types (nativetypes.pod6)
- Syntax (syntax.pod6)
- Type system (typesystem.pod6)
