### PR TITLE
Correct associativity for infix:<Z>

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -3020,7 +3020,7 @@ other positions, it's a syntax error.
 
 =head2 infix C«Z»
 
-    sub infix:<Z>(**@lists --> Seq:D) is assoc<chain>
+    sub infix:<Z>(**@lists --> Seq:D) is assoc<list>
 
 The X<Zip operator> interleaves the lists passed to C<Z> like a zipper,
 taking index-corresponding elements from each operand. The returned C<Seq>


### PR DESCRIPTION

## The problem

The docs currently list the associativity for the `infix:<Z>` operator as `assoc<chain>`, but it's actual associativity is `assoc<list>`.  `Z` has list associativity because `$a Z $b Z $c == infix:<Z>($a, $b, $c)`.  It does not have chain associativity: `($a Z $b Z $c) ≠ ($a Z $b) and ($b Z $c)`.

## Solution provided

This PR  corrects the associativity for the `infix:<Z>` operator from `assoc<chain>` to `assoc<list>`.  The chart at the top of the page already correctly indicated that `Z` has list associativity and thus does not need to be updated.


<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
