### PR TITLE
Replace 'RESULT' with 'OUTPUT:' for consistency

### DIFF
--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -21,7 +21,7 @@ Ad hoc exceptions can be used by calling L<die|/routine/die> with
 a description of the error:
 
     die "oops, something went wrong";
-    # RESULT: «oops, something went wrong in block <unit> at my-script.p6:1␤»
+    # OUTPUT: «oops, something went wrong in block <unit> at my-script.p6:1␤»
 
 
 It is worth noting that C<die> prints the error message to the standard error
@@ -38,7 +38,7 @@ L<X::IO::DoesNotExist|/type/X::IO::DoesNotExist> exception can be raised:
 
     die X::IO::DoesNotExist.new(:path("foo/bar"), :trying("zombie copy"))
 
-    # RESULT: «Failed to find 'foo/bar' while trying to do '.zombie copy'
+    # OUTPUT: «Failed to find 'foo/bar' while trying to do '.zombie copy'
     #          in block <unit> at my-script.p6:1»
 
 Note how the object has provided the backtrace with information about what
@@ -297,7 +297,7 @@ exception's payload is passed on to the backtrace printing mechanism.
 
     "OBAI".say;
 
-    # RESULT: «foo
+    # OUTPUT: «foo
     #          in block <unit> at my-script.p6:1»
 
 This next example doesn't resume from the point of the exception. Instead,

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -289,7 +289,7 @@ work:
     # And an example of a custom operator:
     sub infix:<space-concat> ($a, $b) { $a ~ " " ~ $b };
     my $a = 'word1';
-    $a space-concat= 'word2';                 # RESULT: «'word1 word2'»
+    $a space-concat= 'word2';                 # OUTPUT: «'word1 word2'␤»
 
 One thing the simple and compound assignment operators have in common is that
 they form so-called I<assignment expressions> that return or evaluate to the
@@ -299,7 +299,7 @@ assigned value:
     my @x = ( my $y = fac(100), $y*101 );     # @x = [100!, 101!]
 
     my $i = 0;
-    repeat { say $i } while ($i += 1) < 10;   # OUTPUT: 0,1,2,...9
+    repeat { say $i } while ($i += 1) < 10;   # OUTPUT: «0,1,2,...9␤»
 
 In the first example, the assignment expression C<my $y = fac(100)> declares
 C<$y>, assigns the value C<fac(100)> to it, and finally returns the assigned
@@ -375,7 +375,7 @@ Although not strictly operators, methods can be used in the same fashion as
 compound assignment operators:
 
     my $a = 3.14;
-    $a .= round;      # $a = $a.round; RESULT: «3»
+    $a .= round;      # $a = $a.round; OUTPUT: «3»
 
 =head1 Negated relational operators
 X<|! (negation metaoperator)>X<|!==>X<|!eq>
@@ -563,7 +563,7 @@ The cross metaoperator, C<X>, will apply a given infix operator in order of
 cross product to all lists, such that the rightmost operand varies most
 quickly.
 
-    1..3 X~ <a b> # RESULT: «<1a, 1b, 2a, 2b, 3a, 3b>␤»
+    1..3 X~ <a b> # OUTPUT: «<1a, 1b, 2a, 2b, 3a, 3b>␤»
 
 =head1 Zip metaoperator
 X<|Z (zip metaoperator)>
@@ -572,19 +572,19 @@ The zip metaoperator (which is not the same thing as L<Z|#infix_Z>) will
 apply a given infix operator to pairs taken one left, one right, from its
 arguments. The resulting list is returned.
 
-    my @l = <a b c> Z~ 1, 2, 3;     # RESULT: «[a1 b2 c3]␤»
+    my @l = <a b c> Z~ 1, 2, 3;     # OUTPUT: «[a1 b2 c3]␤»
 
 If one of the operands runs out of elements prematurely, the zip operator will
 stop. An infinite list can be used to repeat elements. A list with a final
 element of C<*> will repeat its 2nd last element indefinitely.
 
-    my @l = <a b c d> Z~ ':' xx *;  # RESULT: «<a: b: c: d:>»
-       @l = <a b c d> Z~ 1, 2, *;   # RESULT: «<a1 b2 c2 d2>»
+    my @l = <a b c d> Z~ ':' xx *;  # OUTPUT: «<a: b: c: d:>»
+       @l = <a b c d> Z~ 1, 2, *;   # OUTPUT: «<a1 b2 c2 d2>»
 
 If an infix operator is not given, the C<,> (comma operator) will be used by
 default:
 
-    my @l = 1 Z 2;  # RESULT: «[(1 2)]»
+    my @l = 1 Z 2;  # OUTPUT: «[(1 2)]»
 
 =head1 Sequential operators
 X<|S,sequential metaoperator>
@@ -2430,7 +2430,7 @@ Returns C<True> if C<$a> is B<not> an B<element> of C<$b>.  Equivalent to
 C<!(elem)>.
 
     =begin code
-    say 4 ∉ (1, 2, 3); # OUTPUT: «True␤»
+    say 4 ∉ (1, 2, 3);       # OUTPUT: «True␤»
     say 2 !(elem) (1, 2, 3); # OUTPUT: «False␤»
     =end code
 
@@ -2447,7 +2447,7 @@ Returns C<True> if C<$a> B<contains> C<$b>.
 
     =begin code
     say (1,2,3) (cont) 2; # OUTPUT: «True␤»
-    say (1, 2, 3) ∋ 4; # OUTPUT: «False␤»
+    say (1, 2, 3) ∋ 4;    # OUTPUT: «False␤»
     =end code
 
 C«∋» is equivalent to C«(cont)», at codepoint U+220B (CONTAINS AS MEMBER).
@@ -2462,7 +2462,7 @@ Returns C<True> if C<$a> does B<not> B<contain> C<$b>.  Equivalent to
 C<!(cont)>.
 
     =begin code
-    say (1,2,3) ∌ 4; # OUTPUT: «True␤»
+    say (1,2,3) ∌ 4;       # OUTPUT: «True␤»
     say (1,2,3) !(cont) 2; # OUTPUT: «False␤»
     =end code
 
@@ -2480,8 +2480,8 @@ elements of C<$a> are elements of C<$b> but C<$a> is a smaller set than C<$b>.
 
     =begin code
     say (1,2,3) (<) (2,3,1); # OUTPUT: «False␤»
-    say (2,3) (<) (2,3,1); # OUTPUT: «True␤»
-    say 4 ⊂ (1,2,3); # OUTPUT: «False␤»
+    say (2,3) (<) (2,3,1);   # OUTPUT: «True␤»
+    say 4 ⊂ (1,2,3);         # OUTPUT: «False␤»
     =end code
 
 C«⊂» is equivalent to C«(<)», at codepoint U+2282 (SUBSET OF).
@@ -2497,8 +2497,8 @@ C«!(<)».
 
     =begin code
     say (1,2,3) ⊄ (2,3,1); # OUTPUT: «True␤»
-    say (2,3) ⊄ (2,3,1); # OUTPUT: «False␤»
-    say 4 !(<) (1,2,3); # OUTPUT: «True␤»
+    say (2,3) ⊄ (2,3,1);   # OUTPUT: «False␤»
+    say 4 !(<) (1,2,3);    # OUTPUT: «True␤»
     =end code
 
 C«⊄» is codepoint U+2284 (NOT A SUBSET OF).
@@ -2516,8 +2516,8 @@ set than C<$b>.
 
     =begin code
     say (1,2,3) (<=) (2,3,1); # OUTPUT: «True␤»
-    say (2,3) (<=) (2,3,1); # OUTPUT: «True␤»
-    say 4 ⊆ (1,2,3); # OUTPUT: «False␤»
+    say (2,3) (<=) (2,3,1);   # OUTPUT: «True␤»
+    say 4 ⊆ (1,2,3);          # OUTPUT: «False␤»
     =end code
 
 C«⊆» is equivalent to C«(<=)», at codepoint U+2286 (SUBSET OF OR EQUAL TO).
@@ -2533,8 +2533,8 @@ C«!(<=)».
 
     =begin code
     say (1,2,3) ⊈ (2,3,1); # OUTPUT: «False␤»
-    say (2,3) ⊈ (2,3,1); # OUTPUT: «False␤»
-    say 4 !(<=) (1,2,3); # OUTPUT: «True␤»
+    say (2,3) ⊈ (2,3,1);   # OUTPUT: «False␤»
+    say 4 !(<=) (1,2,3);   # OUTPUT: «True␤»
     =end code
 
 C«⊈» is codepoint U+2288 (NEITHER A SUBSET OF NOR EQUAL TO).
@@ -2551,8 +2551,8 @@ elements of C<$b> are elements of C<$a> but C<$a> is a larger set than C<$b>.
 
     =begin code
     say (1,2,3) (>) (2,3,1); # OUTPUT: «False␤»
-    say (1,2,3) (>) (2,3); # OUTPUT: «True␤»
-    say 4 ⊃ (1,2,3); # OUTPUT: «False␤»
+    say (1,2,3) (>) (2,3);   # OUTPUT: «True␤»
+    say 4 ⊃ (1,2,3);         # OUTPUT: «False␤»
     =end code
 
 C«⊃» is equivalent to C«(>)», at codepoint U+2283 (SUPERSET OF).
@@ -2568,8 +2568,8 @@ C«!(>)».
 
     =begin code
     say (1,2,3) ⊅ (2,3,1); # OUTPUT: «True␤»
-    say (1,2,3) ⊅ (2,3); # OUTPUT: «False␤»
-    say 4 !(>) (1,2,3); # OUTPUT: «True␤»
+    say (1,2,3) ⊅ (2,3);   # OUTPUT: «False␤»
+    say 4 !(>) (1,2,3);    # OUTPUT: «True␤»
     =end code
 
 C«⊅» is codepoint U+2285 (NOT A SUPERSET OF).
@@ -2587,8 +2587,8 @@ set than C<$b>.
 
     =begin code
     say (1,2,3) (>=) (2,3,1); # OUTPUT: «True␤»
-    say (1,2,3) (>=) (2,3); # OUTPUT: «True␤»
-    say 4 ⊇ (1,2,3); # OUTPUT: «False␤»
+    say (1,2,3) (>=) (2,3);   # OUTPUT: «True␤»
+    say 4 ⊇ (1,2,3);          # OUTPUT: «False␤»
     =end code
 
 C«⊇» is equivalent to C«(>=)», at codepoint U+2287 (SUPERSET OF OR EQUAL TO).
@@ -2604,8 +2604,8 @@ C«!(>=)».
 
     =begin code
     say (1,2,3) ⊉ (2,3,1); # OUTPUT: «False␤»
-    say (1,2,3) ⊉ (2,3); # OUTPUT: «False␤»
-    say 4 !(>=) (1,2,3); # OUTPUT: «True␤»
+    say (1,2,3) ⊉ (2,3);   # OUTPUT: «False␤»
+    say 4 !(>=) (1,2,3);   # OUTPUT: «True␤»
     =end code
 
 C«⊉» is codepoint U+2289 (NEITHER A SUPERSET OF OR EQUAL TO).
@@ -3571,7 +3571,7 @@ This only applies to operators where empty or 0 is always a valid operand. For
 instance, applying it to division will yield an exception.
 
 =for code
-say [%] ();  # OUTPUT: «(exit code 1) No zero-arg meaning for infix:<%>␤
+say [%] ();  # OUTPUT: «(exit code 1) No zero-arg meaning for infix:<%>␤»
 
 =end pod
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -97,11 +97,11 @@ referenced, both outside of an embedding regex and from within an embedding
 regex by means of L<interpolation|/language/regexes#Regex_interpolation>:
 
   my $regex = / R \w+ /;
-  say "Zen Buddhists like Raku too" ~~ $regex; # OUTPUT: ｢Raku｣
+  say "Zen Buddhists like Raku too" ~~ $regex; # OUTPUT: «｢Raku｣␤»
 
   my $regex = /pottery/;
   "Japanese pottery rocks!" ~~ / <$regex> /;  # Interpolation of $regex into /.../
-  say $/;                                     # OUTPUT: ｢pottery｣
+  say $/;                                     # OUTPUT: «｢pottery｣␤»
 
 =head2 Named regex definition syntax
 
@@ -121,10 +121,10 @@ which emphasizes the fact that a L<C<Regex>|/type/Regex> object represents code
 rather than data:
 
 =begin code :preamble<my sub   S { /pattern/ }; my regex R {  pattern  };>
-&S ~~ Code;                 # OUTPUT: True
+&S ~~ Code;                 # OUTPUT: «True␤»
 
-&R ~~ Code;                 # OUTPUT: True
-&R ~~ Method;               # OUTPUT: True (A Regex is really a Method!)
+&R ~~ Code;                 # OUTPUT: «True␤»
+&R ~~ Method;               # OUTPUT: «True␤»   (A Regex is really a Method!)
 =end code
 
 Also unlike with the C<rx> form for defining an anonymous regex, the definition
@@ -247,10 +247,10 @@ against it:
   $_ = "dummy string";        # Set the topic explicitly
 
   rx/ s.* /;                  # Regex object in sink context matches automatically
-  say $/;                     # OUTPUT: ｢string｣
+  say $/;                     # OUTPUT: «｢string｣␤»
 
   say $/ if rx/ d.* /;        # Regex object in boolean context matches automatically
-                              # OUTPUT: ｢dummy string｣
+                              # OUTPUT: «｢dummy string｣␤»
 =end item
 
 =begin item
@@ -869,11 +869,11 @@ instance here:
 =for code :preamble<my $str>
 say $str ~~ m:g/[(<[ACGT]> **: 3) \s*]+ \s+ (<[A..Z a..z \s]>+)/;
 # OUTPUT:
-# (｢ACG GCT ACT An interesting chain｣
-# 0 => ｢ACG｣
-# 0 => ｢GCT｣
-# 0 => ｢ACT｣
-# 1 => ｢An interesting chain｣)
+# «(｢ACG GCT ACT An interesting chain｣
+# «0 => ｢ACG｣␤»
+# «0 => ｢GCT｣␤»
+# «0 => ｢ACT｣␤»
+# «1 => ｢An interesting chain｣)␤»
 
 Although in this case, eliminating the C<:> from behind C<**> would make it
 behave exactly in the same way. The best use is to create I<tokens> that will
@@ -882,11 +882,11 @@ not be backtracked:
     $_ = "ACG GCT ACT IDAQT";
     say  m:g/[(\w+:) \s*]+ (\w+) $$/;
     # OUTPUT:
-    # (｢ACG GCT ACT IDAQT｣
-    # 0 => ｢ACG｣
-    # 0 => ｢GCT｣
-    # 0 => ｢ACT｣
-    # 1 => ｢IDAQT｣)
+    # «(｢ACG GCT ACT IDAQT｣␤»
+    # «0 => ｢ACG｣␤»
+    # «0 => ｢GCT｣␤»
+    # «0 => ｢ACT｣␤»
+    # «1 => ｢IDAQT｣)␤»
 
 Without the C<:> following C<\w+>, the I<ID> part captured would have been
 simply C<T>, since the pattern would go ahead and match everything, leaving a
@@ -960,10 +960,10 @@ Briefly, what C<|> does is this:
 
 =item1 First, select the branch which has the longest declarative prefix.
 
-    say "abc" ~~ /ab | a.* /;                 # Output: ⌜abc⌟
-    say "abc" ~~ /ab | a {} .* /;             # Output: ⌜ab⌟
-    say "if else" ~~ / if | if <.ws> else /;  # Output: ｢if｣
-    say "if else" ~~ / if | if \s+   else /;  # Output: ｢if else｣
+    say "abc" ~~ /ab | a.* /;                 # Output: «⌜abc⌟␤»
+    say "abc" ~~ /ab | a {} .* /;             # Output: «⌜ab⌟␤»
+    say "if else" ~~ / if | if <.ws> else /;  # Output: «｢if｣␤»
+    say "if else" ~~ / if | if \s+   else /;  # Output: «｢if else｣␤»
 
 As is shown above, C<a.*> is a declarative prefix, while C<a {} .*> terminates
 at C<{}>, then its declarative prefix is C<a>. Note that non-declarative atoms
@@ -973,7 +973,7 @@ terminates declarative prefix.
 
 =item1 If it's a tie, select the match with the highest specificity.
 
-    say "abc" ~~ /a. | ab { print "win" } /;  # Output: win｢ab｣
+    say "abc" ~~ /a. | ab { print "win" } /;  # Output: «win｢ab｣␤»
 
 When two alternatives match at the same length, the tie is broken by
 specificity. That is, C<ab>, as an exact match, counts as closer than C<a.>,
@@ -981,7 +981,7 @@ which uses character classes.
 
 =item1 If it's still a tie, use additional tie-breakers.
 
-    say "abc" ~~ /a\w| a. { print "lose" } /; # Output: ⌜ab⌟
+    say "abc" ~~ /a\w| a. { print "lose" } /; # Output: «⌜ab⌟␤»
 
 If the tie breaker above doesn't work, then the textually earlier alternative
 takes precedence.
@@ -1297,10 +1297,10 @@ characters ranges, interpolated variables, subscripts and so on. In such
 cases it does suffice to use a C<?>, or a C<!> for the negate form.
 For instance, the following lines all produce the very same result:
 
-    say 'abcdefg' ~~ rx{ abc <?before def> };        # OUTPUT: ｢abc｣
-    say 'abcdefg' ~~ rx{ abc <?[ d..f ]> };          # OUTPUT: ｢abc｣
+    say 'abcdefg' ~~ rx{ abc <?before def> };        # OUTPUT: «｢abc｣␤»
+    say 'abcdefg' ~~ rx{ abc <?[ d..f ]> };          # OUTPUT: «｢abc｣␤»
     my @ending_letters = <d e f>;
-    say 'abcdefg' ~~ rx{ abc <?@ending_letters> };   # OUTPUT: ｢abc｣
+    say 'abcdefg' ~~ rx{ abc <?@ending_letters> };   # OUTPUT: «｢abc｣␤»
 
 A practical use of lookahead assertions is in substitutions, where
 you only want to substitute regex matches that are in a certain
@@ -1310,7 +1310,7 @@ that are followed by a unit (like I<kg>), but not other numbers:
     my @units = <kg m km mm s h>;
     $_ = "Please buy 2 packs of sugar, 1 kg each";
     s:g[\d+ <?before \s* @units>] = 5 * $/;
-    say $_;         # OUTPUT: Please buy 2 packs of sugar, 5 kg each
+    say $_;         # OUTPUT: «Please buy 2 packs of sugar, 5 kg each␤»
 
 Since the lookahead is not part of the match object, the unit
 is not substituted.
@@ -1384,9 +1384,9 @@ an element of the resulting L<Match|/type/Match> object:
 
     my $str =  'number 42';
     if $str ~~ /'number ' (\d+) / {
-        say "The number is $0";         # OUTPUT: The number is 42
+        say "The number is $0";         # OUTPUT: «The number is 42␤»
         # or
-        say "The number is $/[0]";      # OUTPUT: The number is 42
+        say "The number is $/[0]";      # OUTPUT: «The number is 42␤»
     }
 
 Pairs of parentheses are numbered left to right, starting from zero.
@@ -1457,8 +1457,8 @@ to use the capture variables, but it will become a list with the rest of the
 levels behaving as elements of that list
 
     if 'abc' ~~ / ( a (.) (.) ) / {
-        say "Outer: $0";                # OUTPUT: Outer: abc
-        say "Inner: $0[0] and $0[1]";   # OUTPUT: Inner: b and c
+        say "Outer: $0";                # OUTPUT: «Outer: abc␤»
+        say "Inner: $0[0] and $0[1]";   # OUTPUT: «Inner: b and c␤»
     }
 
 These capture variables are only available outside the regex.
@@ -1842,8 +1842,8 @@ will be called on parse failure:
 Note that you can use this construct to set up expectations for a
 closing construct even when there's no opening delimiter:
 
-    "3)"  ~~ / <?> ~ ')' \d+ /;  # RESULT: «｢3)｣»
-    "(3)" ~~ / <?> ~ ')' \d+ /;  # RESULT: «｢3)｣»
+    "3)"  ~~ / <?> ~ ')' \d+ /;  # OUTPUT: «｢3)｣»
+    "(3)" ~~ / <?> ~ ')' \d+ /;  # OUTPUT: «｢3)｣»
 
 Here C«<?>» successfully matches the null string.
 
@@ -1962,11 +1962,11 @@ For C«$variable» this means the following:
     my $number   = 123;
     my $regex    = /\w+/;
 
-    say $string.match: / 'string' /;                      #  [1] OUTPUT: ｢string｣
-    say $string.match: / $pattern1 /;                     #  [2] OUTPUT: ｢string｣
-    say $string.match: / $pattern2 /;                     #  [3] OUTPUT: ｢\w+｣
-    say $string.match: / $regex /;                        #  [4] OUTPUT: ｢Is｣
-    say $string.match: / $number /;                       #  [5] OUTPUT: ｢123｣
+    say $string.match: / 'string' /;                      #  [1] OUTPUT: «｢string｣␤»
+    say $string.match: / $pattern1 /;                     #  [2] OUTPUT: «｢string｣␤»
+    say $string.match: / $pattern2 /;                     #  [3] OUTPUT: «｢\w+｣␤»
+    say $string.match: / $regex /;                        #  [4] OUTPUT: «｢Is｣␤»
+    say $string.match: / $number /;                       #  [5] OUTPUT: «｢123｣␤»
 
 In this example, the statements C<[1]> and C<[2]> are equivalent and meant to
 illustrate a plain case of regex interpolation. Since unescaped/unquoted
@@ -1988,14 +1988,14 @@ This code exemplifies the use of the C«$(code)» syntax:
     my $bool     = True;
     my sub f1    { return Q[$pattern1] };
 
-    say $string.match: / $pattern3.flip /;                #  [6] OUTPUT: Nil
-    say $string.match: / "$pattern3.flip()" /;            #  [7] OUTPUT: ｢string｣
-    say $string.match: / $($pattern3.flip) /;             #  [8] OUTPUT: ｢string｣
-    say $string.match: / $([~] $pattern3.comb.reverse) /; #  [9] OUTPUT: ｢string｣
-    say $string.match: / $(!$bool) /;                     # [10] OUTPUT: ｢False｣
+    say $string.match: / $pattern3.flip /;                #  [6] OUTPUT: «Nil␤»
+    say $string.match: / "$pattern3.flip()" /;            #  [7] OUTPUT: «｢string｣␤»
+    say $string.match: / $($pattern3.flip) /;             #  [8] OUTPUT: «｢string｣␤»
+    say $string.match: / $([~] $pattern3.comb.reverse) /; #  [9] OUTPUT: «｢string｣␤»
+    say $string.match: / $(!$bool) /;                     # [10] OUTPUT: «｢False｣␤»
 
-    say $string.match: / $pattern4 /;                     # [11] OUTPUT: ｢$pattern1｣
-    say $string.match: / $(f1) /;                         # [12] OUTPUT: ｢$pattern1｣
+    say $string.match: / $pattern4 /;                     # [11] OUTPUT: «｢$pattern1｣␤»
+    say $string.match: / $(f1) /;                         # [12] OUTPUT: «｢$pattern1｣␤»
 
 Statement C<[6]> does not work as probably intended. To the human reader, the
 dot C<.> may seem to represent the L<method call operator|/language/operators#methodop_.>,
@@ -2030,9 +2030,9 @@ respective value is a C<Regex>, it is interpolated as such:
     my $number         = 123;
     my sub f1          { return /s\w+/ };
 
-    say $string.match: / <$pattern1>  /;                  # OUTPUT: ｢Is｣
-    say $string.match: / <$number>    /;                  # OUTPUT: ｢123｣
-    say $string.match: / <{ f1 }>     /;                  # OUTPUT: ｢string｣
+    say $string.match: / <$pattern1>  /;                  # OUTPUT: «｢Is｣␤»
+    say $string.match: / <$number>    /;                  # OUTPUT: «｢123｣␤»
+    say $string.match: / <{ f1 }>     /;                  # OUTPUT: «｢string｣␤»
 
 Importantly, 'to interpolate as a regex' means to interpolate/insert into the
 target regex without protective quoting. Consequently, if the value of the
@@ -2048,13 +2048,13 @@ C<$variable2>:
     my sub f1     { return Q[$variable2] };
 
     # /<{ f1 }>/ ==> /$variable2/ ==> / '$variable1' /
-    say $string.match: / <{ f1 }>     /; # OUTPUT: ｢$variable1｣
+    say $string.match: / <{ f1 }>     /; # OUTPUT: «｢$variable1｣␤»
 
     # /<$variable2>/ ==> /$variable1/ ==> / '\w+' /
-    say $string.match: /<$variable2>/;   # OUTPUT: ｢\w+｣
+    say $string.match: /<$variable2>/;   # OUTPUT: «｢\w+｣␤»
 
     # /<$variable1>/ ==> /\w+/
-    say $string.match: /<$variable1>/;   # OUTPUT: ｢Mindless｣
+    say $string.match: /<$variable1>/;   # OUTPUT: «｢Mindless｣␤»
 
 When an array variable is interpolated into a regex, the regex engine handles it
 like a C<|> alternative of the regex elements (see the documentation on
@@ -2097,7 +2097,7 @@ example that involves a simple IPv4 address matching:
 my $localhost = '127.0.0.1';
 my regex ipv4-octet { \d ** 1..3 <?{ True }> }
 $localhost ~~ / ^ <ipv4-octet> ** 4 % "." $ /;
-say $/<ipv4-octet>;   # OUTPUT: [｢127｣ ｢0｣ ｢0｣ ｢1｣]
+say $/<ipv4-octet>;   # OUTPUT: «[｢127｣ ｢0｣ ｢0｣ ｢1｣]␤»
 =end code
 
 The C<octet> regular expression matches against a number made by one up to three
@@ -2111,7 +2111,7 @@ syntactic point of view:
 my $localhost = '127.0.0.1';
 my regex ipv4-octet { \d ** 1..3 <?{ False }> }
 $localhost ~~ / ^ <ipv4-octet> ** 4 % "." $ /;
-say $/<ipv4-octet>;   # OUTPUT: Nil
+say $/<ipv4-octet>;   # OUTPUT: «Nil␤»
 =end code
 
 From the above examples, it should be clear that it is possible to improve the
@@ -2122,7 +2122,7 @@ octet:
 my $localhost = '127.0.0.1';
 my regex ipv4-octet { \d ** 1..3 <?{ $/.Int <= 255 && $/.Int >= 0 }> }
 $localhost ~~ / ^ <ipv4-octet> ** 4 % "." $ /;
-say $/<ipv4-octet>;   # OUTPUT: [｢127｣ ｢0｣ ｢0｣ ｢1｣]
+say $/<ipv4-octet>;   # OUTPUT: «[｢127｣ ｢0｣ ｢0｣ ｢1｣]␤»
 =end code
 
 Please note that it is not required to evaluate the regular expression in-line,
@@ -2133,7 +2133,7 @@ my $localhost = '127.0.0.1';
 sub check-octet ( Int $o ){ $o <= 255 && $o >= 0 }
 my regex ipv4-octet { \d ** 1..3 <?{ &check-octet( $/.Int ) }> }
 $localhost ~~ / ^ <ipv4-octet> ** 4 % "." $ /;
-say $/<ipv4-octet>;   # OUTPUT: [｢127｣ ｢0｣ ｢0｣ ｢1｣]
+say $/<ipv4-octet>;   # OUTPUT: «[｢127｣ ｢0｣ ｢0｣ ｢1｣]␤»
 =end code
 
 Of course, being C«<!{}>» the negation form of C«<?{}>» the same boolean
@@ -2144,7 +2144,7 @@ my $localhost = '127.0.0.1';
 sub invalid-octet( Int $o ){ $o < 0 || $o > 255 }
 my regex ipv4-octet { \d ** 1..3 <!{ &invalid-octet( $/.Int ) }> }
 $localhost ~~ / ^ <ipv4-octet> ** 4 % "." $ /;
-say $/<ipv4-octet>;   # OUTPUT: [｢127｣ ｢0｣ ｢0｣ ｢1｣]
+say $/<ipv4-octet>;   # OUTPUT: «[｢127｣ ｢0｣ ｢0｣ ｢1｣]␤»
 =end code
 
 =head1 Adverbs
@@ -2302,7 +2302,7 @@ The B<C<:sigspace>> or B<C<:s>> adverb makes whitespace significant in a
 regex.
 
     =begin code :allow<B>
-    say so "I used Photoshop®"   ~~ m:i/   photo shop /;   # OUTPUT: «True␤»
+    say so "I used Photoshop®"   ~~ m:i/   photo shop /;      # OUTPUT: «True␤»
     say so "I used a photo shop" ~~ m:iB<:s>/ photo shop /;   # OUTPUT: «True␤»
     say so "I used Photoshop®"   ~~ m:iB<:s>/ photo shop /;   # OUTPUT: «False␤»
     =end code
@@ -2603,7 +2603,7 @@ In order to better understand backtracking, consider the following example:
 
 =begin code
 my $string = 'PostgreSQL is an SQL database!';
-say $string ~~ /(.+)(SQL) (.+) $1/; # OUTPUT: ｢PostgreSQL is an SQL｣
+say $string ~~ /(.+)(SQL) (.+) $1/; # OUTPUT: «｢PostgreSQL is an SQL｣␤»
 =end code
 
 What happens in the above example is that the string has to be matched against
@@ -2699,7 +2699,7 @@ It is worth noting that the final iteration is number I<24>, and that such numbe
 the distance, in number of chars, from the end of the string to the first I<SQL> occurrence:
 
 =begin code :preamble<my $string = '';>
-say $string.chars - $string.index: 'SQL'; # OUTPUT: 23
+say $string.chars - $string.index: 'SQL'; # OUTPUT: «23␤»
 =end code
 
 Since there are 23 chars from the very end of the string to the very first I<S> of I<SQL>
@@ -2713,8 +2713,8 @@ With regards to the above example, disabling backtracking means
 the regular expression will not have any chance to match:
 
 =begin code :preamble<my $string = '';>
-say $string ~~ /(.+)(SQL) (.+) $1/;      # OUTPUT: ｢PostgreSQL is an SQL｣
-say $string ~~ / :r (.+)(SQL) (.+) $1/;  # OUTPUT: Nil
+say $string ~~ /(.+)(SQL) (.+) $1/;      # OUTPUT: «｢PostgreSQL is an SQL｣␤»
+say $string ~~ / :r (.+)(SQL) (.+) $1/;  # OUTPUT: «Nil␤»
 =end code
 
 The fact is that, as shown in the I<iteration 1> output, the first match of the
@@ -2729,7 +2729,7 @@ Consider the following slightly changed example:
 
 =begin code
 my $string = 'PostgreSQL is an SQL database!';
-say $string ~~ / (SQL) (.+) $1 /; # OUTPUT: Nil
+say $string ~~ / (SQL) (.+) $1 /; # OUTPUT: «Nil␤»
 =end code
 
 Since there is no specification for a character before the word I<SQL>,
@@ -2817,9 +2817,9 @@ matched:
 =begin code
 my $answer = 'a lot of Stuff';
 say 'Hit a capital letter!' if $answer ~~ / <[A..Z>]> /;
-say $/;  # OUTPUT: ｢S｣
+say $/;  # OUTPUT: «｢S｣␤»
 say 'hit an x!' if $answer ~~ / x /;
-say $/;  # OUTPUT: Nil
+say $/;  # OUTPUT: «Nil␤»
 =end code
 
 The reset of C<$/> applies independently from the scope where the regular expression
@@ -2829,16 +2829,16 @@ is matched:
 my $answer = 'a lot of Stuff';
 if $answer ~~ / <[A..Z>]> / {
    say 'Hit a capital letter';
-   say $/;  # OUTPUT: ｢S｣
+   say $/;  # OUTPUT: «｢S｣␤»
 }
-say $/;  # OUTPUT: ｢S｣
+say $/;     # OUTPUT: «｢S｣␤»
 
 if True {
   say 'hit an x!' if $answer ~~ / x /;
-  say $/;  # OUTPUT: Nil
+  say $/;   # OUTPUT: «Nil␤»
 }
 
-say $/;  # OUTPUT: Nil
+say $/;     # OUTPUT: «Nil␤»
 =end code
 
 The very same concept applies to named captures:
@@ -2847,13 +2847,13 @@ The very same concept applies to named captures:
 my $answer = 'a lot of Stuff';
 if $answer ~~ / $<capital>=<[A..Z>]> / {
    say 'Hit a capital letter';
-   say $/<capital>; # OUTPUT: ｢S｣
+   say $/<capital>; # OUTPUT: «｢S｣␤»
 }
 
-say $/<capital>;    # OUTPUT: ｢S｣
+say $/<capital>;    # OUTPUT: «｢S｣␤»
 say 'hit an x!' if $answer ~~ / $<x>=x /;
-say $/<x>;          # OUTPUT: Nil
-say $/<capital>;    # OUTPUT: Nil
+say $/<x>;          # OUTPUT: «Nil␤»
+say $/<capital>;    # OUTPUT: «Nil␤»
 =end code
 
 =head1 Best practices and gotchas

--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -645,7 +645,7 @@ C<X::IO::BinaryMode> exception being thrown.
 
 =for code
 my $fh = open 'path/to/file', :w;
-$fh.say(Complex.new(3, 4));        # RESULT: «3+4i\n»
+$fh.say(Complex.new(3, 4));        # OUTPUT: «3+4i␤»
 $fh.close;
 
 =head2 method read

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -283,7 +283,7 @@ can omit the C<$separator> if you use the method syntax.
 
 Example:
 
-    join ', ', <a b c>;             # RESULT: «a, b, c»
+    join ', ', <a b c>;             # OUTPUT: «a, b, c»
 
 Note that the method form does not flatten sublists:
 
@@ -360,7 +360,7 @@ be handled in the context of that C<Routine>.
         say 'oi‽' # dead code
     };
     s
-    # RESULT: «hi»
+    # OUTPUT: «hi»
 
 =head2 method flatmap
 
@@ -703,7 +703,7 @@ positional argument, getting index C<1> etc.
     my $list = (7, 5, a => 2, b => 17);
     my $capture = $list.Capture;
     say $capture.keys;                                # OUTPUT: «(0 1 a b)␤»
-    my-sub(|$capture);                                # RESULT: «7, 5, 2, 17»
+    my-sub(|$capture);                                # OUTPUT: «7, 5, 2, 17»
 
     sub my-sub($first, $second, :$a, :$b) {
         say "$first, $second, $a, $b"

--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -254,7 +254,7 @@ The returned C<Capture> will not contain any positional arguments.
 
     my $map = Map.new('a' => 2, 'b' => 17);
     my $capture = $map.Capture;
-    my-sub(|$capture);                                # RESULT: «2, 17»
+    my-sub(|$capture);                                # OUTPUT: «2, 17»
 
     sub my-sub(:$a, :$b) {
         say "$a, $b"

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -443,7 +443,7 @@ initializing any attributes.
 Prints value to C<$*OUT> after stringification using C<.Str> method without
 adding a newline at end.
 
-    "abc\n".print;          # RESULT: «abc␤»
+    "abc\n".print;          # OUTPUT: «abc␤»
 
 =head2 method put
 
@@ -452,7 +452,7 @@ adding a newline at end.
 Prints value to C<$*OUT>, adding a newline at end, and if necessary,
 stringifying non-C<Str> object using the C<.Str> method.
 
-    "abc".put;              # RESULT: «abc␤»
+    "abc".put;              # OUTPUT: «abc␤»
 
 =head2 method say
 

--- a/doc/Type/Parameter.pod6
+++ b/doc/Type/Parameter.pod6
@@ -195,7 +195,7 @@ Returns C<True> for parameters that capture the rest of the argument list into
 a single L<Capture|/type/Capture> object.
 
     sub how_many_extra_positionals($!, |capture) { capture.elems.say }
-    how_many_extra_positionals(0, 1, 2, 3);                        # RESULT: «3»
+    how_many_extra_positionals(0, 1, 2, 3);                        # OUTPUT: «3»
     say &how_many_extra_positionals.signature.params[1].capture;   # OUTPUT: «True␤»
 
 Like raw parameters, C<Capture> parameters do not force any context on the

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -33,10 +33,10 @@ Ranges always go from small to larger elements; if the start point is bigger
 than the end point, the range is considered empty.
 
     for 1..5 { .say };       # OUTPUT: «1␤2␤3␤4␤5␤»
-    ('a' ^..^ 'f').list;     # RESULT: «'b', 'c', 'd', 'e'»
-    5 ~~ ^5;                 # RESULT: «False»
-    4.5 ~~ 0..^5;            # RESULT: «True»
-    (1.1..5).list;           # RESULT: «(1.1, 2.1, 3.1, 4.1)»
+    ('a' ^..^ 'f').list;     # OUTPUT: «'b', 'c', 'd', 'e'»
+    5 ~~ ^5;                 # OUTPUT: «False»
+    4.5 ~~ 0..^5;            # OUTPUT: «True»
+    (1.1..5).list;           # OUTPUT: «(1.1, 2.1, 3.1, 4.1)»
 
 Use the L<...|/language/operators#infix_...> sequence operator to produce lists
 of elements that go from larger to smaller values, or to use offsets other than

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -117,8 +117,8 @@ Returns a lower-case version of the string.
 
 Examples:
 
-    lc("A"); # RESULT: «"a"»
-    "A".lc;  # RESULT: «"a"»
+    lc("A"); # OUTPUT: «"a"»
+    "A".lc;  # OUTPUT: «"a"»
 
 =head2 routine uc
 
@@ -672,8 +672,8 @@ Returns the string reversed character by character.
 
 Examples:
 
-    "Perl".flip;  # RESULT: «lreP»
-    "ABBA".flip;  # RESULT: «ABBA»
+    "Perl".flip;  # OUTPUT: «lreP»
+    "ABBA".flip;  # OUTPUT: «ABBA»
 
 =head2 method starts-with
 
@@ -870,11 +870,11 @@ zero, C<X::OutOfRange> exception is thrown. The C<$from-to>'s ending index is
 permitted to extend past the end of string, in which case it will be equivalent
 to the index of the last character.
 
-    say substr("Long string", 3..6);     # RESULT: «g st␤»
-    say substr("Long string", 6, 3);     # RESULT: «tri␤»
-    say substr("Long string", 6);        # RESULT: «tring␤»
-    say substr("Long string", 6, *-1);   # RESULT: «trin␤»
-    say substr("Long string", *-3, *-1); # RESULT: «in␤»
+    say substr("Long string", 3..6);     # OUTPUT: «g st␤»
+    say substr("Long string", 6, 3);     # OUTPUT: «tri␤»
+    say substr("Long string", 6);        # OUTPUT: «tring␤»
+    say substr("Long string", 6, *-1);   # OUTPUT: «trin␤»
+    say substr("Long string", *-3, *-1); # OUTPUT: «in␤»
 
 =head2 method substr-eq
 
@@ -1009,18 +1009,18 @@ Returns the string incremented by one.
 String increment is "magical". It searches for the last alphanumeric
 sequence that is not preceded by a dot, and increments it.
 
-    '12.34'.succ;      # RESULT: «13.34»
-    'img001.png'.succ; # RESULT: «img002.png»
+    '12.34'.succ;      # OUTPUT: «13.34»
+    'img001.png'.succ; # OUTPUT: «img002.png»
 
 The actual increment step works by mapping the last alphanumeric
 character to a character range it belongs to, and choosing the next
 character in that range, carrying to the previous letter on overflow.
 
-    'aa'.succ;   # RESULT: «ab»
-    'az'.succ;   # RESULT: «ba»
-    '109'.succ;  # RESULT: «110»
-    'α'.succ;    # RESULT: «β»
-    'a9'.succ;   # RESULT: «b0»
+    'aa'.succ;   # OUTPUT: «ab»
+    'az'.succ;   # OUTPUT: «ba»
+    '109'.succ;  # OUTPUT: «110»
+    'α'.succ;    # OUTPUT: «β»
+    'a9'.succ;   # OUTPUT: «b0»
 
 String increment is Unicode-aware, and generally works for scripts where a
 character can be uniquely classified as belonging to one range of characters.
@@ -1035,9 +1035,9 @@ String decrementing is "magical" just like string increment (see
 L<succ|/routine/succ>). It fails on underflow
 
 =for code
-'b0'.pred;           # RESULT: «a9»
-'a0'.pred;           # Failure
-'img002.png'.pred;   # RESULT: «img001.png»
+'b0'.pred;           # OUTPUT: «a9»
+'a0'.pred;           # OUTPUT: Failure
+'img002.png'.pred;   # OUTPUT: «img001.png»
 
 =head2 routine ord
 
@@ -1096,11 +1096,11 @@ Example:
 
     $str.=trans( ['a'..'y'] => ['A'..'z'] );
 
-    "abcdefghij".trans(/<[aeiou]> \w/ => '');                     # RESULT: «cdgh»
+    "abcdefghij".trans(/<[aeiou]> \w/ => '');                     # OUTPUT: «cdgh»
 
-    "a123b123c".trans(['a'..'z'] => 'x', :complement);            # RESULT: «axxxbxxxc»
-    "aaa1123bb123c".trans('a'..'z' => 'A'..'Z', :squash);         # RESULT: «A1123B123C»
-    "aaa1123bb123c".trans('a'..'z' => 'x', :complement, :squash); # RESULT: «aaaxbbxc»
+    "a123b123c".trans(['a'..'z'] => 'x', :complement);            # OUTPUT: «axxxbxxxc»
+    "aaa1123bb123c".trans('a'..'z' => 'A'..'Z', :squash);         # OUTPUT: «A1123B123C»
+    "aaa1123bb123c".trans('a'..'z' => 'x', :complement, :squash); # OUTPUT: «aaaxbbxc»
 
 In general, the strings will have the same length after the substitution:
 

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -331,7 +331,7 @@ C<&mapper> and emits it to the new supply.
     my $all      = $supplier.Supply;
     my $double   = $all.map(-> $value { $value * 2 });
     $double.tap(&say);
-    $supplier.emit(4);           # RESULT: «8»
+    $supplier.emit(4);           # OUTPUT: «8»
 
 =head2 method batch
 

--- a/doc/Type/independent-routines.pod6
+++ b/doc/Type/independent-routines.pod6
@@ -710,8 +710,8 @@ no-ops (the semantics are still being determined).
 
 =begin table
 
-     | h  | interpret integer as native "short" (typically int16)
- NYI | l  | interpret integer as native "long" (typically int32 or int64)
+     | h  | interpret integer as native "short"     (typically int16)
+ NYI | l  | interpret integer as native "long"      (typically int32 or int64)
  NYI | ll | interpret integer as native "long long" (typically int64)
  NYI | L  | interpret integer as native "long long" (typically uint64)
  NYI | q  | interpret integer as native "quads" (typically int64 or larger)
@@ -772,26 +772,26 @@ One or more of:
 
 For example:
 
-  sprintf '<% d>',  12;   # RESULT: «< 12>␤»
-  sprintf '<% d>',   0;   # RESULT: «< 0>"»
-  sprintf '<% d>', -12;   # RESULT: «<-12>␤»
-  sprintf '<%+d>',  12;   # RESULT: «<+12>␤»
-  sprintf '<%+d>',   0;   # RESULT: «<+0>"»
-  sprintf '<%+d>', -12;   # RESULT: «<-12>␤»
-  sprintf '<%6s>',  12;   # RESULT: «<    12>␤»
-  sprintf '<%-6s>', 12;   # RESULT: «<12    >␤»
-  sprintf '<%06s>', 12;   # RESULT: «<000012>␤»
-  sprintf '<%#o>',  12;   # RESULT: «<014>␤»
-  sprintf '<%#x>',  12;   # RESULT: «<0xc>␤»
-  sprintf '<%#X>',  12;   # RESULT: «<0XC>␤»
-  sprintf '<%#b>',  12;   # RESULT: «<0b1100>␤»
-  sprintf '<%#B>',  12;   # RESULT: «<0B1100>␤»
+  sprintf '<% d>',  12;   # OUTPUT: «< 12>␤»
+  sprintf '<% d>',   0;   # OUTPUT: «< 0>"»
+  sprintf '<% d>', -12;   # OUTPUT: «<-12>␤»
+  sprintf '<%+d>',  12;   # OUTPUT: «<+12>␤»
+  sprintf '<%+d>',   0;   # OUTPUT: «<+0>"»
+  sprintf '<%+d>', -12;   # OUTPUT: «<-12>␤»
+  sprintf '<%6s>',  12;   # OUTPUT: «<    12>␤»
+  sprintf '<%-6s>', 12;   # OUTPUT: «<12    >␤»
+  sprintf '<%06s>', 12;   # OUTPUT: «<000012>␤»
+  sprintf '<%#o>',  12;   # OUTPUT: «<014>␤»
+  sprintf '<%#x>',  12;   # OUTPUT: «<0xc>␤»
+  sprintf '<%#X>',  12;   # OUTPUT: «<0XC>␤»
+  sprintf '<%#b>',  12;   # OUTPUT: «<0b1100>␤»
+  sprintf '<%#B>',  12;   # OUTPUT: «<0B1100>␤»
 
 When a space and a plus sign are given as the flags at once, the space
 is ignored:
 
-  sprintf '<%+ d>', 12;   # RESULT: «<+12>␤»
-  sprintf '<% +d>', 12;   # RESULT: «<+12>␤»
+  sprintf '<%+ d>', 12;   # OUTPUT: «<+12>␤»
+  sprintf '<% +d>', 12;   # OUTPUT: «<+12>␤»
 
 When the C<#> flag and a precision are given in the C<%o> conversion, the
 necessary number of 0s is added at the beginning. If the value of the number is
@@ -800,7 +800,8 @@ the actual number of elements will return the number with 0 to the left:
 
   say sprintf '<%#.5o>', 0o12;     # OUTPUT: «<00012>␤»
   say sprintf '<%#.5o>', 0o12345;  # OUTPUT: «<012345>␤»
-  say sprintf '<%#.0o>', 0;        # OUTPUT: «<>␤» zero precision and value 0 results in no output!
+  say sprintf '<%#.0o>', 0;        # OUTPUT: «<>␤» zero precision and value 0
+                                   #               results in no output!
   say sprintf '<%#.0o>', 0o1       # OUTPUT: «<01>␤»
 
 =head3 Vector flag 'v'
@@ -832,11 +833,11 @@ number here, or get the desired width from the next argument (with C<*> ) or
 from a specified argument (e.g., with C<*2$>):
 
 =begin code :skip-test<partly not yet implemented>
- sprintf "<%s>", "a";           # RESULT: «<a>␤»
- sprintf "<%6s>", "a";          # RESULT: «<     a>␤»
- sprintf "<%*s>", 6, "a";       # RESULT: «<     a>␤»
- NYI sprintf '<%*2$s>', "a", 6; # RESULT: «<     a>␤»
- sprintf "<%2s>", "long";       # RESULT: «<long>␤» (does not truncate)
+ sprintf "<%s>", "a";           # OUTPUT: «<a>␤»
+ sprintf "<%6s>", "a";          # OUTPUT: «<     a>␤»
+ sprintf "<%*s>", 6, "a";       # OUTPUT: «<     a>␤»
+ NYI sprintf '<%*2$s>', "a", 6; # OUTPUT: «<     a>␤»
+ sprintf "<%2s>", "long";       # OUTPUT: «<long>␤»   (does not truncate)
 =end code
 
 In all cases, the specified width will be increased as necessary to accommodate the given integral numerical value or string.
@@ -852,24 +853,24 @@ specifies how many places right of the decimal point to show (the
 default being 6). For example:
 
   # These examples are subject to system-specific variation.
-  sprintf '<%f>', 1;    # RESULT: «"<1.000000>"␤»
-  sprintf '<%.1f>', 1;  # RESULT: «"<1.0>"␤»
-  sprintf '<%.0f>', 1;  # RESULT: «"<1>"␤»
-  sprintf '<%e>', 10;   # RESULT: «"<1.000000e+01>"␤»
-  sprintf '<%.1e>', 10; # RESULT: «"<1.0e+01>"␤»
+  sprintf '<%f>', 1;    # OUTPUT: «"<1.000000>"␤»
+  sprintf '<%.1f>', 1;  # OUTPUT: «"<1.0>"␤»
+  sprintf '<%.0f>', 1;  # OUTPUT: «"<1>"␤»
+  sprintf '<%e>', 10;   # OUTPUT: «"<1.000000e+01>"␤»
+  sprintf '<%.1e>', 10; # OUTPUT: «"<1.0e+01>"␤»
 
 For "g" and "G", this specifies the maximum number of digits to show,
 including those prior to the decimal point and those after it; for
 example:
 
   # These examples are subject to system-specific variation.
-  sprintf '<%g>', 1;        # RESULT: «<1>␤»
-  sprintf '<%.10g>', 1;     # RESULT: «<1>␤»
-  sprintf '<%g>', 100;      # RESULT: «<100>␤»
-  sprintf '<%.1g>', 100;    # RESULT: «<1e+02>␤»
-  sprintf '<%.2g>', 100.01; # RESULT: «<1e+02>␤»
-  sprintf '<%.5g>', 100.01; # RESULT: «<100.01>␤»
-  sprintf '<%.4g>', 100.01; # RESULT: «<100>␤»
+  sprintf '<%g>', 1;        # OUTPUT: «<1>␤»
+  sprintf '<%.10g>', 1;     # OUTPUT: «<1>␤»
+  sprintf '<%g>', 100;      # OUTPUT: «<100>␤»
+  sprintf '<%.1g>', 100;    # OUTPUT: «<1e+02>␤»
+  sprintf '<%.2g>', 100.01; # OUTPUT: «<1e+02>␤»
+  sprintf '<%.5g>', 100.01; # OUTPUT: «<100.01>␤»
+  sprintf '<%.4g>', 100.01; # OUTPUT: «<100>␤»
 
 For integer conversions, specifying a precision implies the
 output of the number itself should be zero-padded to this width (where
@@ -879,46 +880,46 @@ the C<0> flag is ignored):
 not for signed integer.)
 
   =begin code :skip-test<partly not yet implemented>
-  sprintf '<%.6d>', 1;         # RESULT: «<000001>␤»
-  NYI sprintf '<%+.6d>', 1;    # RESULT: «<+000001>␤»
-  NYI sprintf '<%-10.6d>', 1;  # RESULT: «<000001    >␤»
-  sprintf '<%10.6d>', 1;       # RESULT: «<    000001>␤»
-  NYI sprintf '<%010.6d>', 1;  # RESULT: «<    000001>␤»
-  NYI sprintf '<%+10.6d>', 1;  # RESULT: «<   +000001>␤»
-  sprintf '<%.6x>', 1;         # RESULT: «<000001>␤»
-  sprintf '<%#.6x>', 1;        # RESULT: «<0x000001>␤»
-  sprintf '<%-10.6x>', 1;      # RESULT: «<000001    >␤»
-  sprintf '<%10.6x>', 1;       # RESULT: «<    000001>␤»
-  sprintf '<%010.6x>', 1;      # RESULT: «<    000001>␤»
-  sprintf '<%#10.6x>', 1;      # RESULT: «<  0x000001>␤»
+  sprintf '<%.6d>', 1;         # OUTPUT: «<000001>␤»
+  NYI sprintf '<%+.6d>', 1;    # OUTPUT: «<+000001>␤»
+  NYI sprintf '<%-10.6d>', 1;  # OUTPUT: «<000001    >␤»
+  sprintf '<%10.6d>', 1;       # OUTPUT: «<    000001>␤»
+  NYI sprintf '<%010.6d>', 1;  # OUTPUT: «<    000001>␤»
+  NYI sprintf '<%+10.6d>', 1;  # OUTPUT: «<   +000001>␤»
+  sprintf '<%.6x>', 1;         # OUTPUT: «<000001>␤»
+  sprintf '<%#.6x>', 1;        # OUTPUT: «<0x000001>␤»
+  sprintf '<%-10.6x>', 1;      # OUTPUT: «<000001    >␤»
+  sprintf '<%10.6x>', 1;       # OUTPUT: «<    000001>␤»
+  sprintf '<%010.6x>', 1;      # OUTPUT: «<    000001>␤»
+  sprintf '<%#10.6x>', 1;      # OUTPUT: «<  0x000001>␤»
   =end code
 
 For string conversions, specifying a precision truncates the string to
 fit the specified width:
 
-  sprintf '<%.5s>', "truncated";   # RESULT: «<trunc>␤»
-  sprintf '<%10.5s>', "truncated"; # RESULT: «<     trunc>␤»
+  sprintf '<%.5s>', "truncated";   # OUTPUT: «<trunc>␤»
+  sprintf '<%10.5s>', "truncated"; # OUTPUT: «<     trunc>␤»
 
 You can also get the precision from the next argument using C<.*>, or
 from a specified argument (e.g., with C<.*2$>):
 
   =begin code :skip-test<partly not yet implemented>
-  sprintf '<%.6x>', 1;       # RESULT: «<000001>␤»
-  sprintf '<%.*x>', 6, 1;    # RESULT: «<000001>␤»
-  NYI sprintf '<%.*2$x>', 1, 6;  # "<000001>"
-  NYI sprintf '<%6.*2$x>', 1, 4; # "<  0001>"
+  sprintf '<%.6x>', 1;           # OUTPUT: «<000001>␤»
+  sprintf '<%.*x>', 6, 1;        # OUTPUT: «<000001>␤»
+  NYI sprintf '<%.*2$x>', 1, 6;  # OUTPUT: «<000001>␤»
+  NYI sprintf '<%6.*2$x>', 1, 4; # OUTPUT: «<  0001>␤»
   =end code
 
 If a precision obtained through C<*> is negative, it counts as having
 no precision at all:
 
-  sprintf '<%.*s>',  7, "string";   # RESULT: «<string>␤»
-  sprintf '<%.*s>',  3, "string";   # RESULT: «<str>␤»
-  sprintf '<%.*s>',  0, "string";   # RESULT: «<>␤»
-  sprintf '<%.*s>', -1, "string";   # RESULT: «<string>␤»
-  sprintf '<%.*d>',  1, 0;          # RESULT: «<0>␤»
-  sprintf '<%.*d>',  0, 0;          # RESULT: «<>␤»
-  sprintf '<%.*d>', -1, 0;          # RESULT: «<0>␤»
+  sprintf '<%.*s>',  7, "string";   # OUTPUT: «<string>␤»
+  sprintf '<%.*s>',  3, "string";   # OUTPUT: «<str>␤»
+  sprintf '<%.*s>',  0, "string";   # OUTPUT: «<>␤»
+  sprintf '<%.*s>', -1, "string";   # OUTPUT: «<string>␤»
+  sprintf '<%.*d>',  1, 0;          # OUTPUT: «<0>␤»
+  sprintf '<%.*d>',  0, 0;          # OUTPUT: «<>␤»
+  sprintf '<%.*d>', -1, 0;          # OUTPUT: «<0>␤»
 
 =head3 Size
 
@@ -957,7 +958,7 @@ the next argument.
 So:
 
    my $a = 5; my $b = 2; my $c = 'net';
-   sprintf "<%*.*s>", $a, $b, $c; # RESULT: «<   ne>␤»
+   sprintf "<%*.*s>", $a, $b, $c; # OUTPUT: «<   ne>␤»
 
 uses C<$a> for the width, C<$b> for the precision, and C<$c> as the value to
 format; while:
@@ -971,30 +972,30 @@ Here are some more examples; be aware that when using an explicit
 index, the C<$> may need escaping:
 
 =for code :skip-test<partly not yet implemented>
-sprintf "%2\$d %d\n",      12, 34;         # RESULT: «34 12␤␤»
-sprintf "%2\$d %d %d\n",   12, 34;         # RESULT: «34 12 34␤␤»
-sprintf "%3\$d %d %d\n",   12, 34, 56;     # RESULT: «56 12 34␤␤»
-NYI sprintf "%2\$*3\$d %d\n",  12, 34,  3; # RESULT: « 34 12␤␤»
-NYI sprintf "%*1\$.*f\n",       4,  5, 10; # RESULT: «5.0000␤␤»
+sprintf "%2\$d %d\n",      12, 34;         # OUTPUT: «34 12␤␤»
+sprintf "%2\$d %d %d\n",   12, 34;         # OUTPUT: «34 12 34␤␤»
+sprintf "%3\$d %d %d\n",   12, 34, 56;     # OUTPUT: «56 12 34␤␤»
+NYI sprintf "%2\$*3\$d %d\n",  12, 34,  3; # OUTPUT: « 34 12␤␤»
+NYI sprintf "%*1\$.*f\n",       4,  5, 10; # OUTPUT: «5.0000␤␤»
 
 Other examples:
 
 =for code :skip-test<partly not yet implemented>
 NYI sprintf "%ld a big number", 4294967295;
 NYI sprintf "%%lld a bigger number", 4294967296;
-sprintf('%c', 97);                  # RESULT: «a␤»
-sprintf("%.2f", 1.969);             # RESULT: «1.97␤»
-sprintf("%+.3f", 3.141592);         # RESULT: «+3.142␤»
-sprintf('%2$d %1$d', 12, 34);       # RESULT: «34 12␤»
-sprintf("%x", 255);                 # RESULT: «ff␤»
+sprintf('%c', 97);                  # OUTPUT: «a␤»
+sprintf("%.2f", 1.969);             # OUTPUT: «1.97␤»
+sprintf("%+.3f", 3.141592);         # OUTPUT: «+3.142␤»
+sprintf('%2$d %1$d', 12, 34);       # OUTPUT: «34 12␤»
+sprintf("%x", 255);                 # OUTPUT: «ff␤»
 
 Special case: C«sprintf("<b>%s</b>\n", "Raku")» will not work, but
 one of the following will:
 
 =for code
-sprintf Q:b "<b>%s</b>\n",  "Raku"; # RESULT: «<b>Raku</b>␤␤»
-sprintf     "<b>\%s</b>\n", "Raku"; # RESULT: «<b>Raku</b>␤␤»
-sprintf     "<b>%s\</b>\n", "Raku"; # RESULT: «<b>Raku</b>␤␤»
+sprintf Q:b "<b>%s</b>\n",  "Raku"; # OUTPUT: «<b>Raku</b>␤␤»
+sprintf     "<b>\%s</b>\n", "Raku"; # OUTPUT: «<b>Raku</b>␤␤»
+sprintf     "<b>%s\</b>\n", "Raku"; # OUTPUT: «<b>Raku</b>␤␤»
 
 =head2 sub flat
 


### PR DESCRIPTION
The latest convention for the docs is to show output in examples in
this manner:

    ...some Raku code...   # OUTPUT: <<...some example output...\n>>

This commit updates examples to be consistent with the "# OUTPUT: ".
part of the convention.

It also: (1) adds French quotes and newlines around output
examples that are missing them and (2) aligns output examples
vertically when feasible.

Files affected:

+ doc/Language/exceptions.pod6
+ doc/Language/operators.pod6
+ doc/Language/regexes.pod6
+ doc/Type/IO/Handle.pod6
+ doc/Type/List.pod6
+ doc/Type/Map.pod6
+ doc/Type/Mu.pod6
+ doc/Type/Parameter.pod6
+ doc/Type/Range.pod6
+ doc/Type/Str.pod6
+ doc/Type/Supply.pod6
+ doc/Type/independent-routines.pod6
