### PR TITLE
Document few additions introduced with 2020.05

### DIFF
--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -67,6 +67,34 @@ Optionally accepts a formatter as a named parameter.
 
     say Date.new-from-daycount(49987);          # OUTPUT: «1995-09-27␤»
 
+=head2 method last-date-in-month
+
+Defined as:
+
+    method last-date-in-month(Date:D: --> Date:D)
+
+Returns the last date in the month of the C«Date» object. Otherwise, returns
+the invocant if the day value is already the last day of the month.
+
+    say Date.new('2015-11-24').last-date-in-month; # OUTPUT: «2015-11-30␤»
+
+This should allow for much easier ranges like
+
+    $date .. $date.last-date-in-month
+
+for all remaining dates in the month.
+
+=head2 method first-date-in-month
+
+Defined as:
+
+    method first-date-in-month(Date:D: --> Date:D)
+
+Returns the first date in the month of the C«Date» object. Otherwise, returns
+the invocant if the day value is already the first day of the month.
+
+    say Date.new('2015-11-24').first-date-in-month; # OUTPUT: «2015-11-01␤»
+
 =head2 method clone
 
 Defined as:

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -183,13 +183,50 @@ has occurred so far during that month, the day itself included.
 Defined as:
 
 =for code :ok-test<dd>
-method yyyy-mm-dd(Date:D: --> Str:D)
+method yyyy-mm-dd(str $sep = "-" --> Str:D)
 
-Returns the date in C<YYYY-MM-DD> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>)
+Returns the date in C<YYYY-MM-DD> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>).
+The optional positional argument C<$sep>, which defaults to C«-», is a one-character
+separator placed between the different parts of the date.
 
 =begin code :ok-test<dd>
 say Date.new("2015-11-15").yyyy-mm-dd;   # OUTPUT: «2015-11-15␤»
 say DateTime.new(1470853583).yyyy-mm-dd; # OUTPUT: «2016-08-10␤»
+say Date.today.yyyy-mm-dd("/");          # OUTPUT: «2020/03/14␤»
+=end code
+
+=head2 method mm-dd-yyyy
+
+Defined as:
+
+=for code :ok-test<dd>
+method mm-dd-yyyy(str $sep = "-" --> Str:D)
+
+Returns the date in C<MM-DD-YYYY> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>).
+The optional positional argument C<$sep>, which defaults to C«-», is a one-character
+separator placed between the different parts of the date.
+
+=begin code :ok-test<dd>
+say Date.new("2015-11-15").mm-dd-yyyy;   # OUTPUT: «11-15-2015␤»
+say DateTime.new(1470853583).mm-dd-yyyy; # OUTPUT: «08-10-2016␤»
+say Date.today.mm-dd-yyyy("/");          # OUTPUT: «03/14/2020␤»
+=end code
+
+=head2 method dd-mm-yyyy
+
+Defined as:
+
+=for code :ok-test<dd>
+method dd-mm-yyyy(str $sep = "-" --> Str:D)
+
+Returns the date in C<DD-MM-YYYY> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>).
+The optional positional argument C<$sep>, which defaults to C«-», is a one-character
+separator placed between the different parts of the date.
+
+=begin code :ok-test<dd>
+say Date.new("2015-11-15").dd-mm-yyyy;    # OUTPUT: «15-11-2015␤»
+say DateTime.new(1470853583).dd-mm-yyyy;  # OUTPUT: «10-08-2016␤»
+say Date.today.dd-mm-yyyy("/");           # OUTPUT: «14/03/2020␤»
 =end code
 
 =head2 method daycount

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -1274,6 +1274,34 @@ signature|/type/Signature#Coercion_type>, as for example:
 
 B<Note>: Available since version 6.e (2020.01 and later).
 
+=head2 method Date
+
+Defined as:
+
+    method Date(Str:D:)
+
+Coerces a C<Str> to a L«C«Date»|/type/Date» object, provided the string is
+properly formatted. C«Date(Str)» also works.
+
+Examples:
+
+    say '2015-11-24'.Date.year;  # OUTPUT: «2015␤»
+    say Date('2015-11-24').year; # OUTPUT: «2015␤»
+
+=head2 method DateTime
+
+Defined as:
+
+    method DateTime(Str:D:)
+
+Coerces a C<Str> to a L«C«DateTime»|/type/DateTime» object, provided the
+string is properly formatted. C«DateTime(Str)» also works.
+
+Examples:
+
+    say ('2012-02-29T12:34:56Z').DateTime.hour; # OUTPUT: «12␤»
+    say DateTime('2012-02-29T12:34:56Z').hour;  # OUTPUT: «12␤»
+
 =end pod
 
 # vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6


### PR DESCRIPTION
* `Str` now has `.Date` and `DateTime` coercers
* `Date.yyyy-mm-dd` now takes a separator parameter, defaulting to `-`
* Add `Date.dd-mm-yyyy` and `Date.mm-dd-yyyy` methods
* Add `Date.last-date-in-month` and `Date.first-day-in-month` methods

<!--
## The problem


## Solution provided



    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
