### PR TITLE
Add tuple section for Python to Raku page.

### DIFF
--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -761,6 +761,32 @@ in the C<user_input> variable. This is similar to L<prompt|/routine/prompt> in R
     my $user_input = prompt("Say hi → ");
     say $user_input; # OUTPUT: whatever you entered.
 
+=head2 X<Tuples|Python>
+
+Python tuples are immutable sequences.  The sequence elements do not need
+to be of the same types.
+
+Python
+
+=for code :lang<python>
+tuple1 = (1, "two", 3, "hat")
+tuple2 = (5, 6, "seven")
+print(tuple1[1])                                   # OUTPUT: «two␤»
+tuple3 = tuple1 + tuple2
+print(tuple3)                                      # OUTPUT: «(1, 'two', 3, 'hat', 5, 6, 'seven')␤»
+
+Raku
+
+Raku does not have a builtin Tuple type, though they are available as modules.
+You can obtain the same behavior from Raku using the List type.
+
+    my $list1 = (1, "two", 3, "hat");
+    my $list2 = (5, 6, "seven");
+    say $list1[1];                                 # OUTPUT: «two␤»
+    my $list3 = slip($list1), slip($list2);
+    my $list4 = |$list1, |$list2;                  # equivalent to previous line
+    say $list3;                                    # OUTPUT: «(1, two, 3, hat, 5, 6, seven)␤»
+
 =end pod
 
 # vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6


### PR DESCRIPTION
This is to help users coming from any language with
Tuples find a page listing an equivalent Raku feature.

## The problem
As identified in issue #3393 I am trying to add sections using keywords
in other languages that have Raku equivalents with different names.

## Solution provided

I started with the Python tuple.