### PR TITLE
Attempt to add 'case statements' to indexing

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -776,7 +776,7 @@ L<supply|/language/concurrency#index-entry-supply_(on-demand)>:
     # received Rat (0.5)
 
 =head1 X<given|control flow, given>
-X<|switch (given)>
+X<|switch (given);case statements (given)>
 
 The C<given> statement is Raku's topicalizing keyword in a similar way that
 C<switch> topicalizes in languages such as C. In other words, C<given>

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -776,7 +776,8 @@ L<supply|/language/concurrency#index-entry-supply_(on-demand)>:
     # received Rat (0.5)
 
 =head1 X<given|control flow, given>
-X<|switch (given);case statements (given)>
+X<|switch (given)>
+X<|case statements (given)>
 
 The C<given> statement is Raku's topicalizing keyword in a similar way that
 C<switch> topicalizes in languages such as C. In other words, C<given>


### PR DESCRIPTION
This is just for a search convenience if someone
coming from a C-style language background searches for 'case' or
'case statements' instead of 'switch'.

## The problem
As part of #3393 
If the user exploring Raku has not encountered given/when in Raku before,
they might search the site using 'case' or 'case statement'.  Right now those terms
do not take the user directly to the given/when documentation.

## Solution provided

I am not skilled with pod6 format, so it is likely I got the syntax wrong.  But
I tried to make a change that would add 'case statements' to the search index.