### PR TITLE
Set the TERM environment variable's value in xt/p6doc-blackbox.t

### DIFF
--- a/xt/p6doc-blackbox.t
+++ b/xt/p6doc-blackbox.t
@@ -22,6 +22,7 @@ sub run-doc(*@args, :$interact = False, :$rc = 0) {
     # XXX: This should be fixed in bin/p6doc itself, probably
     # Avoid hard-coded, non-portable 'less -r' in bin/p6doc
     %env<PAGER> = 'more';
+    %env<TERM> = %*ENV<TERM> // 'unknown';
 
     my $in := $interact ~~ IO::Handle ?? $interact !! so $interact;
 


### PR DESCRIPTION
On OpenBSD, `more` doesn't like when `TERM` is unset, causing tests run here
to fail.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
