### PR TITLE
Capitalise the word "Boolean"

### DIFF
--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -322,7 +322,7 @@ X<| close - perlfunc>
 
 =item close FILEHANDLE
 
-As in Perl, closes a filehandle. Returns a boolean value. Both C<close
+As in Perl, closes a filehandle. Returns a Boolean value. Both C<close
 $fh> and C<$fh.close> will work.
 
 Note that C<close()> (without arguments) is not supported in Raku.

--- a/doc/Language/5to6-perlop.pod6
+++ b/doc/Language/5to6-perlop.pod6
@@ -377,13 +377,13 @@ C<Nil while foo();> instead.
 
 Documented individually above, but to summarize...
 
-Bitwise integer negation is prefix C<+^>. Bitwise boolean
+Bitwise integer negation is prefix C<+^>. Bitwise Boolean
 negation is C<?^>.
 
 Bitwise and is C<+&>.
 
 Bitwise integer or is C<+|>. Bitwise integer xor is infix C<+^>. Bitwise
-boolean or is C<?|>.
+Boolean or is C<?|>.
 
 Left shift and right shift are C<< +< >> and C<< +> >>.
 

--- a/doc/Language/concurrency.pod6
+++ b/doc/Language/concurrency.pod6
@@ -550,7 +550,7 @@ channel must be checked to determine whether it is closed:
     # Doing some unrelated things...
 
 The L<method closed|/type/Channel#method_closed> returns a L<Promise|/type/Promise> that
-will be kept (and consequently will evaluate to True in a boolean context)
+will be kept (and consequently will evaluate to True in a Boolean context)
 when the channel is closed.
 
 The C<.poll> method can be used in combination with C<.receive> method, as a

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -452,11 +452,11 @@ C<if> or C<when> blocks:
 
 =begin code
 {
-    if X {...} # if X is true in boolean context, block is executed
+    if X {...} # if X is true in Boolean context, block is executed
     # following statements are executed regardless
 }
 {
-    when X {...} # if X is true in boolean context, block is executed
+    when X {...} # if X is true in Boolean context, block is executed
                  # and control passes to the outer block
     # following statements are NOT executed
 }
@@ -466,7 +466,7 @@ Should the C<if> and C<when> blocks above appear at file scope, following
 statements would be executed in each case.
 
 There is one other feature C<when> has that C<if> doesn't: the C<when>'s
-boolean context test defaults to C<$_ ~~> while the C<if>'s does not. That has
+Boolean context test defaults to C<$_ ~~> while the C<if>'s does not. That has
 an effect on how one uses the X in the C<when> block without a value for C<$_>
 (it's C<Any> in that case and C<Any> smartmatches on C<True>: C<Any ~~ True>
 yields C<True>). Consider the following:

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -205,8 +205,8 @@ resulting in a junction C<False|True|False>. This process of separating
 junction arguments into multiple calls to a function is called
 I<autothreading>.
 
-If you use the resulting junction in a boolean context, such as with an
-C<if>, it collapses into a single boolean which is C<True> if any of the
+If you use the resulting junction in a Boolean context, such as with an
+C<if>, it collapses into a single Boolean which is C<True> if any of the
 values in the junction are True.
 
 =for code :preamble<sub f {};>
@@ -366,7 +366,7 @@ and the more descriptive name helps recall its purpose better.
 X<|iffy>
 =head1 iffy
 
-Often used as a boolean value. See L<operator|#Operator>. Made via
+Often used as a Boolean value. See L<operator|#Operator>. Made via
 the L<C<use> keyword|/language/modules#index-entry-use>.
 
 X<|import>
@@ -1124,7 +1124,7 @@ with the looser operator. Operators with
 L<tight precedence|/language/operators#Tight_AND_precedence>
 are grouped with priority to others and are generally tighter than most
 others; loose
-L<exactly the opposite|/language/traps#Loose_boolean_operators>,
+L<exactly the opposite|/language/traps#Loose_Boolean_operators>,
 so it is always convenient to be aware of the exact precedence of all
 operators used in an expression.
 

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1122,7 +1122,7 @@ Note that this collapses L<Junction|/type/Junction>s.
 
     multi sub prefix:<!>(Mu --> Bool:D)
 
-X<Negated boolean context operator>.
+X<Negated Boolean context operator>.
 
 Coerces the argument to L<Bool|/type/Bool> by calling the C<Bool> method on it,
 and returns the negation of the result.
@@ -2384,7 +2384,7 @@ for the type on the right-hand side of the operator.
     Str                 string equality
     Numeric             numeric equality
     Regex               regex match
-    Callable            boolean result of invocation
+    Callable            Boolean result of invocation
     Set/Bag             equal element values
     Any:D               object identity
 
@@ -2643,7 +2643,7 @@ C«⊉» is codepoint U+2289 (NEITHER A SUPERSET OF OR EQUAL TO).
 
 =head2 infix C«&&»
 
-Returns the first argument that evaluates to C<False> in boolean context,
+Returns the first argument that evaluates to C<False> in Boolean context,
 otherwise returns the last argument.
 
 Note that this short-circuits, i.e. if one of the arguments evaluates to a
@@ -2658,7 +2658,7 @@ false value, the arguments to the right are never evaluated.
 
 =head2 infix C«||»
 
-Returns the first argument that evaluates to C<True> in boolean context,
+Returns the first argument that evaluates to C<True> in Boolean context,
 otherwise returns the last argument.
 
 Note that this short-circuits; i.e., if one of the arguments evaluates to a
@@ -2685,7 +2685,7 @@ any arguments after a 2nd true result.
 Note that the semantics of this operator may not be what you assume: infix C«^^»
 flips to the first true value it finds and then flips to Nil I<forever> after the
 second, no matter how many more true values there are. (In other words, it has
-"find the one true value" semantics, not "boolean parity" semantics.)
+"find the one true value" semantics, not "Boolean parity" semantics.)
 
 =head2 infix C«//»
 
@@ -2973,16 +2973,16 @@ create C<Pair> objects.
 
     multi sub prefix:<not>(Mu $x --> Bool:D)
 
-Evaluates its argument in boolean context (and thus collapses L<Junction|/type/Junction>s),
+Evaluates its argument in Boolean context (and thus collapses L<Junction|/type/Junction>s),
 and negates the result. Please note that C<not> is easy to misuse. See
-L<traps|/language/traps#Loose_boolean_operators>.
+L<traps|/language/traps#Loose_Boolean_operators>.
 
 
 =head2 prefix C«so»
 
     multi sub prefix:<so>(Mu $x --> Bool:D)
 
-Evaluates its argument in boolean context (and thus collapses
+Evaluates its argument in Boolean context (and thus collapses
 L<Junction|/type/Junction>s), and returns the result.
 
 =head1 Comma operator precedence
@@ -3280,7 +3280,7 @@ precedence.
 
 Short-circuits so that it returns the first operand that evaluates to
 C<False>, otherwise returns the last operand. Note that C<and> is easy
-to misuse, see L<traps|/language/traps#Loose_boolean_operators>.
+to misuse, see L<traps|/language/traps#Loose_Boolean_operators>.
 
 =head2 infix X<C«andthen»>
 
@@ -3373,9 +3373,9 @@ good-things() notandthen 'boo'.say;
 
 Same as L<infix C<||>|/routine/||>, except with looser precedence.
 
-Returns the first argument that evaluates to C<True> in boolean context, or
+Returns the first argument that evaluates to C<True> in Boolean context, or
 otherwise the last argument, it short-circuits. Please note that C<or> is easy
-to misuse. See L<traps|/language/traps#Loose_boolean_operators>.
+to misuse. See L<traps|/language/traps#Loose_Boolean_operators>.
 
 X<|orelse>
 =head2 infix C«orelse»
@@ -3413,8 +3413,8 @@ and L<Failure|/type/Failure> never is:
 
 Same as L<infix C<^^>|/routine/$CIRCUMFLEX_ACCENT$CIRCUMFLEX_ACCENT>, except with looser precedence.
 
-Returns the operand that evaluates to C<True> in boolean context, if and
-only if the other operand evaluates to C<False> in boolean context. If
+Returns the operand that evaluates to C<True> in Boolean context, if and
+only if the other operand evaluates to C<False> in Boolean context. If
 both operands evaluate to C<False>, returns the last argument. If both
 operands evaluate to C<True>, returns C<Nil>.
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -237,7 +237,7 @@ and C</ /> syntax:
 =end item
 
 =begin item
-I«Implicit topic match in sink and boolean contexts»
+I«Implicit topic match in sink and Boolean contexts»
 
 In case a C<Regex> object is used in sink context, or in a context in which it
 is coerced to L<C<Bool>|/type/Bool>, the topic variable
@@ -249,7 +249,7 @@ against it:
   rx/ s.* /;                  # Regex object in sink context matches automatically
   say $/;                     # OUTPUT: «｢string｣␤»
 
-  say $/ if rx/ d.* /;        # Regex object in boolean context matches automatically
+  say $/ if rx/ d.* /;        # Regex object in Boolean context matches automatically
                               # OUTPUT: «｢dummy string｣␤»
 =end item
 
@@ -2020,7 +2020,7 @@ emerges as the return value of the C<flip> method call. Since general Raku
 code may be run from within the parentheses of C<$( )>, the same effect can
 also be achieved with a bit more effort, like in statement C<[9]>. Statement
 C<[10]> illustrates how the stringified version of the code's return value (the
-boolean value C<False>) is matched literally.
+Boolean value C<False>) is matched literally.
 
 Finally, statements C<[11]> and C<[12]> show how the value of C<$pattern4> and
 the return value of C<f1> are I<not> subject to a further round of
@@ -2086,12 +2086,12 @@ C<@(code)>. In this example, both regexes are equivalent:
 
 The use of hashes in regexes is reserved.
 
-=head2 Regex boolean condition check
+=head2 Regex Boolean condition check
 
 X«|regex, <?{}>;regex, <!{}>»
-The special operator C«<?{}>» allows the evaluation of a boolean expression that
+The special operator C«<?{}>» allows the evaluation of a Boolean expression that
 can perform a semantic evaluation of the match before the regular expression
-continues. In other words, it is possible to check in a boolean context a part
+continues. In other words, it is possible to check in a Boolean context a part
 of a regular expression and therefore invalidate the whole match (or allow it to
 continue) even if the match succeeds from a syntactic point of view.
 
@@ -2135,7 +2135,7 @@ say $/<ipv4-octet>;   # OUTPUT: «[｢127｣ ｢0｣ ｢0｣ ｢1｣]␤»
 =end code
 
 Please note that it is not required to evaluate the regular expression in-line,
-but also a regular method can be called to get the boolean value:
+but also a regular method can be called to get the Boolean value:
 
 =begin code
 my $localhost = '127.0.0.1';
@@ -2145,7 +2145,7 @@ $localhost ~~ / ^ <ipv4-octet> ** 4 % "." $ /;
 say $/<ipv4-octet>;   # OUTPUT: «[｢127｣ ｢0｣ ｢0｣ ｢1｣]␤»
 =end code
 
-Of course, being C«<!{}>» the negation form of C«<?{}>» the same boolean
+Of course, being C«<!{}>» the negation form of C«<?{}>» the same Boolean
 evaluation can be rewritten in a negated form:
 
 =begin code

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -797,7 +797,7 @@ for other, more common, things:
 
 The C<^>, C<|>, and C<&> are I<not> bitwise operators, they create
 L<Junctions|/type/Junction>. The corresponding bitwise operators in Raku are:
-C<+^>, C<+|>, C<+&> for integers and C<?^>, C<?|>, C<?&> for booleans.
+C<+^>, C<+|>, C<+&> for integers and C<?^>, C<?|>, C<?&> for Booleans.
 
 =head2 Exclusive sequence operator
 
@@ -1071,7 +1071,7 @@ The loose precedence of C<..> can lead to some errors.  It is usually best to pa
 1..3.say;    # OUTPUT: «3␤» (and warns about useless use of "..")
 (1..3).say;  # OUTPUT: «1..3␤»
 
-=head2 Loose boolean operators
+=head2 Loose Boolean operators
 
 The precedence of C<and>, C<or>, etc. is looser than routine calls. This can
 have surprising results for calls to routines that would be operators or

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -287,7 +287,7 @@ The dynamic variables differ from other variable types in that referring
 to an undeclared dynamic variable is not a compile time error but a
 runtime L<failure|/type/Failure>, so a dynamic variable can be used
 undeclared as long as it's checked for definedness or used in a
-boolean context before using it for anything else:
+Boolean context before using it for anything else:
 
 =begin code
 sub foo() {

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -130,7 +130,7 @@ Defined as:
 
 By default, this trait allows setting up a I«private attribute» during object
 construction via C«.new». The same trait can be used to prevent setting up a
-I«public attribute» via C«.new» by passing it the boolean value C«False».
+I«public attribute» via C«.new» by passing it the Boolean value C«False».
 
     class Foo {
         has $!bar is built; # same as `is built(True)`

--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -2,14 +2,14 @@
 
 =TITLE enum Bool
 
-=SUBTITLE Logical boolean
+=SUBTITLE Logical Boolean
 
     enum Bool <False True>
 
 X<|True>
 X<|False>
 X<|Boolean>
-An enum for boolean true/false decisions.
+An enum for Boolean true/false decisions.
 
 =head1 Methods
 

--- a/doc/Type/Cancellation.pod6
+++ b/doc/Type/Cancellation.pod6
@@ -10,7 +10,7 @@ A low level part of the Raku L<concurrency|/language/concurrency#Schedulers>
 system. Some L<Scheduler|/type/Scheduler> objects return a C<Cancellation> with the
 L<.cue|/type/Scheduler#method_cue> method which can be used to cancel the
 scheduled execution before normal completion.  C<Cancellation.cancelled> is a
-boolean that is true after L<#cancel> is called.
+Boolean that is true after L<#cancel> is called.
 
 =head1 Methods
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -441,7 +441,7 @@ use a block:
 
     say <a b c d e f>.grep({! /<[aeiou]>/})     # OUTPUT: «(b c d f)␤»
 
-The reason the example above works is because a regex in boolean context applies
+The reason the example above works is because a regex in Boolean context applies
 itself to C<$_>. In this case, C<!> boolifies the C«/<[aeiou]>/» regex and
 negates the result. Smartmatching against a L<Callable|/type/Callable> (in this
 case a L<Block|/type/Block>) returns the value returned from that callable, so

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -630,7 +630,7 @@ Returns the given item to the enclosing C<gather> block, without introducing a n
 
     method so()
 
-Evaluates the item in boolean context (and thus, for instance, collapses Junctions),
+Evaluates the item in Boolean context (and thus, for instance, collapses Junctions),
 and returns the result.
 It is the opposite of C<not>, and equivalent to the
 L«C<?> operator|/language/operators#prefix_?».
@@ -654,7 +654,7 @@ result will be C<True>. C<so> is performing all those operations under the hood.
 
     method not()
 
-Evaluates the item in boolean context (leading to final evaluation of Junctions, for instance),
+Evaluates the item in Boolean context (leading to final evaluation of Junctions, for instance),
 and negates the result.
 It is the opposite of C<so> and its behavior is equivalent to the
 L«C<!> operator|/language/operators#prefix_!».

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -152,8 +152,8 @@ be different:
     say :10z ~~ :42a; # OUTPUT: «False␤»
 
 If C<$topic> is any other value, the invocant C<Pair>'s key is treated as a method name.
-This method is called on C<$topic>, the L«boolean|/routine/Bool» result of which is compared
-against the invocant C<Pair>'s L«boolean|/routine/Bool» value. For example, primality can
+This method is called on C<$topic>, the L«Boolean|/routine/Bool» result of which is compared
+against the invocant C<Pair>'s L«Boolean|/routine/Bool» value. For example, primality can
 be tested using smartmatch:
 
     say 3 ~~ :is-prime;             # OUTPUT: «True␤»

--- a/doc/Type/Regex.pod6
+++ b/doc/Type/Regex.pod6
@@ -9,7 +9,7 @@
 A regex is a kind of pattern that describes a set of strings. The process of
 finding out whether a given string is in the set is called I<matching>. The
 result of such a matching is a L<Match|/type/Match> object, which evaluates to C<True> in
-boolean context if the string is in the set.
+Boolean context if the string is in the set.
 
 A regex is typically constructed by a regex literal
 
@@ -33,7 +33,7 @@ To match a string against a regex, you can use the smartmatch operator:
     say $match.from;                # OUTPUT: «0␤»
     say $match.to;                  # OUTPUT: «2␤»
 
-Or you can evaluate the regex in boolean context, in which case it matches
+Or you can evaluate the regex in Boolean context, in which case it matches
 against the C<$_> variable
 
     $_ = 'abc';


### PR DESCRIPTION
... since it comes from a person's name.  This should address issue #3517; although I'm not 100% sure if I've satisfied the requirements of @coke's comment about linking to the Bool enum, as I didn't find (what I thought) were references to the Raku Boolean type, however I might have misread the docs in those places.