### PR TITLE
Use single angle brackets for infix cmp. Fixes #3038.

### DIFF
--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -454,9 +454,9 @@ Compares the equivalent instant, returns the Order.
 
     say DateTime.now <=> DateTime.now; # OUTPUT: «Less␤»
 
-=head2 sub infix:«cmp»
+=head2 sub infix:<cmp>
 
-    multi sub infix:«cmp»(DateTime:D \a, DateTime:D \b --> Order:D)
+    multi sub infix:<cmp>(DateTime:D \a, DateTime:D \b --> Order:D)
 
 Compares the equivalent instant, returns the Order.
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -1374,7 +1374,7 @@ more thorough explanation.
 
 =head1 Operators
 
-=head2 infix C«cmp»
+=head2 infix C<cmp>
 
     multi sub infix:<cmp>(List @a, List @b)
 


### PR DESCRIPTION
## The problem

Different quoting characters were being used for `infix:<cmp>`. #3038

## Solution provided

Replaced `infix:«cmp»` with `infix:<cmp>`.

Also replaced a heading with `< >`. 
Operators doc has [heading](https://github.com/Raku/doc/blob/a07587818a5a9826dd49e1f72dfd33014d238a42/doc/Language/operators.pod6#L1902) with `C«cmp»` but I left it for consistency with the rest of the headers in that file. Let me know and I can update those headings as well.

```
$ grep -r 'infix:.cmp.'
doc/Type/DateTime.pod6:    multi sub infix:<cmp>(DateTime:D \a, DateTime:D \b --> Order:D)
doc/Type/ComplexStr.pod6:    multi sub infix:<cmp>(ComplexStr:D $a, ComplexStr:D $b)
doc/Type/Range.pod6:    multi sub infix:<cmp>(Range:D \a, Range:D \b --> Order:D)
doc/Type/Range.pod6:    multi sub infix:<cmp>(Num(Real) \a, Range:D \b --> Order:D)
doc/Type/Range.pod6:    multi sub infix:<cmp>(Range:D \a, Num(Real) \b --> Order:D)
doc/Type/Range.pod6:    multi sub infix:<cmp>(Positional \a, Range:D \b --> Order:D)
doc/Type/Range.pod6:    multi sub infix:<cmp>(Range:D \a, Positional \b --> Order:D)
doc/Type/List.pod6:    multi sub infix:<cmp>(List @a, List @b)
doc/Type/IntStr.pod6:    multi sub infix:<cmp>(IntStr:D $a, IntStr:D $b)
doc/Type/NumStr.pod6:    multi sub infix:<cmp>(NumStr:D $a, NumStr:D $b)
doc/Type/RatStr.pod6:    multi sub infix:<cmp>(RatStr:D $a, RatStr:D $b)
doc/Type/Order.pod6:    multi sub infix:<cmp>(\a, \b --> Order:D)
doc/Type/Pair.pod6:    multi sub infix:<cmp>(Pair:D, Pair:D)
doc/Language/operators.pod6:    multi sub infix:<cmp>(Any,       Any)
doc/Language/operators.pod6:    multi sub infix:<cmp>(Real:D,    Real:D)
doc/Language/operators.pod6:    multi sub infix:<cmp>(Str:D,     Str:D)
doc/Language/operators.pod6:    multi sub infix:<cmp>(Version:D, Version:D)
```