### PR TITLE
Remove parenthesis

### DIFF
--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -857,9 +857,9 @@ L<C<postcircumfix [ ]>|/routine/[ ]#postcircumfix_[_]> normally calls.
 If you want an element to be mutable (like they are for the built-in
 L<Array|/type/Array> type), you'll have to make sure to return it in the form of
 an item container that evaluates to the element's value when read, and updates
-it when assigned to. (Remember to use C<return-rw> or the C<is rw> routine trait
+it when assigned to. Remember to use C<return-rw> or the C<is rw> routine trait
 to make that work; see the L<example
-|/language/subscripts#Custom_type_example>.)
+|/language/subscripts#Custom_type_example>.
 
 =head3 method EXISTS-POS
 
@@ -1009,9 +1009,9 @@ L<C<postcircumfix { }>|/routine/{ }#postcircumfix_{_}> normally calls.
 If you want an element to be mutable (like they are for the built-in
 L<Hash|/type/Hash> type), you'll have to make sure to return it in the form of
 an item container that evaluates to the element's value when read, and updates
-it when assigned to. (Remember to use C<return-rw> or the C<is rw> routine trait
+it when assigned to. Remember to use C<return-rw> or the C<is rw> routine trait
 to make that work; see the L<example
-|/language/subscripts#Custom_type_example>.)
+|/language/subscripts#Custom_type_example>.
 
 On the other hand if you want your collection to be read-only, feel free
 to return non-container values directly.


### PR DESCRIPTION
Emphasize advice on how to implement AT-KEY and AT-PO methods by
removing parentheses
