### PR TITLE
show that roles are objects

### DIFF
--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -629,6 +629,20 @@ Default parameters can be provided.
     my $i = 1 does R;
     CATCH { default { say .^name, ': ', .Str} }
     # OUTPUT: «X::AdHoc: Could not instantiate role 'R':␤Please provide a parameter to role R␤»
+    
+Roles can be stored in a scalar and so can parameterized roles. Specializing them does not work 
+in this case because the compiler assumes an array subscript.
+
+    my $R = role :: { has $.some-text = 'a default text' };
+    my $i = 42 but $R;
+    say $i.some-text;
+    # OUTPUT: «a default text␤»
+    
+    my $F = role :: [$t] { has $.text = $t }
+    my $j = 42 but $F['does not work'];
+    # OUTPUT: «Could not instantiate role '<anon|1>':␤Too few positionals passed; expected 2 arguments but got 1␤»
+    
+Using parameterized roles as objects and specializing them via the L<MOP|/language/mop> is considered an implementation detail.
 
 =head3 As type constraints
 


### PR DESCRIPTION
And note the gotcha with parameterized roles as objects.

Discussion: https://colabti.org/irclogger/irclogger_log/raku-dev?date=2020-06-18#l384
