### PR TITLE
Str.subst: Add examples for nth(*), etc.

### DIFF
--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -823,14 +823,23 @@ regex, not the C<subst> method call.
 Here are other examples of usage:
 
     my $str = "Hey foo foo foo";
-    $str.subst(/foo/, "bar", :g); # global substitution - returns Hey bar bar bar
 
-    $str.subst(/\s+/, :g); # global substitution - returns Heyfoofoofoo
+    say $str.subst(/foo/, "bar", :g);           # OUTPUT: «Hey bar bar bar␤»
+    say $str.subst(/\s+/, :g);                  # OUTPUT: «Heyfoofoofoo␤»
 
-    $str.subst(/foo/, "no subst", :x(0)); # targeted substitution. Number of times to substitute. Returns back unmodified.
-    $str.subst(/foo/, "bar", :x(1)); #replace just the first occurrence.
+    say $str.subst(/foo/, "bar", :x(0));        # OUTPUT: «Hey foo foo foo␤»
+    say $str.subst(/foo/, "bar", :x(1));        # OUTPUT: «Hey bar foo foo␤»
+    # Can not match 4 times, so no substitutions made
+    say $str.subst(/foo/, "bar", :x(4));        # OUTPUT: «Hey foo foo foo␤»
+    say $str.subst(/foo/, "bar", :x(2..4));     # OUTPUT: «Hey bar bar bar␤»
+    # Replace all of them, identical to :g
+    say $str.subst(/foo/, "bar", :x(*));        # OUTPUT: «Hey bar bar bar␤»
 
-    $str.subst(/foo/, "bar", :nth(3)); # replace nth match alone. Replaces the third foo. Returns Hey foo foo bar
+    say $str.subst(/foo/, "bar", :nth(3));      # OUTPUT: «Hey foo foo bar␤»
+    # Replace last match
+    say $str.subst(/foo/, "bar", :nth(*));      # OUTPUT: «Hey foo foo bar␤»
+    # Replace next-to-last last match
+    say $str.subst(/foo/, "bar", :nth(*-1));    # OUTPUT: «Hey foo bar foo␤»
 
 The C<:nth> adverb has readable English-looking variants:
 


### PR DESCRIPTION
## The problem

Missing example of how to substitute only the last match with `.subst`.

## Solution provided

Add missing examples. While here, clean up formatting of nearby examples, too.
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
