### PR TITLE
Link to Bool types

### DIFF
--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -797,7 +797,8 @@ for other, more common, things:
 
 The C<^>, C<|>, and C<&> are I<not> bitwise operators, they create
 L<Junctions|/type/Junction>. The corresponding bitwise operators in Raku are:
-C<+^>, C<+|>, C<+&> for integers and C<?^>, C<?|>, C<?&> for Booleans.
+C<+^>, C<+|>, C<+&> for integers and C<?^>, C<?|>, C<?&> for
+L<Bools|/type/Bool>.
 
 =head2 Exclusive sequence operator
 

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -152,8 +152,8 @@ be different:
     say :10z ~~ :42a; # OUTPUT: «False␤»
 
 If C<$topic> is any other value, the invocant C<Pair>'s key is treated as a method name.
-This method is called on C<$topic>, the L«Boolean|/routine/Bool» result of which is compared
-against the invocant C<Pair>'s L«Boolean|/routine/Bool» value. For example, primality can
+This method is called on C<$topic>, the L«Bool|/type/Bool» result of which is compared
+against the invocant C<Pair>'s L«Bool|/type/Bool» value. For example, primality can
 be tested using smartmatch:
 
     say 3 ~~ :is-prime;             # OUTPUT: «True␤»


### PR DESCRIPTION
@JJ mentioned in #3542 two locations where it would be more appropriate
to refer to the Bool type as opposed to Booleans.  This commit addresses
this issue and helps address #3517.