### PR TITLE
Add `update-html` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ help:
 html: for-documentable
 	documentable start -a -v --highlight
 
+update-html:
+	documentable update
+
 init-highlights highlights/package-lock.json:
 	ATOMDIR="./highlights/atom-language-perl6";  \
 	if [ -d "$$ATOMDIR" ]; then (cd "$$ATOMDIR" && git pull); \

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ to add to the configuration to make it work:
     location / {
         try_files $uri $uri/ $uri.html /404.html;
     }
-
 ```
 
 This will rewrite the URLs for you. Equivalent configuration might have to be

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ and start building process:
 You need to do this only the first time to build the cache. When there's some
 change in the source (done by yourself or pulled from the repo),
 
-    documentable update
+    make update-html
 
 will re-generate only affected pages.
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ and start building process:
 
     git clone https://github.com/Raku/doc.git # clone the repo
     cd doc # move to the clone of the repo
-    make for-documentable # Generates CSS and JS, installs highlighting modules
-    documentable start -a -v --highlight # Builds cache and generates pages.
+    # Generate CSS and JS, install highlighting modules, build cache and pages
+    make html
 
 You need to do this only the first time to build the cache. When there's some
 change in the source (done by yourself or pulled from the repo),


### PR DESCRIPTION
This target name is easier to remember than the `documentable update` command as it uses the make infrastructure which is already present.  It also uses the same general interface to the various build processes provided by make (i.e. one can use `make <target>` as opposed to having to remember what command is necessary to perform a particular operation).  Also, this wraps the `update` process behind an interface; the details of which can be changed in the future without changing the interface.

I've also updated the README to mention the new target name.

Also, and somewhat unrelated to the above changes, I've simplified the docs in the README for HTML generation as well as have removed superfluous vertical whitespace.  These changes have been put into separate commits so that they can be cherry picked as desired.

This PR is submitted in the hope that it is useful.  If any changes are required I'll happily update the PR and resubmit as necessary.