### PR TITLE
Add section on tail call optimization/elimination.

### DIFF
--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -537,12 +537,11 @@ compare it to let/in and where constructs maybe?
 
 TODO
 
-=head1 Tail Call Optimization
+=head1 Tail Call Optimization or Tail Call Elimination
 
-=head2 Tail Call Optimization or Tail Call Elimination
-
-Haskell and many other functional programming languages use tail call optimization to remove
-the stack overhead of some types of recursive function calls.
+Haskell and many other functional programming languages use tail call optimization, also
+sometimes called tail tall elimination, to remove the stack overhead of some types
+of recursive function calls.
 
 There is nothing in the Raku language specification forbidding the implementation of this
 class of optimization, but no current implementation has it.

--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -537,6 +537,21 @@ compare it to let/in and where constructs maybe?
 
 TODO
 
+=head1 Tail Call Optimization
+
+=head2 Tail Call Optimization or Tail Call Elimination
+
+Haskell and many other functional programming languages use tail call optimization to remove
+the stack overhead of some types of recursive function calls.
+
+There is nothing in the Raku language specification forbidding the implementation of this
+class of optimization, but no current implementation has it.
+
+Please note that many Haskell looping constructs use recursive function calls.  Haskell programs
+would encounter stack overflow errors more often without tail call optimization. The standard
+Raku looping constructs are not built on recursive function calls, which makes the feature
+less important.
+
 =begin comment
 
 ### Guidelines for contributions:


### PR DESCRIPTION
Someone coming from Haskell, Common Lisp, and
several other functional languages might want to know
if Raku supports tail call optimization.

I can't find any recent detailed discussions on it, but
my understanding is that it's not in the Raku language spec
or in the Rakudo implementation.

## The problem
Per issue #3393  I wanted to add a section on tail call optimization.

## Solution provided

A short section mentioning the feature and that Raku does not require it, and would get smaller benefit from it than Haskell or many other functional programming languages.