### PR TITLE
Language/variables: Stronger warning about pre-compiled constants

### DIFF
--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -974,7 +974,9 @@ constant $pi2 = pi * 2;
 $pi2 = 6; # OUTPUT: «(exit code 1) Cannot assign to an immutable value␤
 =end code
 
-The value is assigned at compile time. Please check
+The value is assigned at compile time. Since Raku modules are L<pre-compiled
+automatically|/language/compilation>, constants defined in modules are not
+re-evaluated when the program is run. Please check
 L<the section on constants in the Terms page|/language/terms#Constants> for
 additional information.
 


### PR DESCRIPTION
## The problem

It's easy to put `constant $foo = changes-at-runtime()` in a module, not realizing that it will be precompiled on the first run. The previous warning here was too milquetoast and easy to gloss over.