### PR TITLE
Remove false "shorthand"

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1817,16 +1817,17 @@ However, it mostly ignores the left argument, and operates on the next
 two atoms (which may be quantified). Its operation on those next two
 atoms is to "twiddle" them so that they are actually matched in
 reverse order. Hence the expression above, at first blush, is merely
-shorthand for:
+another way of writing:
 
     / '(' <expression> ')' /
 
-But beyond that, when it rewrites the atoms it also inserts the
-apparatus that will set up the inner expression to recognize the
-terminator, and to produce an appropriate error message if the inner
-expression does not terminate on the required closing atom. So it
-really does pay attention to the left delimiter as well, and it actually
-rewrites our example to something more like:
+Using C<~> keeps the separators closer together but beyond that,
+when it rewrites the atoms it also inserts the apparatus that will
+set up the inner expression to recognize the terminator, and to
+produce an appropriate error message if the inner expression does
+not terminate on the required closing atom. So it really does pay
+attention to the left delimiter as well, and it actually rewrites
+our example to something more like:
 
 X<|SETGOAL>
     =begin code :skip-test<incomplete code>


### PR DESCRIPTION
## The problem

The code referred to as a "shorthand" is in fact longer in bytes and in the number of regex atoms involved.

## Solution provided

The "shorthand" formulation is removed and another quality of the `~` operator is mentioned as a substitute, then the paragraph is reflowed.