### PR TITLE
Tweak names of two variables

### DIFF
--- a/doc/Language/contexts.pod6
+++ b/doc/Language/contexts.pod6
@@ -66,9 +66,9 @@ I<Number context> is called whenever we need to apply a numerical operation on a
 variable.
 
 =begin code
-my $not-a-string = "1                 ";
-my $neither-a-string = "3                        ";
-say $not-a-string + $neither-a-string; # OUTPUT: «4␤»
+my $stringone = "1                 ";
+my $stringthree = "3                        ";
+say $stringone + $stringthree; # OUTPUT: «4␤»
 =end code
 
 In the code above, strings will be interpreted in numeric context as long as


### PR DESCRIPTION
## The problem
I was confused with the original names. Also, the text after the code example talks about strings being interpreted in numeric context, so ```$not-a-string``` looks off.

## Solution provided
I guess the new names match the original author's intention.