### PR TITLE
Rework List.join examples and description

### DIFF
--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -278,28 +278,26 @@ Defined as:
 
 Treats the elements of the list as strings by calling
 L<C<.Str>|/type/Any#routine_Str> on each of them, interleaves them with
-C<$separator> and concatenates everything into a single string. Note that you
-can omit the C<$separator> if you use the method syntax.
+C<$separator> and concatenates everything into a single string.
 
 Example:
 
     join ', ', <a b c>;             # OUTPUT: «a, b, c»
 
-Note that the method form does not flatten sublists:
-
-    say (1, <a b c>).join('|');     # OUTPUT: «1|a b c␤»
-
 The method form also allows you to omit the separator:
 
     say <a b c>.join;               # OUTPUT: «abc␤»
 
-But it behaves slurpily, flattening all arguments after the first into a single
-list:
+Note that the method form does not flatten sublists:
 
-    say join('|', 3, 'þ', 1+4i);    # OUTPUT: «3|þ|1+4i␤»
-    say join ', ', <a b c>, 'd', 'e' , 'f'; # OUTPUT: «a, b, c, d, e, f␤»
+    say (1, <a b c>).join('|');     # OUTPUT: «1|a b c␤»
 
-In this case, the first list C«<a b c» is I<slurped> and flattened, unlike what
+The subroutine form behaves slurpily, flattening all arguments after
+the first into a single list:
+
+    say join '|', 1, <a b c>;       # OUTPUT: «1|a|b|c␤»
+
+In this case, the list C«<a b c>» is I<slurped> and flattened, unlike what
 happens when C<join> is invoked as a method.
 
 If one of the elements of the list happens to be a C<Junction>, then C<join>


### PR DESCRIPTION
- Remove duplicate note about the optional separator for the method form
- It's the subroutine form that is slurpy and flattening
- Group related examples
- Correct a typo
