### PR TITLE
Fix -f routine lookup in Type/independent-routines

### DIFF
--- a/bin/p6doc
+++ b/bin/p6doc
@@ -264,7 +264,7 @@ sub disambiguate-f-search($docee, %data) {
         if %data{$ndocee} {
             my @types = %data{$ndocee}.values>>.Str.grep({ $^v ~~ /^ 'Type' / });
             @types = [gather @types.deepmap(*.take)].unique.list;
-            @types.=grep({!/$pref/});
+            @types.=grep({!/^ $pref \h/});
             %found{$ndocee}.push: @types X~ $docee;
         }
     }


### PR DESCRIPTION
## The problem

Because the pseudo-`Type` name 'independent-routines' contains the string
'routine', it was being filtered out of the results list when looking up
a routine in it, such as `p6doc -f sprintf`.

```
$ p6doc -f sprintf
No such type ''
```

## Solution provided

Be less cavalier about filtering the `@types` array.