### PR TITLE
Add short description for a NativeCall helper

### DIFF
--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -47,6 +47,15 @@ Please check the
 L<section on the ABI/API version|/language/nativecall#ABI/API_version> for
 more information.
 
+=head2 NativeCall helper module
+
+A non-core Raku module with the unusual name of B<App::GPTrixie> has a
+Raku program, C<gptrixie>, to establish a starting code framework when
+initiating a new NativeCall project.  It describes itself as I<A tool
+to generate NativeCall code from C headers> and its Github repository
+is L<here|https://github.com/Skarsnik/gptrixie>. For now it is only for the I<C>
+language but I<C++> support is planned.
+
 =head1 Changing names
 
 Sometimes you want the name of your Raku subroutine to be different from the

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -49,7 +49,7 @@ more information.
 
 =head2 NativeCall helper module
 
-A non-core Raku module with the unusual name of B<App::GPTrixie> has a
+A non-core Raku module, B<App::GPTrixie>, has a
 Raku program, C<gptrixie>, to establish a starting code framework when
 initiating a new NativeCall project.  It describes itself as I<A tool
 to generate NativeCall code from C headers> and its Github repository


### PR DESCRIPTION
## The problem

Because of its name, the subject module is hard to find. Additionally, with its link shown early on in the very lengthy NativeCall description, it could encourage more authors to contribute Raku wrappers for their favorite libraries since they could get help starting with framework code.

## Solution provided

Short descrription and a link to the parent repo.
