### PR TITLE
Fix doc/Language/regexes.pod6 xt/ failures. Fixes #3408.

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -537,7 +537,7 @@ character to be matched. For example:
 
 C<\X> matches a single character that is not the given Unicode codepoint.
 
-In addition, C<\x> and C<\X> can be used without brackets, in which case, any
+In addition, C<\x> and C<\X> can be used without square brackets, in which case, any
 characters that follow the C<x> or C<X> that are valid hexadecimal digits will
 be consumed. This means that all of these are equivalent:
 

--- a/xt/words.pws
+++ b/xt/words.pws
@@ -1368,6 +1368,7 @@ typepretense
 tz
 ub
 uc
+ucd
 ucfirst
 udp
 ugt


### PR DESCRIPTION
## The problem

#3408 and #3433 

xt/aspell.t and xt/braces.t failed on doc/Language/regexes.pod6 file.

## Solution provided

1. Add 'square' to description of \x character class to fix xt/braces test failures.
2. Add 'UCD' to xt/words.pws to fix xt/aspell test failures. 'UCD' is used here:
https://github.com/Raku/doc/blob/b91e0eb3f4dda9cae5dd94f1b6c1115b530420ef/doc/Language/regexes.pod6#L511-L518