### PR TITLE
Document Proc.Bool method

### DIFF
--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -192,6 +192,13 @@ The command method is an accessor to a list containing the arguments
 that were passed when the Proc object was executed via C<spawn> or
 C<shell> or C<run>.
 
+=head2 method Bool
+
+    multi method Bool(Proc:D:)
+
+Awaits for the process to finish and returns C<True> if both exit code and signal
+of the process were 0, indicating a successful process termination. Returns C<False> otherwise.
+
 =head2 method pid
 
     method pid()


### PR DESCRIPTION
Proc::Async does not override Bool, so closes https://github.com/Raku/doc/issues/3397

## The problem

No docs for the method.

## Solution provided

Document it.