### PR TITLE
Fix indexing of proceed/succeed

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -855,8 +855,7 @@ be in the same "switch" just so long as you do not open a new block:
 C<when> statements can smartmatch
 against L<Signatures|/language/syntax#Signature_literals>.
 
-=head2 X<proceed|control flow, proceed>
-=head2 X<succeed|control flow, succeed>
+=head2 X<proceed|control flow, proceed> and X<succeed|control flow, succeed>
 
 Both C<proceed> and C<succeed> are meant to be used only from inside C<when>
 or C<default> blocks.


### PR DESCRIPTION
Previously, there were two separate headers for proceed and succeed,
and likely meant to be read as "header + header + content".
ALas, on content pages used to display search results, a single pair of "header + content"
is delivered, and it is actually read as "header + nothing + header + content".
To avoid an empty page for the first header, just merge those two into a single one.

Fixes https://github.com/Raku/doc/issues/3167
