### PR TITLE
p6doc: Add a deprecation comment to inform developers

### DIFF
--- a/bin/p6doc
+++ b/bin/p6doc
@@ -1,5 +1,17 @@
 #!/usr/bin/env perl6
 
+# DEPRECATED DEPRECATED DEPRECATED DEPRECATED DEPRECATED DEPRECATED
+#
+# This program is scheduled to be replaced as soon as possible. Details
+# of the plan are in https://github.com/Raku/doc/issues/2983
+#
+# If you _must_ scratch an itch with a quick fix here, it's okay to
+# submit a pull request. But any real development should be done in the
+# new repository.
+#
+# DEPRECATED DEPRECATED DEPRECATED DEPRECATED DEPRECATED DEPRECATED
+
+
 use v6;
 use JSON::Fast;
 use File::Find;


### PR DESCRIPTION
Hopefully this will help people find the right place to apply their
efforts. And prevent JJ from having to link to #2983 in more new PRs.

Examples of the need include #3196, #3202, #3422