### PR TITLE
Fix index syntax of pointy block

### DIFF
--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -100,7 +100,7 @@ Or even
     say { $^a ** 2 + $^b ** 2 }(3, 4)            # OUTPUT: «25␤»
 
 X<|pointy blocks>
-=head2 X«Blocks and lambdas|syntax,->»
+=head2 X«Blocks and lambdas|->,syntax»
 
 Whenever you see something like C«{ $_ + 42 }», C«-> $a, $b { $a ** $b }», or
 C«{ $^text.indent($:spaces) }», that's L<Block|/type/Block> syntax; the C«->» is


### PR DESCRIPTION
Previously, the search term and category were reversed, which
created resulted in a buggy results displayed to the user on search.
Use the correct order.

Can we try if it helps with https://github.com/Raku/doc/issues/3190 ?