### PR TITLE
Overhaul the list-missing-methods.p6 script

### DIFF
--- a/util/ignored-methods.txt
+++ b/util/ignored-methods.txt
@@ -1,9 +1,15 @@
-# This file is loaded by `list-missing-methods.p6` (unless a different file is # specified a CLI
-# option).  It list methods that should *not* be listed as 'missing' from the docs.  It is read as a
-# standard Raku hash, so you can use any valid Raku syntax.  When adding items to this list, please
-# do your best to add a line-comment explaining why that method should not be counted as 'missing'.
-%( Any =>     ( 'lazy-if'),
-   Hash =>    ( 'categorize-list',
+# This file is loaded by `list-missing-methods.p6` (unless a different file is specified
+# as a CLI option).  It list methods that should *not* be listed as 'undocumented'.  It is
+# read as a standard Raku hash, so you can use any valid Raku syntax.  Each key should be
+# either 1) a Type name, or the special key `GLOBAL`; each value should be a list of
+# methods that don't need to be checked for that Type.  The list for the `GLOBAL` key
+# applies to all Types.  When adding items to this list, please do your best to add a
+# line-comment explaining why that method should not be checked.
+
+%( GLOBAL  => ( 'BUILDALL',            # Implementation detail listed as local in 100+ types
+              ),
+   Any     => ( 'lazy-if', ),
+   Hash    => ( 'categorize-list',
                 'dynamic',
                 'name', 
                 'BIND-KEY',
@@ -11,13 +17,13 @@
                 'clone', ),
    Dateish => ( 'IO',
                 'earlier'),
-   Str =>     ( 'codes',
+   Str     => ( 'codes',
                 'simplematch',
                 'BUILD',
                 'Int',
                 'Num',
                 'word-by-word', ),
-   Array =>   ( 'dynamic',
+   Array   => ( 'dynamic',
                 'STORE',
                 'default',
                 'name',

--- a/util/ignored-methods.txt
+++ b/util/ignored-methods.txt
@@ -28,5 +28,6 @@
                 'default',
                 'name',
                 'from-iterator',
-                'reification-target',)
+                'reification-target',),
+   Regex   => ( 'clone', 'gist', 'raku' )
 )

--- a/util/ignored-methods.txt
+++ b/util/ignored-methods.txt
@@ -1,6 +1,26 @@
-# This file can have comments.
-Any: lazy-if
-Hash: categorize-list dynamic name BIND-KEY classify-list clone
-Dateish: IO earlier
-Str: codes simplematch BUILD Int Num word-by-word
-Array: dynamic STORE default name from-iterator reification-target
+# This file is loaded by `list-missing-methods.p6` (unless a different file is # specified a CLI
+# option).  It list methods that should *not* be listed as 'missing' from the docs.  It is read as a
+# standard Raku hash, so you can use any valid Raku syntax.  When adding items to this list, please
+# do your best to add a line-comment explaining why that method should not be counted as 'missing'.
+%( Any =>     ( 'lazy-if'),
+   Hash =>    ( 'categorize-list',
+                'dynamic',
+                'name', 
+                'BIND-KEY',
+                'classify-list',
+                'clone', ),
+   Dateish => ( 'IO',
+                'earlier'),
+   Str =>     ( 'codes',
+                'simplematch',
+                'BUILD',
+                'Int',
+                'Num',
+                'word-by-word', ),
+   Array =>   ( 'dynamic',
+                'STORE',
+                'default',
+                'name',
+                'from-iterator',
+                'reification-target',)
+)

--- a/util/ignored-methods.txt
+++ b/util/ignored-methods.txt
@@ -1,33 +1,32 @@
 # This file is loaded by `list-missing-methods.p6` (unless a different file is specified
 # as a CLI option).  It list methods that should *not* be listed as 'undocumented'.  It is
 # read as a standard Raku hash, so you can use any valid Raku syntax.  Each key should be
-# either 1) a Type name, or the special key `GLOBAL`; each value should be a list of
-# methods that don't need to be checked for that Type.  The list for the `GLOBAL` key
+# either 1) a Type name, or the special key `ALL_TYPES`; each value should be a list of
+# methods that don't need to be checked for that Type.  The list for the `ALL_TYPES` key
 # applies to all Types.  When adding items to this list, please do your best to add a
 # line-comment explaining why that method should not be checked.
 
-%( GLOBAL  => ( 'BUILDALL',            # Implementation detail listed as local in 100+ types
-              ),
-   Any     => ( 'lazy-if', ),
-   Hash    => ( 'categorize-list',
-                'dynamic',
-                'name', 
-                'BIND-KEY',
-                'classify-list',
-                'clone', ),
-   Dateish => ( 'IO',
-                'earlier'),
-   Str     => ( 'codes',
-                'simplematch',
-                'BUILD',
-                'Int',
-                'Num',
-                'word-by-word', ),
-   Array   => ( 'dynamic',
-                'STORE',
-                'default',
-                'name',
-                'from-iterator',
-                'reification-target',),
-   Regex   => ( 'clone', 'gist', 'raku' )
+%( ALL_TYPES  => ( 'BUILDALL',            # Implementation detail listed as local in 100+ types
+                  ),
+   Any        => ( 'lazy-if', ),
+   Hash       => ( 'categorize-list',
+                   'dynamic',
+                   'name',
+                   'BIND-KEY',
+                   'classify-list',
+                   'clone', ),
+   Dateish    => ( 'IO',
+                   'earlier'),
+   Str        => ( 'codes',
+                   'simplematch',
+                   'BUILD',
+                   'Int',
+                   'Num',
+                   'word-by-word', ),
+   Array      => ( 'dynamic',
+                   'STORE',
+                   'default',
+                   'name',
+                   'from-iterator',
+                   'reification-target',),
 )

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -34,8 +34,7 @@ sub MAIN(
     my $output = $(process($src, EVALFILE($ignore), $exclude)).map( {
         when .<uncheckable>.so {
             %summary<totals><unchecked-types>++;
-            # TODO: Better '?'
-            "⍰ {.<type-name>} – documented at  ⟨{.<path>.IO}⟩\nSkipped as uncheckable\n";
+            "∅ {.<type-name>} – documented at  ⟨{.<path>.IO}⟩\nSkipped as uncheckable\n";
         }
        %summary.&insert-data($_);
 

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -16,21 +16,79 @@ grammar MethodDoc {
 #| Scan one or more pod6 files for undocumented methods
 sub MAIN(
     IO(Str) $source-path = './doc/Type/',   #= The file or directory to check (default: ./doc/Type)
-    Str :$exclude = ".git",                 #= Comma-seperated list of file extensions to ignore (default: .git)
-    :$ignore = './util/ignored-methods.txt' #= File listing methods to ignore (default ./util/ignored-methods.txt)
+    Str :$exclude = ".git",                 #= Comma-seperated list of files/directories to ignore (default: .git)
+    :$ignore = './util/ignored-methods.txt' #= Path to file with methods to ignore (default ./util/ignored-methods.txt)
 ) {
-    for process($source-path, EVALFILE($ignore), $exclude) { .say }
+    my %total is BagHash; my %missing-methods is BagHash; my %missing-methods-per-type is BagHash;
+    for $(process($source-path, EVALFILE($ignore), $exclude)) { my $a = $_;
+        when .<uncheckable>.so {
+            %total.add('uncheckable') for ^.<uncheckable>;
+            say "✗ {.<name>} – documented at  ⟨{.<path>.IO}⟩\n"
+            ~ "Skipped as uncheckable\n"; }
+
+        %total.add('errors') for ^+.<errors>;
+        %total.add('missing-header') for ^+.<missing-header>;
+        %missing-methods-per-type.add($a.<name>) for ^+.<missing-header>;
+        for .<missing-header>.keys { %missing-methods.add($_)};
+        %total.add('missing-signature') for ^+.<missing-signature>;
+
+        say (+.<errors> || +.<missing-header> || +.<missing-signature> ?? "✗ " !! "✔ ")
+        ~ "{.<name>} – documented at ⟨{.<path>.IO}⟩\n"
+        ~ ( if +.<errors> {
+                  "{+.<errors>} methods couldn't be checked:\n".indent(2)
+                  ~ .<errors>.join("\n").indent(4) ~ "\n" })
+        ~ ( if +.<missing-header> {
+                  "{+.<missing-header>} methods were missing:\n".indent(2)
+                  ~ .<missing-header>.keys.sort.join("\n").indent(4) ~ "\n" })
+        ~ ( if .<missing-signature> {
+                  "{+.<missing-signature>} methods lacked signatures:\n".indent(2)
+                  ~ .<missing-signature>.keys.sort.join("\n").indent(4) ~ "\n"});
+    };
+
+    say qq:to/EOF/;
+         Summary of missing types: 
+        ===========================
+         UNCHECKABLE types:   {%total<uncheckable>}
+         UNCHECKABLE methods: {%total<errors>}
+         MISSING methods:     {%total<missing-header>}
+         SIGNATURE errors:    {%total<missing-signature>}
+        EOF
+
+    my $top-missing = %missing-methods.grep(*.value ≥ 10).cache;
+
+    if $top-missing {
+       say " Methods missing from 10+ types: \n"
+          ~"=================================\n"
+          ~ $top-missing.sort(*.value).map({ sprintf(" %-*s    %d\n",
+                                                     $top-missing.&max-len, .key,
+                                                     .value)}).join
+          ~ sprintf("%s\n   %*s  %d\n\n",
+                    '-' x ($top-missing.&max-len + 8),
+                    $top-missing.&max-len, "TOTAL",
+                    $top-missing.map(*.value).sum) };
+
+    my $top-types = %missing-methods-per-type.sort(*.value).tail(10).cache;
+    say " Types with the most missing methods: \n"
+       ~"======================================\n"
+       ~ $top-types.map({ sprintf(" %-*s %-5d\n",
+                                  $top-types.max(*.key.chars).key.chars, .key,
+                                  .value)}).join;
+
+
 }
+
+
 multi process($path where {.IO ~~ :d}, %ignored, $exclude) {
-    flat (lazy $path.dir
+    |(lazy $path.dir
                ==> grep({ .basename ~~ none($exclude.split(',')».trim) })
                ==> map({ process($^next-path, %ignored, $exclude)}))
 }
 
-multi process($path, %ignored, $) {
+multi process($path, %ignored, $ --> Hash) {
     my $type-name = (S/.*'doc/Type/'(.*)'.pod6'/$0/).subst(:g, '/', '::') with $path;
-    when $type-name eq 'independent-routines' | 'Routine::WrapHandle' { #`(TODO) }
-    CATCH { default { return "✗ $type-name – documented at  ⟨{$path.IO}⟩\nSkipped as uncheckable\n" } }
+    when $type-name eq 'independent-routines' | 'Routine::WrapHandle' {
+        %( uncheckable => True, name => $type-name, path => $path )#`(TODO) }
+    CATCH { default { return %( uncheckable => True, name => $type-name, path => $path ) } }
     my @errors =[];
     my @real-methods = ::($type-name).^methods(:local).grep(-> $method {
         # Some builtins don't support the introspection we need (e.g., NQPRoutine)
@@ -41,12 +99,11 @@ multi process($path, %ignored, $) {
     my Set $missing-header      = @real-methods (-) %ignored{$type-name} (-) $in-header;
     my Set $missing-signature   = @real-methods (-) %ignored{$type-name} (-) $with-signature (-) $missing-header;
 
-    (+@errors || +$missing-header || +$missing-signature ?? "✗ " !! "✔ ")
-    ~ "{$type-name} – documented at ⟨{$path.IO}⟩\n"
-    ~ ( if +@errors {
-        "  {+@errors} methods couldn't be checked:\n    {@errors.join("\n    ")}\n" })
-    ~ ( if +$missing-header {
-        "  {+$missing-header} methods were missing:\n    {$missing-header.keys.sort.join("\n    ")}\n"})
-    ~ ( if $missing-signature {
-        "  {+$missing-signature} methods lacked signatures:\n    {$missing-signature.keys.sort.join("\n    ")}\n"})
+    %(errors => @errors,
+      missing-header => $missing-header,
+      missing-signature => $missing-signature,
+      path => $path,
+      name => $type-name)
 }
+
+sub max-len($pair-list --> Int) { $pair-list.max(*.key.chars).key.chars }

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -3,24 +3,137 @@ use v6;
 use Telemetry;
 use Test;
 
-grammar MethodDoc {
-    token TOP { [<in-header>  | <with-signature>]
-                { make ($<in-header><method>, $<with-signature><method>).map({ ~($_ // ()) }) } }
+class Summary {...}
+grammar MethodDoc {...}
 
-    token with-signature { <ws> ['multi' <ws>]? <keyword> <ws> <method> '(' .* }
-    token in-header      { '=head' \d? <ws> <keyword> <ws> <method> }
-    token keyword        { ['method' | 'routine'] }
-    token method         { <[-'\w]>+ }
+subset ReportCsv  of Str:D where *.split(',')».trim ⊆ <over under skip pass fail all none>;
+subset SummaryCsv of Str:D where *.split(',')».trim ⊆ <totals over under all none yes>;
+
+#| Scan a pod6 file or directory of pod6 files for over- and under-documented methods
+sub MAIN(
+    IO(Str) $input-path      = './doc/Type/',     #= Path to the file or directory to check
+    Str :e(:$exclude)        = ".git",            #= Comma-separated list of files/directories to ignore
+    ReportCsv :r(:$report)   = 'all',             #= Comma-separated list of documentation types to display
+    SummaryCsv :summary(:$s) = 'all',             #= Whether to display summary statistics
+    Bool :h(:$help),                              #= Display this message and exit
+    :i(:$ignore) = './util/ignored-methods.txt'   #= Path to file with methods to skip
+) {
+    when $help { USAGE }
+    my $report-items  = any(|$report.split(',')».trim);
+    my $summary-items = any(|$s.split(',')».trim);
+    my $summary = Summary.new;
+
+    for $input-path.&process-pod6($exclude, ignored-types => EVALFILE($ignore)).hyper.map(
+        -> $pod6 {
+        my (:$type-name, :$path, :%local-methods, :$uncheckable, :%uncheckable-methods, :%over-documented, :%under-documented) := $pod6;
+        when $uncheckable.so {
+            $summary.count-uncheckable-type;
+            (if $report-items ~~ ('all' | 'skip') {
+                    "\n∅ {$type-name} – documented at  ⟨{$path.IO}⟩\n  Skipped as uncheckable\n" });
+        }
+        $summary.update-totals(:%local-methods, :%uncheckable-methods, :%under-documented, :%over-documented);
+        $summary.update-over-documented(:%over-documented, :$type-name);
+        $summary.update-under-documented(:%under-documented, :$type-name);
+
+        my $status = (%uncheckable-methods ∪  |%under-documented.values ∪ |%over-documented.values
+                      ?? '✗'
+                      !! '✔');
+
+        (if (($report-items ~~ 'all' | 'pass')  && $status eq '✔')
+         || (($report-items ~~ 'all' | 'skip')  && ?%uncheckable-methods)
+         || (($report-items ~~ 'all' | 'under') && ?%under-documented.values)
+         || (($report-items ~~ 'all' | 'over')  && ?%over-documented.values) {
+          "\n$status {$type-name} – documented at ⟨{$path.IO}⟩\n"
+         })
+
+         ~ (if $report-items ~~ ('all' | 'skip') && ?$uncheckable  { fmt-report(:$uncheckable) })
+         ~ (if $report-items ~~ ('all' | 'under')                  { fmt-report(:%under-documented)})
+         ~ (if $report-items ~~ ('all' | 'over')                   { fmt-report(:%over-documented)});
+    }) { .print };
+
+    if $summary-items !~~ 'none'          { print $summary.fmt-header };
+    if $summary-items ~~ 'all' | 'totals' { print $summary.fmt-totals };
+    if $summary-items ~~ 'all' | 'under'  { print $summary.fmt-under-documented };
+    if $summary-items ~~ 'all' | 'over'   { print $summary.fmt-over-documented };
 }
 
-# TODO: Reorder subs
 
+#| Process a directory of Pod6 files by recursivly processing each file
+multi process-pod6($path where {.IO ~~ :d}, $exclude, :%ignored-types --> List) {
+    |(lazy $path.dir
+               ==> grep({ .basename ~~ none($exclude.split(',')».trim) })
+               ==> map({ |process-pod6($^next-path, $exclude, :%ignored-types )}))
+}
+
+class Pod6 {
+    has Str $.type-name;
+    has IO::Path $.path;
+    has Set $.local-methods;
+    has Bool $.uncheckable;
+    has Set $.uncheckable-methods;
+    has Map $.over-documented;
+    has Map $.under-documented;
+}
+
+#| Process a Pod6 file by parsing with the MethodDoc grammar and then comparing
+#| the documented methods against the methods visible via introspection
+multi process-pod6($path, $?, :%ignored-types  --> List) {
+    # TODO: error if cannot do vvvvv
+    my $type-name = (S/.*'doc/Type/'(.*).pod6/$0/).subst(:g, '/', '::') with $path;
+
+    try { ::($type-name).raku;
+          ::($type-name).HOW.raku;
+          ::($type-name).^methods;
+          # if we're at a low enough level that this amount of introspection fails, skip the type
+          CATCH { default { return (%( uncheckable => True, :$type-name, path => $path), )}}
+    }
+
+    my $uncheckable-methods = SetHash.new();
+    # TODO: do this with clasify;
+    # Confusingly, many methods returned by ^methods(:local) are *not* local, so we filter by package
+    my Set $local-methods = (::($type-name).^methods(:local).grep(-> $method {
+        # Some builtins don't support the introspection we need, mostly ones that call ForeignCode
+        # (which includes NQP methods).  ForeignCode methods typically have the name `<anon>`
+        CATCH { default { $uncheckable-methods{~$method.name}++ unless $method.name eq '<anon>' } }
+        try { $method.package.isa($type-name) } // $method.package ~~ ::($type-name)
+    })».name  (-) %ignored-types{$type-name}) ;
+
+
+    # TODO: add support for %ignored-types<GLOBAL> ^^^^^
+    my (:@in-header, :@with-signature) :=  $path.IO.lines
+                                                   .map({ MethodDoc.parse($_).made })
+                                                   .grep(*.defined)
+                                                   .classify(*.key, :as{.value});
+    my Set $missing-header    = $local-methods (-) Set.new(@in-header);
+    my Set $missing-signature     = $local-methods (-) @with-signature (-) $missing-header;
+    (@in-header (-) $local-methods (-) Set.new('', Any)).keys.classify(-> $method {
+        # if ^find_method finds it, it's *somewhere* in the inheritance graph, just not local
+        when try {::($type-name).^find_method($method).defined} { 'non-local' }
+        # If the type matches first item in the signiture, then it's a sub the type can call with .&…
+        when try { any(&::($method).candidates.map(-> $a {::($type-name) ~~ $a.signature.params.head.type}))} {
+             'non-method-sub'
+         }
+        "doesn't-exist"
+    },
+    :into( my %over-documented = doesn't-exist => [], non-local => [], non-method-sub => [] )
+);
+
+   (Pod6.new(:$type-name,
+              :$path,
+              :$local-methods,
+              uncheckable-methods => $uncheckable-methods.Set,
+              :%over-documented,
+              under-documented => Map.new((:$missing-header, :$missing-signature))),)
+
+}
+
+#| Provide dynamic usage info, including default values assigned in MAIN
 sub USAGE() {
     my &fmt-param = { $^a ~ (' ' x (20 - $^a.chars) ~ $^b.WHY ~ (with $^b.default { " [default: {.()}]"})) }
     # TODO: add info about meaning of output for over- and under-documented methods.
 
     print do given &MAIN.signature.params {
-      "Usage: ./{$*PROGRAM.relative} [OPTION]... [SRC]\n"
+      "Usage: ./{$*PROGRAM.relative} [FLAGS]... [OPTION]... [ARG]\n"
       ~ "{&MAIN.WHY}\n\n"
       ~ (with .grep(!*.named) {
           "ARGS:\n"
@@ -50,10 +163,8 @@ sub USAGE() {
     }
 }
 
-subset ReportCsv  of Str:D where *.split(',')».trim ⊆ <over under skip pass fail all none>;
-subset SummaryCsv of Str:D where *.split(',')».trim ⊆ <totals over under all none yes>;
-
-multi GENERATE-USAGE(&main, |capture) {
+#| Provide error messages that inform the user what unsupported paramater they passed
+sub GENERATE-USAGE(&main, |capture) {
     my $last-invalid; my $cap = capture;
     while $cap !~~ &main.signature {
         $last-invalid = $cap.pairs.tail;
@@ -68,165 +179,113 @@ multi GENERATE-USAGE(&main, |capture) {
     ~ "\nUse ./{$*PROGRAM.relative} --help for usage info"
 }
 
-#| Scan a pod6 file or directory of pod6 files for over- and under-documented methods
-sub MAIN(
-    IO(Str) $src             = './doc/Type/',     #= Path to the file or directory to check
-    Str :e(:$exclude)        = ".git",            #= Comma-separated list of files/directories to ignore
-    ReportCsv :r(:$report)   = 'all',             #= Comma-separated list of documentation types to display
-    SummaryCsv :s(:$summary) = 'all',             #= Whether to display summary statistics
-    Bool :h(:$help),                              #= Display this message and exit
-    :i(:$ignore) = './util/ignored-methods.txt'   #= Path to file with methods to skip
-) {
-    when $help { USAGE }
-    my $report-items  = any(|$report.split(',')».trim);
-    my $summary-items = any(|$summary.split(',')».trim);
-
-    # TODO: Comment
-    my %summary  :=
-        Map.new(%{
-            totals           => Map.new(( types   => %(:0skip, :0pass, :0fail),
-                                          methods => %(:0skip, :0pass, :0under, :0over))),
-            under-documented => Map.new(( sums    => %(:0doesn't-exist, :0non-method-sub, :0non-local),
-                                          types   => BagHash.new(),
-                                          methods => BagHash.new())),
-            over-documented  => Map.new(( sums    => %(:0doesn't-exist, :0non-method-sub, :0non-local),
-                                          types   => BagHash.new()))
-    });
-
-    my $output = $(process($src, EVALFILE($ignore), $exclude)).map( {
-        when .<uncheckable>.so {
-            %summary<totals><types><skip>++;
-            (if $report-items ~~ ('all' | 'skip') {
-                    "\n∅ {.<type-name>} – documented at  ⟨{.<path>.IO}⟩\n  Skipped as uncheckable\n" });
-        }
-        %summary<totals>.&update-totals($_);
-        %summary<under-documented>.&update-under-documented($_);
-        %summary<over-documented>.&update-over-documented($_);
-
-        my $status = (.<uncheckable-method> ∪  |.<under-documented>.values ∪ |.<over-documented>.values
-                      ?? '✗'
-                      !! '✔');
-
-        (if (($report-items ~~ 'all' | 'pass')  && $status eq '✔')
-         || (($report-items ~~ 'all' | 'skip')  && ?.<uncheckable-method>)
-         || (($report-items ~~ 'all' | 'under') && ?.<under-documented>.values)
-         || (($report-items ~~ 'all' | 'over')  && ?.<over-documented>.values) {
-          "\n$status {.<type-name>} – documented at ⟨{.<path>.IO}⟩\n"
-         })
-
-         ~ (if $report-items ~~ ('all' | 'skip')  { fmt-uncheckable-methods(.<uncheckable>)})
-         ~ (if $report-items ~~ ('all' | 'under') { fmt-under-documented-methods(.<under-documented>)})
-         ~ (if $report-items ~~ ('all' | 'over')  { fmt-over-documented-methods(.<over-documented>)})
-    });
-    for $output[] { .print }
-
-    if $summary-items !~~ 'none'          { print fmt-summary-header; }
-    if $summary-items ~~ 'all' | 'totals' { print fmt-totals-summary(|%summary<totals>) };
-    if $summary-items ~~ 'all' | 'under'  { print fmt-under-documented-summary(|%summary<under-documented>) };
-    if $summary-items ~~ 'all' | 'over'   { print fmt-over-documented-summary(|%summary<over-documented>) };
-}
-
-
-sub update-totals(%totals, $data) { given $data {
-    .<uncheckable-method> ∪  |.<under-documented>.values ∪ |.<over-documented>.values
-                      ?? %totals<types><fail>++
-                      !! %totals<types><pass>++;
-    my $under-count = +.<missing-header> + .<missing-signature>  with .<under-documented>;
-    my $over-count  = +.<non-local> + .<non-method-sub> + .<doesn't-exist> with .<over-documented>;
-    %totals<methods><skip>  += +.<uncheckable-method>;
-    %totals<methods><under> += $under-count;
-    %totals<methods><over>  += $over-count;
-    %totals<methods><pass>  += +.<local-methods> - (.<uncheckable-method> + $under-count + $over-count)
-}}
-
-sub update-under-documented(%under-documented, $data) {
-    %under-documented<sums>{.key} += .value.elems for $data.<under-documented>.pairs;
-    %under-documented<methods>.add($data)         for $data.<under-documented><missing-header>.keys;
-    %under-documented<types>{$data.<type-name>}    += $data.<under-documented><missing-header>.elems;
-}
-
-sub update-over-documented(%over-documented, $data) {
-    %over-documented<sums>{.key}                += .value.elems for $data.<over-documented>.pairs;
-    %over-documented<types>{$data.<type-name>}  += $data.<over-documented><doesn't-exist>.elems;
-}
-
-my &fmt-uncheckable-methods = {
-    ~ ( if $_ {  "{+$_} uncheckable method:\n".&pluralize('method').indent(2)
-                 ~ ($_.join("\n").indent(4) ~ "\n") } )
-}
-
-my &fmt-under-documented-methods = {
-    ~ ( if +.<missing-header> {
-         "{+.<missing-header>} missing method:\n".&pluralize('method').indent(2)
-         ~ .<missing-header>.keys.sort.join("\n").indent(4) ~ "\n" })
-    ~ ( if .<missing-signature> {
-         ("{+.<missing-signature>} method without signature:\n"
-             ).&pluralize('method').&pluralize('signature').indent(2)
-         ~ .<missing-signature>.keys.sort.join("\n").indent(4) ~ "\n"})
-}
-
-my &fmt-over-documented-methods = {
-    ~( if .<non-local> {
-         ("{+.<non-local>} non-local method with documentation:\n").&pluralize('method').indent(2)
-         ~ .<non-local>.sort.join("\n").indent(4) ~ "\n"})
-    ~( if .<non-method-sub> {
-         ("{+.<non-method-sub>} non-method with documentation:\n").&pluralize('non-method').indent(2)
-         ~ .<non-method-sub>.sort.join("\n").indent(4) ~ "\n"})
-    ~( if .<doesn't-exist> {
-         ("{+.<doesn't-exist>} non-existing method with documentation:\n").&pluralize('method').indent(2)
-         ~ .<doesn't-exist>.sort.join("\n").indent(4) ~ "\n"})
-}
-
-
-
+#| Helper sub to dynamically format a number as both a raw number and
+#| as a percent of a dynamic variable
 sub fmt-with-percent-of($num, $name) { # pretty hacky, should be a macro once Raku-AST lands
     sprintf("%4d (%4.1f%% of $name)", $num, 100 × $num/CALLER::OUTER::("\$*$name"))
 }
 
-sub fmt-summary-header() {
-    q:to/EOF/
-        ##################
-        #    SUMMARY     #
-        ##################
-       EOF
+#| Helper sub that returns the length of the longest key in a list of pairs
+sub max-len(List $pairs --> Int) { $pairs.max(*.key.chars).key.chars }
+
+#| Appends an 's' to the provided $noun if the closest preceding number in $phrase is ≥ 2
+sub pluralize(Str $phrase, Str $noun --> Str) {
+    $phrase ~~ /(\d+) \D* $noun/;
+    +$0 == 1 ?? $phrase !! $phrase.subst(/$noun/, $noun ~ 's')
 }
 
-sub fmt-totals-summary(:%types, :%methods --> Str) {
-    do { my $*checked  = %types<pass> + %types<fail>;
-         my $*detected = %types<skip> + $*checked;
-         qq:to/EOF/
+multi fmt-report(:$uncheckable) {  "{+$uncheckable} uncheckable method:\n".&pluralize('method').indent(2)
+                                   ~ ($uncheckable.join("\n").indent(4) ~ "\n")
+}
 
-         Total types processed:
-         ======================
-         types detected:    $*detected
-         types checked:    {$*checked.&fmt-with-percent-of('detected')}
-         types skipped:    {%types<skip>.&fmt-with-percent-of('detected')}
-         problems found:   {%types<fail>.&fmt-with-percent-of('checked')}
-         no problems found:{%types<pass>.&fmt-with-percent-of('checked')}
-        EOF
-    } ~ do {
-        my $*checked  = %methods<pass> + %methods<over> + %methods<under>;
-        my $*detected = %methods<skip> + $*checked;
-        qq:to/EOF/
+multi fmt-report(:%over-documented) {
+    my (:@non-local, :@non-method-sub, :@doesn't-exist) := %over-documented;
+    ~( if @non-local {
+         ("{+@non-local} non-local method with documentation:\n").&pluralize('method').indent(2)
+         ~ @non-local.sort.join("\n").indent(4) ~ "\n"})
+    ~( if @non-method-sub {
+         ("{+@non-method-sub} non-method with documentation:\n").&pluralize('non-method').indent(2)
+         ~ @non-method-sub.sort.join("\n").indent(4) ~ "\n"})
+    ~( if @doesn't-exist {
+         ("{+@doesn't-exist} non-existing method with documentation:\n").&pluralize('method').indent(2)
+         ~ @doesn't-exist.sort.join("\n").indent(4) ~ "\n"})
+}
 
-         Total methods processed:
-         ========================
-         methods detected:  $*detected
-         methods checked:   {$*checked.&fmt-with-percent-of('detected')}
-         methods skipped:   {%methods<skip>.&fmt-with-percent-of('detected')}
-         over-documented:   {%methods<over>.&fmt-with-percent-of('checked')}
-         under-documented:  {%methods<under>.&fmt-with-percent-of('checked')}
-         no problems found: {%methods<pass>.&fmt-with-percent-of('checked')}
+multi fmt-report(:%under-documented) {
+    my (:%missing-header, :%missing-signature) := %under-documented;
+    ~ ( if +%missing-header {
+         "{+%missing-header} missing method:\n".&pluralize('method').indent(2)
+         ~ %missing-header.keys.sort.join("\n").indent(4) ~ "\n" })
+    ~ ( if %missing-signature {
+         ("{+%missing-signature} method without signature:\n"
+             ).&pluralize('method').&pluralize('signature').indent(2)
+         ~ %missing-signature.keys.sort.join("\n").indent(4) ~ "\n"})
+}
+
+
+#| Manages the collection and formatting of summary statistics (displayed with --summary)
+class Summary {
+    has Map $!totals;
+    has Map $!under-documented;
+    has Map $!over-documented;
+
+    submethod BUILD() {
+        $!totals           := Map.new(( types   => %(:0skip, :0pass, :0fail),
+                                        methods => %(:0skip, :0pass, :0under, :0over)));
+        $!under-documented := Map.new(( sums    => %(:0doesn't-exist, :0non-method-sub, :0non-local),
+                                        types   => BagHash.new(),
+                                        methods => BagHash.new()));
+        $!over-documented  := Map.new(( sums    => %(:0doesn't-exist, :0non-method-sub, :0non-local),
+                                        types   => BagHash.new()));
+    }
+
+    submethod count-uncheckable-type() { $!totals<types><skip>++ }
+
+    submethod fmt-header() {
+        q:to/EOF/
+         ##################
+         #    SUMMARY     #
+         ##################
         EOF
     }
 
-}
+    submethod fmt-totals() {
+        my (:%types, :%methods) := $!totals;
+        do { my $*checked  = %types<pass> + %types<fail>;
+             my $*detected = %types<skip> + $*checked;
+             qq:to/EOF/
 
-sub fmt-under-documented-summary(:%sums, :%methods, :%types) {
-    my $*total = %sums<missing-header> + %sums<missing-signature>;
-    my $top-missing = %methods.grep(*.value ≥ 20).cache;
-    my $top-types = %types.sort(*.value).tail(5).cache;
-    qq:to/EOF/
+              Total types processed:
+              ======================
+              types detected:    $*detected
+              types checked:    {$*checked.&fmt-with-percent-of('detected')}
+              types skipped:    {%types<skip>.&fmt-with-percent-of('detected')}
+              problems found:   {%types<fail>.&fmt-with-percent-of('checked')}
+              no problems found:{%types<pass>.&fmt-with-percent-of('checked')}
+             EOF
+           } ~ do {
+            my $*checked  = %methods<pass> + %methods<over> + %methods<under>;
+            my $*detected = %methods<skip> + $*checked;
+            qq:to/EOF/
+
+             Total methods processed:
+             ========================
+             methods detected:  $*detected
+             methods checked:   {$*checked.&fmt-with-percent-of('detected')}
+             methods skipped:   {%methods<skip>.&fmt-with-percent-of('detected')}
+             over-documented:   {%methods<over>.&fmt-with-percent-of('checked')}
+             under-documented:  {%methods<under>.&fmt-with-percent-of('checked')}
+             no problems found: {%methods<pass>.&fmt-with-percent-of('checked')}
+            EOF
+        }
+    }
+
+    submethod fmt-under-documented() {
+        my (:%sums, :%methods, :%types) := $!under-documented;
+        my $*total = %sums<missing-header> + %sums<missing-signature>;
+        my $top-missing = %methods.grep(*.value ≥ 20).cache;
+        my $top-types = %types.sort(*.value).tail(5).cache;
+        qq:to/EOF/
 
          UNDER-DOCUMENTED:
          #################
@@ -237,30 +296,31 @@ sub fmt-under-documented-summary(:%sums, :%methods, :%types) {
          missing methods:           {%sums<missing-header>.&fmt-with-percent-of('total')}
          methods with no signature: {%sums<missing-signature>.&fmt-with-percent-of('total')}
         EOF
-    ~ (if $top-missing {
-             "\n"
-           ~ "Methods missing from 20+ types:\n".indent(1)
-           ~ "===============================\n".indent(1)
-           ~ $top-missing.sort(*.value).map({ sprintf(" %-*s    %d",
-                                                      $top-missing.&max-len, .key,
-                                                      .value)}).join("\n")
-           ~ sprintf("\n %s\n   %*s  %d",
-                     '-' x ($top-missing.&max-len + 7),
-                     $top-missing.&max-len, "TOTAL",
-                     $top-missing.map(*.value).sum) })
-    ~ (if $top-types.elems ≥ 3 {
-             "\n"
-           ~ " Types with the most missing methods:\n"
-           ~ " ====================================\n"
-           ~ $top-types.map({ sprintf(" %-*s %-5d",
-                                      $top-types.&max-len, .key,
-                                      .value)}).join("\n") ~ "\n"})
-}
+        ~ (if $top-missing {
+                  "\n"
+                  ~ "Methods missing from 20+ types:\n".indent(1)
+                  ~ "===============================\n".indent(1)
+                  ~ $top-missing.sort(*.value).map({ sprintf(" %-*s    %d",
+                                                             $top-missing.&max-len, .key,
+                                                             .value)}).join("\n") ~ "\n"
+                  ~ ('-' x ($top-missing.&max-len + 7)).indent(1) ~ "\n"
+                  ~ "TOTAL".indent($top-missing.&max-len - 1)
+                  ~ $top-missing.map(*.value).sum.&fmt-with-percent-of('total') ~ "\n"
+              })
+        ~ (if $top-types.elems ≥ 3 {
+                  "\n"
+                  ~ " Types with the most missing methods:\n"
+                  ~ " ====================================\n"
+                  ~ $top-types.map({ sprintf(" %-*s %-5d",
+                                             $top-types.&max-len, .key,
+                                             .value)}).join("\n") ~ "\n"})
+    }
 
-sub fmt-over-documented-summary(:%sums, :%types) {
-    my $*total = %sums<non-local> + %sums<non-method-sub> + %sums<doesn't-exist>;
-    my $top-types = %types.sort(*.value).tail(5).cache;
-    qq:to/EOF/
+    submethod fmt-over-documented() {
+        my (:%sums, :%types) := $!over-documented;
+        my $*total = %sums<non-local> + %sums<non-method-sub> + %sums<doesn't-exist>;
+        my $top-types = %types.sort(*.value).tail(5).cache;
+        qq:to/EOF/
 
          OVER-DOCUMENTED:
          ################
@@ -268,70 +328,50 @@ sub fmt-over-documented-summary(:%sums, :%types) {
          Total over-documented methods:
          ==============================
          total over documented:     $*total
-         non-local methods:         {%sums<non-local>.&fmt-with-percent-of('total')}
-         non-method routines:       {%sums<non-method-sub>.&fmt-with-percent-of('total')}
-         non-existent methods:      {%sums<doesn't-exist>.&fmt-with-percent-of('total')}
+         non-local methods:        {%sums<non-local>.&fmt-with-percent-of('total')}
+         non-method routines:      {%sums<non-method-sub>.&fmt-with-percent-of('total')}
+         non-existent methods:     {%sums<doesn't-exist>.&fmt-with-percent-of('total')}
         EOF
-     ~ (if $top-types.elems ≥ 3 {
-              "\n"
-            ~ "Types with the most over-documented methods:\n".indent(1)
-            ~ "============================================\n".indent(1)
-            ~ ($top-types.map({ sprintf(" %-*s %-5d\n",
-                                        $top-types.&max-len, .key,
-                                        .value)}).join)})
-}
-
-multi process($path where {.IO ~~ :d}, %ignored, $exclude --> List) {
-    |(lazy $path.dir
-               ==> grep({ .basename ~~ none($exclude.split(',')».trim) })
-               ==> map({ |process($^next-path, %ignored, $exclude)}))
-}
-
-multi process($path, %ignored, $ --> List) {
-    # TODO: error if cannot do vvvvv
-    my $type-name = (S/.*'doc/Type/'(.*)'.pod6'/$0/).subst(:g, '/', '::') with $path;
-
-    try { ::($type-name).raku;
-          ::($type-name).HOW.raku;
-          ::($type-name).^methods;
-          # if we're at a low enough level that this amount of introspection fails, skip the type
-          CATCH { default { return (%( uncheckable => True, :$type-name, path => $path), )}}
+        ~ (if $top-types.elems ≥ 3 {
+                  "\n"
+                  ~ "Types with the most over-documented methods:\n".indent(1)
+                  ~ "============================================\n".indent(1)
+                  ~ ($top-types.map({ sprintf(" %-*s %-5d\n",
+                                              $top-types.&max-len, .key,
+                                              .value)}).join)})
     }
 
-    my %uncheckable-method = SetHash.new();
-    # Confusingly, many methods returned by ^methods(:local) are *not* local, so we filter by packaged
-    my Set $local-methods = (::($type-name).^methods(:local).grep(-> $method {
-        # Some builtins don't support the introspection we need, mostly ones that call ForeignCode
-        # (which includes NQP methods).  ForeignCode methods typically have the name `<anon>`
-        CATCH { default { %uncheckable-method{~$method.name}++ unless $method.name eq '<anon>' } }
-        try { $method.package.isa($type-name) } // $method.package ~~ ::($type-name)
-    })».name).Set (-) %ignored{$type-name};
+    submethod update-totals(:%local-methods, :%uncheckable-methods, :%under-documented, :%over-documented) {
+        %uncheckable-methods ∪  |%under-documented.values ∪ |%over-documented.values
+                ?? $!totals<types><fail>++
+                !! $!totals<types><pass>++;
+        my $under-count = +.<missing-header> + .<missing-signature>  with %under-documented;
+        my $over-count  = +.<non-local> + .<non-method-sub> + .<doesn't-exist> with %over-documented;
+        $!totals<methods><skip>  += +%uncheckable-methods;
+        $!totals<methods><under> += $under-count;
+        $!totals<methods><over>  += $over-count;
+        $!totals<methods><pass>  += +%local-methods - (%uncheckable-methods + $under-count + $over-count)
+    }
 
-    # TODO: add support for %ignored<GLOBAL> ^^^^^
+    submethod update-under-documented(:%under-documented, :$type-name) {
+        $!under-documented<sums>{.key} += .value.elems for %under-documented.pairs;
+        $!under-documented<methods>.add($_)         for %under-documented<missing-header>.keys;
+        $!under-documented<types>{$type-name}    += %under-documented<missing-header>.elems;
+    }
 
-    my ($in-header, $with-signature) = [Z] $path.IO.lines.map({ MethodDoc.parse($_).made}).grep({.elems == 2});
-
-    my %missing-header    = $local-methods (-) $in-header;
-    my %missing-signature = $local-methods (-) $with-signature (-) %missing-header;
-    ($in-header (-) $local-methods (-) Set.new('', Any)).keys.classify(-> $method {
-        # if ^find_method finds it, it's *somewhere* in the inheritance graph, just not local
-        when try {::($type-name).^find_method($method).defined} { 'non-local' }
-        # If the type matches first item in the signiture, then it's a sub the type can call with .&…
-        when try { any(&::($method).candidates.map(-> $a {::($type-name) ~~ $a.signature.params.head.type}))} {
-             'non-method-sub'
-         }
-        "doesn't-exist"
-    },
-    :into( my %over-documented = doesn't-exist => [], non-local => [], non-method-sub => [] )
-);
-    (%( :$type-name, :$path, :$local-methods, :%uncheckable-method, :%over-documented,
-        under-documented => %{:%missing-header, :%missing-signature} ),)
+    submethod update-over-documented(:%over-documented, :$type-name) {
+        $!over-documented<sums>{.key}                += .value.elems for %over-documented.pairs;
+        $!over-documented<types>{$type-name}  += %over-documented<doesn't-exist>.elems;
+    }
 }
 
-sub max-len($pair-list --> Int) { $pair-list.max(*.key.chars).key.chars }
+grammar MethodDoc {
+    token TOP { [<in-header>  | <with-signature>]
+                { with $<in-header><method>      { make (in-header      => ~$_) }
+                  with $<with-signature><method> { make (with-signature => ~$_) }}}
 
-#| Appends an 's' to the provided $noun if the closest preceding number in $phrase is ≥ 2
-sub pluralize(Str $phrase, Str $noun --> Str) {
-    $phrase ~~ /(\d+) \D* $noun/;
-    +$0 == 1 ?? $phrase !! $phrase.subst(/$noun/, $noun ~ 's')
+    token with-signature { <ws> ['multi' <ws>]? <keyword> <ws> <method> '(' .* }
+    token in-header      { '=head' \d? <ws> <keyword> <ws> <method> }
+    token keyword        { ['method' | 'routine'] }
+    token method         { <[-'\w]>+ }
 }

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -12,6 +12,7 @@ constant $missing_method_threshold    = 20;
 constant $overdocked_method_threshold = 20;
 constant $most_missing_list_length    = 5;
 constant $most_overdocked_list_length = 5;
+my $util_dir := $*PROGRAM.resolve.parent;
 
 #| Allowable values for --report
 subset ReportCsv  of Str:D where *.split(',')».trim ⊆ <skip pass fail err over under all none>;
@@ -20,12 +21,12 @@ subset SummaryCsv of Str:D where *.split(',')».trim ⊆ <totals             ove
 
 #| Scan a pod6 file or directory of pod6 files for over- and under-documented methods
 sub MAIN(
-    IO(Str) $input-path      = './doc/Type/',     #= Path to the file or directory to check
-    Str :e(:$exclude)        = ".git",            #= Comma-separated list of files/directories to ignore
-    ReportCsv  :report(:$r)  = 'all',             #= Comma-separated list of documentation types to display
-    SummaryCsv :summary(:$s) = 'all',             #= Whether to display summary statistics
-    Bool :h(:$help),                              #= Display this message and exit
-    :i(:$ignore) = './util/ignored-methods.txt',  #= Path to file with methods to skip
+    IO(Str) $input-path = "{$util_dir.parent}/doc/Type", #= Path to the file or directory to check
+    Str :e(:$exclude)        = ".git",                   #= Comma-separated list of files/directories to ignore
+    ReportCsv  :report(:$r)  = 'all',                    #= Comma-separated list of documentation types to display
+    SummaryCsv :summary(:$s) = 'all',                    #= Whether to display summary statistics
+    Bool :h(:$help),                                     #= Display this message and exit
+    Str :i(:$ignore) = "$util_dir/ignored-methods.txt",  #= Path to file with methods to skip
 ) {
     when $help { USAGE }
     my $reports-to-print  = any(|(S/'all'/skip,pass,fail,err,over,under/ with $r).split(',')».trim);
@@ -348,7 +349,7 @@ sub USAGE() {
     # TODO: add info about meaning of output for over- and under-documented methods.
     # TODO: Update for new functionality
 
-    print do given &MAIN.signature.params {
+    print S:g/'/home/'$(%*ENV<USER>)/~/ with do given &MAIN.signature.params {
       "Usage: ./{$*PROGRAM.relative} [FLAGS]... [OPTION]... [ARG]\n"
       ~ "{&MAIN.WHY}\n\n"
       ~ (with .grep(!*.named) {

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -417,10 +417,9 @@ grammar MethodDoc {
     token TOP { <doc-line> { make $<doc-line>.made }}
 
     proto rule doc-line          {*}
-    rule doc-line:sym<signature> { <.ws>['multi' ]?<keyword> <method>'('.+ { make (with-signature => ~$<method>)}}
-    rule doc-line:sym<in-header> { '=head'\d? <keyword> <method>           { make (in-header => ~$<method>)}}
-    token keyword                                                          { ['method' | 'routine'] }
-    token method                                                           { <[-'\w]>+ }
+    rule doc-line:sym<signature> { <.ws>['multi' ]?<method-decl>'('.+  { make (with-signature => ~$<method-decl>)}}
+    rule doc-line:sym<in-header> {      '=head'\d? <method-decl>       { make (in-header      => ~$<method-decl>)}}
+    token method-decl            { ['method' | 'routine'] <.ws> <(<[-'\w]>+)>}
 }
 
 

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -86,7 +86,7 @@ sub MAIN($source-path = './doc/Type/', Str :$exclude = ".git", :$ignore = 'util/
 
     for matched-methods -> ($type-name, $path, Set $missing-methods) {
         put "Type: {$type-name}, File: ⟨{$path}⟩";
-        put $missing-methods;
+        put $missing-methods.keys.sort;
         put "";
     };
 }

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -30,7 +30,6 @@ sub MAIN(
     Str :i(:$ignore) = "$util_dir/ignored-methods.txt",  #= Path to file with methods to skip
 ) {
     when $help { USAGE }
-#    when $input-path.IO.absolute !~~ /.*'doc/Type/'/ {note  Report::fmt-bad-file($input-path)};
     # normalize long & short options for --summary & --report
     my $reports   =  $report_opts.map(-> ($short, $l) {if  $short | $l ∈  $r.split(',')».trim { $l }}).cache;
     my $summaries = $summary_opts.map(-> ($short, $l) {if  $short | $l ∈  $s.split(',')».trim { $l }}).cache;
@@ -413,7 +412,10 @@ class Summary {
     #| Format a number as a percent of a pair's value, and label it with the key's name
     sub fmt-with-percent-of($num, *%names where *.elems == 1) {
         my $name = S:g/'-'/ / with %names.head.key;
-        "%4d (%4.1f%% of $name)".sprintf($num, 100 × $num/%names.head.value)
+        given %names.head.value -> $val {
+            when $val > 0 { "%4d (%4.1f%% of $name)".sprintf($num, 100 × $num/$val) }
+            default       { "%4d".sprintf($num) }
+        }
     }
 
     #| Recursivly total a Map consisiting consisting of Maps of Ints (cf. Bag.total)

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -19,36 +19,34 @@ sub MAIN(
     Str :$exclude = ".git",                 #= Comma-seperated list of file extensions to ignore (default: .git)
     :$ignore = './util/ignored-methods.txt' #= File listing methods to ignore (default ./util/ignored-methods.txt)
 ) {
-    my %ignored is Map = EVALFILE($ignore);
-    sub process($path)  {
-        when $path.IO ~~ :d {
-            flat (lazy $path.dir.grep({ .basename ~~ none($exclude.split(',')».trim) }).map({ process($^next-path)}));
-        }
+    for process($source-path, EVALFILE($ignore), $exclude) { .say }
+}
+multi process($path where {.IO ~~ :d}, %ignored, $exclude) {
+    flat (lazy $path.dir
+               ==> grep({ .basename ~~ none($exclude.split(',')».trim) })
+               ==> map({ process($^next-path, %ignored, $exclude)}))
+}
 
-        my $type-name = (S/.*'doc/Type/'(.*)'.pod6'/$0/).subst(:g, '/', '::') with $path;
-        when $type-name eq 'independent-routines' | 'Routine::WrapHandle' { #`(TODO) }
-        CATCH { default { return "✗ $type-name – documented at  ⟨{$path.IO}⟩\nSkipped as uncheckable\n" } }
-        my @errors =[];
-        my @real-methods = ::($type-name).^methods(:local).grep({
-            my $name = .name;
-            # Some builtins don't support the introspection we need (e.g., NQPRoutine)
-            CATCH { default { @errors.push("$name") unless $name eq '<anon>';
-                              False } }
-            (.package eqv ::($type-name))
-        })».name;
-        my ($in-header, $with-signature) = [Z] $path.IO.lines.map({ MethodDoc.parse($_).made}).grep({.elems == 2});
-        my Set $missing-header      = @real-methods (-) %ignored{$type-name} (-) $in-header;
-        my Set $missing-signature   = @real-methods (-) %ignored{$type-name} (-) $with-signature (-) $missing-header;
+multi process($path, %ignored, $) {
+    my $type-name = (S/.*'doc/Type/'(.*)'.pod6'/$0/).subst(:g, '/', '::') with $path;
+    when $type-name eq 'independent-routines' | 'Routine::WrapHandle' { #`(TODO) }
+    CATCH { default { return "✗ $type-name – documented at  ⟨{$path.IO}⟩\nSkipped as uncheckable\n" } }
+    my @errors =[];
+    my @real-methods = ::($type-name).^methods(:local).grep(-> $method {
+        # Some builtins don't support the introspection we need (e.g., NQPRoutine)
+        CATCH { default { @errors.push(~$method.name) unless $method.name eq '<anon>' } }
+        ($method.package eqv ::($type-name))
+    })».name;
+    my ($in-header, $with-signature) = [Z] $path.IO.lines.map({ MethodDoc.parse($_).made}).grep({.elems == 2});
+    my Set $missing-header      = @real-methods (-) %ignored{$type-name} (-) $in-header;
+    my Set $missing-signature   = @real-methods (-) %ignored{$type-name} (-) $with-signature (-) $missing-header;
 
-        (+@errors || +$missing-header || +$missing-signature ?? "✗ " !! "✔ ")
-        ~ "{$type-name} – documented at ⟨{$path.IO}⟩\n"
-        ~ ( if +@errors {
-            "  {+@errors} methods couldn't be checked:\n    {@errors.join("\n    ")}\n" })
-        ~ ( if +$missing-header {
-            "  {+$missing-header} methods were missing:\n    {$missing-header.keys.sort.join("\n    ")}\n"})
-        ~ ( if $missing-signature {
-            "  {+$missing-signature} methods lacked signatures:\n    {$missing-signature.keys.sort.join("\n    ")}\n"})
-    }
-
-    for process($source-path) { .say };
+    (+@errors || +$missing-header || +$missing-signature ?? "✗ " !! "✔ ")
+    ~ "{$type-name} – documented at ⟨{$path.IO}⟩\n"
+    ~ ( if +@errors {
+        "  {+@errors} methods couldn't be checked:\n    {@errors.join("\n    ")}\n" })
+    ~ ( if +$missing-header {
+        "  {+$missing-header} methods were missing:\n    {$missing-header.keys.sort.join("\n    ")}\n"})
+    ~ ( if $missing-signature {
+        "  {+$missing-signature} methods lacked signatures:\n    {$missing-signature.keys.sort.join("\n    ")}\n"})
 }

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -1,16 +1,6 @@
 #! /usr/bin/env raku
 use v6;
 
-sub USAGE () {
-print Q:c:to/EOH/;
-    Usage: {$*PROGRAM-NAME} [FILE|PATH]
-
-    Scan a single pod6 file or pod6 files under a path for method declarations,
-    infer the typename from the filename and output any methods name that is
-    found in the type but not in the pod6 file.
-EOH
-}
-
 class LazyLookup does Associative {
     # Read a file line by line, turn it into a hash in a lazy fashion. Quite
     # handy when only a single file is checked and the key is close to the top
@@ -55,7 +45,12 @@ grammar MethodDoc {
     token method           { <[-'\w]>+ }
 }
 
-sub MAIN($source-path = './doc/Type/', Str :$exclude = ".git", :$ignore = 'util/ignored-methods.txt') {
+#| Scan one or more pod6 files for undocumented methods
+sub MAIN(
+    IO(Str) $source-path = './doc/Type/',   #= The file or directory to check (default: ./doc/Type)
+    Str :$exclude = ".git",                 #= Comma-seperated list of file extensions to ignore (default: .git)
+    :$ignore = './util/ignored-methods.txt' #= File listing methods to ignore (default ./util/ignored-methods.txt)
+) {
     my \exclude = none('.', '..', $exclude.split(','));
 
     my \ignore = LazyLookup.new(:path($ignore));

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -1,40 +1,6 @@
 #! /usr/bin/env raku
 use v6;
 
-class LazyLookup does Associative {
-    # Read a file line by line, turn it into a hash in a lazy fashion. Quite
-    # handy when only a single file is checked and the key is close to the top
-    # of the file.
-
-    has IO::Path $.path;
-    has IO::Handle $.in;
-    has %!cache;
-
-    submethod BUILD(:$path){ $!path = $path.IO };
-
-    method in {
-        $!in //= $!path.open :r or die "could not open ⸨$!path.Str⸩";
-        $!in
-    }
-
-    method AT-KEY(Str() $key) {
-       %!cache{$key} // self!scan-for-key($key)
-    }
-
-    method !scan-for-key(Str $key){
-        for $.in.lines() {
-            # By splitting on # and taking [0], we skip any comment.  If we
-            # don't get a typename we either have an empty line or a line
-            # starting with a comment.
-            my ($type-name, $method-names) = .split('#')[0].split(':')».trim;
-            next unless $type-name;
-            $method-names.=split(' ').Set;
-            %!cache{$type-name} = $method-names;
-            return $method-names if $key eq $type-name;
-        }
-    }
-}
-
 grammar MethodDoc {
     token TOP { [<in-header>  | <with-signature>]
                 { make ($<in-header><method>, $<with-signature><method>).map({ ~($_ // ()) }) } }
@@ -53,8 +19,6 @@ sub MAIN(
 ) {
     my \exclude = none('.', '..', $exclude.split(','));
 
-    my \ignore = LazyLookup.new(:path($ignore));
-
     my \type-pod-files := $source-path.ends-with('.pod6')
     ?? ($source-path.IO,)
     !! gather for $source-path {
@@ -66,7 +30,6 @@ sub MAIN(
     my \types := gather for type-pod-files».IO {
         my $file-path = S/.*'doc/Type/'(.*)'.pod6'/$0/;
         my $type-name = $file-path.subst(:g, '/', '::');
-
         take ($type-name, .IO)
     }
 
@@ -81,13 +44,13 @@ sub MAIN(
         })».name)
     }
 
+    my %ignored is Map = EVALFILE($ignore);
     my \matched-methods := gather for methods -> ($type-name, $path, @existing) {
         my ($in-header, $with-signature) = [Z] $path.lines.map({ MethodDoc.parse($_).made}).grep({.elems == 2});
-        my Set $missing-header      = @existing (-) ignore{$type-name} (-) $in-header;
-        my Set $missing-signature   = @existing (-) ignore{$type-name} (-) $with-signature (-) $missing-header;
+        my Set $missing-header      = @existing (-) %ignored{$type-name} (-) $in-header;
+        my Set $missing-signature   = @existing (-) %ignored{$type-name} (-) $with-signature (-) $missing-header;
         if $missing-header || $missing-signature {
-            take ($type-name, $path, $missing-header, $missing-signature)
-        }
+            take ($type-name, $path, $missing-header, $missing-signature) }
     }
 
     for matched-methods -> ($type-name, $path, Set $missing-from-header, Set $missing-signature) {

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -87,14 +87,11 @@ multi process-pod6($path where {.IO ~~ :d}, :%ignored-types,
                                   (with $only-dir    { $path.parent    ~~ $_}))})
                      ==> map({ |process-pod6($^next-path, :%filters, :%ignored-types )}))
 }
-sub set_bag($el) { when $el.isa('Set') || $el.isa('Bag') { True }
-                   when $el.isa('Map')                   { $el.values».&set_bag }
-                   default                               { False } }
+
 #| Process a Pod6 file by parsing with the MethodDoc grammar and then comparing
 #| the documented methods against the methods visible via introspection
 multi process-pod6($path, :%ignored-types, *%  --> List ) {
-    # Every item in .<methods> is a Set|Bag or a Map containing Set|Bag
-    POST { with .[0]<methods> { ?all(.values».&set_bag) } else { True }}
+    POST { with .[0]<methods> { $_ ~~ Set | Bag | Map } else { True }}
 
     when $path !~~ /.*'doc/Type/'(.*).pod6/ { (%(file => Map.new((no-type-found => True,  :$path))), )}
     my $type-name := (S/.*'doc/Type/'(.*).pod6/$0/).subst(:g, '/', '::') with $path;

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -3,76 +3,68 @@ use v6;
 use Telemetry;
 use Test;
 
-class Summary {...}
+class Summary     {...}
+class Report      {...}
 grammar MethodDoc {...}
 
-subset ReportCsv  of Str:D where *.split(',')».trim ⊆ <over under skip pass fail all none>;
-subset SummaryCsv of Str:D where *.split(',')».trim ⊆ <totals over under all none yes>;
+# Hard-coded constants that change Summary output.  (Could be user-configurable if wanted)
+constant $missing_method_threshold    = 20;
+constant $overdocked_method_threshold = 20;
+constant $most_missing_list_length    = 5;
+constant $most_overdocked_list_length = 5;
+
+#| Allowable values for --report
+subset ReportCsv  of Str:D where *.split(',')».trim ⊆ <skip pass fail over under all none>;
+#| Allowable values for --summary
+subset SummaryCsv of Str:D where *.split(',')».trim ⊆ <totals         over under all none>;
 
 #| Scan a pod6 file or directory of pod6 files for over- and under-documented methods
 sub MAIN(
     IO(Str) $input-path      = './doc/Type/',     #= Path to the file or directory to check
     Str :e(:$exclude)        = ".git",            #= Comma-separated list of files/directories to ignore
-    ReportCsv :r(:$report)   = 'all',             #= Comma-separated list of documentation types to display
+    ReportCsv  :report(:$r)  = 'all',             #= Comma-separated list of documentation types to display
     SummaryCsv :summary(:$s) = 'all',             #= Whether to display summary statistics
     Bool :h(:$help),                              #= Display this message and exit
-    :i(:$ignore) = './util/ignored-methods.txt'   #= Path to file with methods to skip
+    :i(:$ignore) = './util/ignored-methods.txt',  #= Path to file with methods to skip
 ) {
     when $help { USAGE }
-    my $report-items  = any(|$report.split(',')».trim);
-    my $summary-items = any(|$s.split(',')».trim);
+    my $reports-to-print  = any(|(S/'all'/skip,pass,fail,over,under/ with $r).split(',')».trim);
+    my $summaries-to-print = any(|(S/'all'/totals,over,under/         with $s).split(',')».trim);
     my $summary = Summary.new;
 
     for $input-path.&process-pod6($exclude, ignored-types => EVALFILE($ignore)).hyper.map(
-        -> $pod6 {
-        my (:$type-name, :$path, :%local-methods, :$uncheckable, :%uncheckable-methods, :%over-documented, :%under-documented) := $pod6;
-        when $uncheckable.so {
-            $summary.count-uncheckable-type;
-            (if $report-items ~~ ('all' | 'skip') {
-                    "\n∅ {$type-name} – documented at  ⟨{$path.IO}⟩\n  Skipped as uncheckable\n" });
-        }
-        $summary.update-totals(:%local-methods, :%uncheckable-methods, :%under-documented, :%over-documented);
-        $summary.update-over-documented(:%over-documented, :$type-name);
-        $summary.update-under-documented(:%under-documented, :$type-name);
+        -> (:%file, :%methods (:%local, :%uncheckable, :%over-documented, :%under-documented)) {
 
-        my $status = (%uncheckable-methods ∪  |%under-documented.values ∪ |%over-documented.values
-                      ?? '✗'
-                      !! '✔');
+        when %file<uncheckable> { $summary.count-uncheckable-type;
+                                  (if $reports-to-print ~~ 'skip' { Report::fmt-skipped(:%file) }) }
 
-        (if (($report-items ~~ 'all' | 'pass')  && $status eq '✔')
-         || (($report-items ~~ 'all' | 'skip')  && ?%uncheckable-methods)
-         || (($report-items ~~ 'all' | 'under') && ?%under-documented.values)
-         || (($report-items ~~ 'all' | 'over')  && ?%over-documented.values) {
-          "\n$status {$type-name} – documented at ⟨{$path.IO}⟩\n"
+        $summary.update-totals(:%local, :%uncheckable, :%under-documented, :%over-documented);
+        $summary.update-over-documented(:%over-documented,   :%file);
+        $summary.update-under-documented(:%under-documented, :%file);
+
+        my $status = (%uncheckable ∪  |%under-documented.values ∪ |%over-documented.values ?? '✗' !! '✔');
+        (if (($reports-to-print ~~ 'pass')  && $status eq '✔')
+         || (($reports-to-print ~~ 'skip')  && ?%uncheckable)
+         || (($reports-to-print ~~ 'under') && ?%under-documented.values)
+         || (($reports-to-print ~~ 'over')  && ?%over-documented.values) {
+             "\n$status {%file<type-name>} – documented at ⟨%file<path>.IO}⟩\n"
          })
 
-         ~ (if $report-items ~~ ('all' | 'skip') && ?$uncheckable  { fmt-report(:$uncheckable) })
-         ~ (if $report-items ~~ ('all' | 'under')                  { fmt-report(:%under-documented)})
-         ~ (if $report-items ~~ ('all' | 'over')                   { fmt-report(:%over-documented)});
+         ~ (if $reports-to-print ~~ ('skip')  { Report::fmt(:%uncheckable) })
+         ~ (if $reports-to-print ~~ ('under') { Report::fmt(:%under-documented) })
+         ~ (if $reports-to-print ~~ ('over')  { Report::fmt(:%over-documented) });
     }) { .print };
 
-    if $summary-items !~~ 'none'          { print $summary.fmt-header };
-    if $summary-items ~~ 'all' | 'totals' { print $summary.fmt-totals };
-    if $summary-items ~~ 'all' | 'under'  { print $summary.fmt-under-documented };
-    if $summary-items ~~ 'all' | 'over'   { print $summary.fmt-over-documented };
+    if $summaries-to-print !~~ 'none'   { print $summary.fmt-header };
+    if $summaries-to-print ~~  'totals' { print $summary.fmt-totals };
+    if $summaries-to-print ~~  'under'  { print $summary.fmt-under-documented };
+    if $summaries-to-print ~~  'over'   { print $summary.fmt-over-documented };
 }
 
-
-#| Process a directory of Pod6 files by recursivly processing each file
+#| Process a directory of Pod6 files by recursively processing each file
 multi process-pod6($path where {.IO ~~ :d}, $exclude, :%ignored-types --> List) {
-    |(lazy $path.dir
-               ==> grep({ .basename ~~ none($exclude.split(',')».trim) })
-               ==> map({ |process-pod6($^next-path, $exclude, :%ignored-types )}))
-}
-
-class Pod6 {
-    has Str $.type-name;
-    has IO::Path $.path;
-    has Set $.local-methods;
-    has Bool $.uncheckable;
-    has Set $.uncheckable-methods;
-    has Map $.over-documented;
-    has Map $.under-documented;
+    |(lazy $path.dir ==> grep({ .basename ~~ none($exclude.split(',')».trim) })
+                     ==> map({ |process-pod6($^next-path, $exclude, :%ignored-types )}))
 }
 
 #| Process a Pod6 file by parsing with the MethodDoc grammar and then comparing
@@ -81,15 +73,13 @@ multi process-pod6($path, $?, :%ignored-types  --> List) {
     # TODO: error if cannot do vvvvv
     my $type-name = (S/.*'doc/Type/'(.*).pod6/$0/).subst(:g, '/', '::') with $path;
 
-    try { ::($type-name).raku;
-          ::($type-name).HOW.raku;
-          ::($type-name).^methods;
+    try { ::($type-name).raku && ::($type-name).HOW.raku && ::($type-name).^methods;
           # if we're at a low enough level that this amount of introspection fails, skip the type
-          CATCH { default { return (%( uncheckable => True, :$type-name, path => $path), )}}
+          CATCH { default { return (%(file => Map.new((uncheckable => True, :$type-name, :$path))), )}}
     }
 
+    # TODO: do this with classify;
     my $uncheckable-methods = SetHash.new();
-    # TODO: do this with clasify;
     # Confusingly, many methods returned by ^methods(:local) are *not* local, so we filter by package
     my Set $local-methods = (::($type-name).^methods(:local).grep(-> $method {
         # Some builtins don't support the introspection we need, mostly ones that call ForeignCode
@@ -104,28 +94,254 @@ multi process-pod6($path, $?, :%ignored-types  --> List) {
                                                    .map({ MethodDoc.parse($_).made })
                                                    .grep(*.defined)
                                                    .classify(*.key, :as{.value});
+
     my Set $missing-header    = $local-methods (-) Set.new(@in-header);
-    my Set $missing-signature     = $local-methods (-) @with-signature (-) $missing-header;
-    (@in-header (-) $local-methods (-) Set.new('', Any)).keys.classify(-> $method {
+    my Set $missing-signature = $local-methods (-) @with-signature (-) $missing-header;
+    (@in-header (-) $local-methods).keys.classify(-> $method {
         # if ^find_method finds it, it's *somewhere* in the inheritance graph, just not local
         when try {::($type-name).^find_method($method).defined} { 'non-local' }
-        # If the type matches first item in the signiture, then it's a sub the type can call with .&…
+        # If the type matches first item in the signature, then it's a sub the type can call with .&…
         when try { any(&::($method).candidates.map(-> $a {::($type-name) ~~ $a.signature.params.head.type}))} {
-             'non-method-sub'
+             'non-method'
          }
         "doesn't-exist"
     },
-    :into( my %over-documented = doesn't-exist => [], non-local => [], non-method-sub => [] )
-);
+    :into( my %over-documented = doesn't-exist => [], non-local => [], non-method => [] ));
 
-   (Pod6.new(:$type-name,
-              :$path,
-              :$local-methods,
-              uncheckable-methods => $uncheckable-methods.Set,
-              :%over-documented,
-              under-documented => Map.new((:$missing-header, :$missing-signature))),)
+    (file => Map.new((:$type-name, :$path)),
+     methods => Map.new(( local            => $local-methods,
+                          uncheckable      => $uncheckable-methods.Set,
+                          under-documented => Map.new((:$missing-header, :$missing-signature)),
+                          :%over-documented, ))),
+}
+
+# Formats reports for individual Types (displayed with --report)
+class Report {
+    our sub fmt-skipped(:%file (:$type-name, :$path, *%)) {
+        "\n∅ {$type-name} – documented at  ⟨{$path.IO}⟩\n  Skipped as uncheckable\n"
+    }
+
+    our proto fmt(|) {*}
+
+    multi fmt(:$uncheckable) {
+        ( if $uncheckable {
+            "{+$uncheckable} uncheckable method:\n".&pluralize('method').indent(2)
+            ~ ($uncheckable.keys.sort.join("\n").indent(4) ~ "\n")})
+    }
+
+    multi fmt(:%over-documented) {
+        my (:@non-local, :@non-method, :@doesn't-exist) := %over-documented;
+        ~( if @non-local {
+             ("{+@non-local} non-local method with documentation:\n").&pluralize('method').indent(2)
+             ~ @non-local.sort.join("\n").indent(4) ~ "\n"})
+        ~( if @non-method {
+             ("{+@non-method} non-method with documentation:\n").&pluralize('non-method').indent(2)
+             ~ @non-method.sort.join("\n").indent(4) ~ "\n"})
+        ~( if @doesn't-exist {
+             ("{+@doesn't-exist} non-existing method with documentation:\n").&pluralize('method').indent(2)
+             ~ @doesn't-exist.sort.join("\n").indent(4) ~ "\n"})
+    }
+
+    multi fmt(:%under-documented) {
+        my (:%missing-header, :%missing-signature) := %under-documented;
+        ~ ( if +%missing-header {
+             "{+%missing-header} missing method:\n".&pluralize('method').indent(2)
+             ~ %missing-header.keys.sort.join("\n").indent(4) ~ "\n" })
+        ~ ( if %missing-signature {
+             ("{+%missing-signature} method without signature:\n"
+                 ).&pluralize('method').&pluralize('signature').indent(2)
+             ~ %missing-signature.keys.sort.join("\n").indent(4) ~ "\n"})
+    }
+
+    #| Appends an 's' to the provided $noun if the closest preceding number in $phrase is ≥ 2
+    sub pluralize(Str $phrase, Str $noun --> Str) {
+        $phrase ~~ /(\d+) \D* $noun/;
+        +$0 == 1 ?? $phrase !! $phrase.subst(/$noun/, $noun ~ 's')
+    }
 
 }
+
+#| Collects and formats summary statistics (displayed with --summary)
+class Summary {
+    has Map $!totals;
+    has Map $!under-documented;
+    has Map $!over-documented;
+
+    submethod BUILD() {
+        $!totals           := Map.new(( types                      => %(:0skip, :0pass, :0fail),
+                                        methods                    => %(:0skip, :0pass, :0under, :0over)));
+        $!under-documented := Map.new(( sums                       => %(:0missing-header, :0missing-signature),
+                                        missing-per-type           => BagHash.new(),
+                                        times-missing-by-method    => BagHash.new()));
+        $!over-documented  := Map.new(( sums                       => %(:0doesn't-exist, :0non-method, :0non-local),
+                                        missing-per-type           => BagHash.new(),
+                                        times-overdocked-by-method => BagHash.new()));
+    }
+
+    submethod count-uncheckable-type() { $!totals<types><skip>++ }
+
+    submethod fmt-header() {
+        q:to/EOF/
+         ##################
+         #    SUMMARY     #
+         ##################
+        EOF
+    }
+
+    submethod update-totals(:%local, :%uncheckable, :%under-documented, :%over-documented) {
+        %uncheckable ∪  |%under-documented.values ∪ |%over-documented.values
+                ?? $!totals<types><fail>++
+                !! $!totals<types><pass>++;
+
+        given $!totals<methods> {
+            .<skip>  += +%uncheckable;
+            .<under> += +%under-documented.values».List.flat;
+            .<over>  +=  +%over-documented.values».List.flat;
+            .<pass>  += +%local - ( %uncheckable
+                                    + %under-documented.values».List.flat
+                                    +  %over-documented.values».List.flat );
+        }
+    }
+
+    submethod fmt-totals() {
+        my (:%types, :%methods) := $!totals;
+        do { my $*checked  = %types<pass> + %types<fail>;
+             my $*detected = %types<skip> + $*checked;
+             qq:to/EOF/
+
+              Total types processed:
+              ======================
+              types detected:    $*detected
+              types checked:    {$*checked.&fmt-with-percent-of('detected')}
+              types skipped:    {%types<skip>.&fmt-with-percent-of('detected')}
+              problems found:   {%types<fail>.&fmt-with-percent-of('checked')}
+              no problems found:{%types<pass>.&fmt-with-percent-of('checked')}
+             EOF
+           } ~ do {
+            my $*checked  = %methods<pass> + %methods<over> + %methods<under>;
+            my $*detected = %methods<skip> + $*checked;
+            qq:to/EOF/
+
+             Total methods processed:
+             ========================
+             methods detected:  $*detected
+             methods checked:   {      $*checked.&fmt-with-percent-of('detected')}
+             methods skipped:   { %methods<skip>.&fmt-with-percent-of('detected')}
+             over-documented:   { %methods<over>.&fmt-with-percent-of('checked')}
+             under-documented:  {%methods<under>.&fmt-with-percent-of('checked')}
+             no problems found: { %methods<pass>.&fmt-with-percent-of('checked')}
+            EOF
+        }
+    }
+
+    submethod update-under-documented(:%under-documented, :%file (:$type-name, *%)) {
+        $!under-documented<missing-per-type>{$type-name} += +%under-documented<missing-header>;
+        $!under-documented<sums><missing-signature>      += +%under-documented<missing-signature>;
+        for %under-documented<missing-header>.keys -> $method {
+            $!under-documented<sums><missing-header>++;
+            $!under-documented<times-missing-by-method>.add($method)};
+    }
+
+    submethod fmt-under-documented() {
+        my (:%sums, :%times-missing-by-method, :%missing-per-type) := $!under-documented;
+        my $*total = %sums<missing-header> + %sums<missing-signature>;
+        my $top-missing = %times-missing-by-method.grep(*.value ≥ $missing_method_threshold).cache;
+        my $top-types = %missing-per-type.sort(*.value).tail($most_missing_list_length).cache;
+
+        qq:to/EOF/
+
+         UNDER-DOCUMENTED:
+         #################
+
+         (Potentially) under-documented methods:
+         =======================================
+         total under documented:    $*total
+         missing methods:           {%sums<missing-header>.&fmt-with-percent-of('total')}
+         methods with no signature: {%sums<missing-signature>.&fmt-with-percent-of('total')}
+        EOF
+        ~ (if $top-missing {
+                  ~ "\nMethods missing from 20+ types:\n".indent(1)
+                  ~   "===============================\n".indent(1)
+                  ~ self!fmt-top-methods( $top-missing)
+              })
+        ~ (if $top-types.elems {
+                  ~ "\nTypes with the most missing methods:\n"
+                  ~   "====================================\n"
+                  ~ $top-types.map({ sprintf(" %-*s %-5d",
+                                             $top-types.&max-len, .key,
+                                             .value)}).join("\n") ~ "\n"})
+    }
+
+    submethod update-over-documented(:%over-documented, :%file (:$type-name, *%)) {
+        $!over-documented<sums>{.key}        += .value.elems for %over-documented.pairs;
+        $!over-documented<missing-per-type>{$type-name} += +%over-documented<doesn't-exist>;
+        for %over-documented<doesn't-exist>.values -> $method {
+            $!over-documented<times-overdocked-by-method>.add($method)};
+    }
+
+    submethod fmt-over-documented() {
+        my (:%sums, :%missing-per-type, :%times-overdocked-by-method) := $!over-documented;
+        my $*total = %sums<non-local> + %sums<non-method> + %sums<doesn't-exist>;
+        my $top-types = %missing-per-type.sort(*.value).tail($most_overdocked_list_length).cache;
+        my $top-overdocked = %times-overdocked-by-method.grep(*.value ≥ $overdocked_method_threshold).cache;
+        qq:to/EOF/
+
+         OVER-DOCUMENTED:
+         ################
+
+         Total over-documented methods:
+         ==============================
+         total over documented:     $*total
+         non-local methods:        {%sums<non-local>.&fmt-with-percent-of('total')}
+         non-method routines:      {%sums<non-method>.&fmt-with-percent-of('total')}
+         non-existent methods:     {%sums<doesn't-exist>.&fmt-with-percent-of('total')}
+        EOF
+        ~ (if $top-overdocked {
+                  ~ "\nOverdocumented methods in 20+ types:\n".indent(1)
+                  ~   "===============================\n".indent(1)
+                  ~ self!fmt-top-methods($top-overdocked)
+              })
+        ~ (if $top-types.elems ≥ 3 {
+                  "\n"
+                  ~ "Types with the most over-documented methods:\n".indent(1)
+                  ~ "============================================\n".indent(1)
+                  ~ ($top-types.map({ sprintf(" %-*s %-5d\n",
+                                              $top-types.&max-len, .key,
+                                              .value)}).join)})
+    }
+
+    submethod !fmt-top-methods($top-methods) {
+                  ~ $top-methods.sort(*.value).map({ sprintf(" %-*s    %d",
+                                                             $top-methods.&max-len, .key,
+                                                             .value)}).join("\n") ~ "\n"
+                  ~ ('-' x ($top-methods.&max-len + 7)).indent(1) ~ "\n"
+                  ~ "TOTAL".indent($top-methods.&max-len - 1)
+                  ~ $top-methods.map(*.value).sum.&fmt-with-percent-of('total') ~ "\n"
+    }
+
+    #| Returns the length of the longest key in a list of pairs
+    sub max-len(List $pairs --> Int) { $pairs.max(*.key.chars).key.chars }
+
+    #| Dynamically format a number as both a raw number and a percent of a dynamic variable
+    sub fmt-with-percent-of($num, $name) { # pretty hacky, should be a macro once Raku-AST lands
+        sprintf("%4d (%4.1f%% of $name)", $num, 100 × $num/(CALLER::OUTER::("\$*$name") || 1))
+    }
+
+}
+
+#| Parses a Pod6 document and returns all methods mentioned in a header or given a signature
+grammar MethodDoc {
+    # TODO consider splitting this into two `build`
+    token TOP { [<in-header>  | <with-signature>]
+                { with $<in-header><method>      { make (in-header      => ~$_) }
+                  with $<with-signature><method> { make (with-signature => ~$_) }}}
+
+    token with-signature { <ws> ['multi' <ws>]? <keyword> <ws> <method> '(' .* }
+    token in-header      { '=head' \d? <ws> <keyword> <ws> <method> }
+    token keyword        { ['method' | 'routine'] }
+    token method         { <[-'\w]>+ }
+}
+
 
 #| Provide dynamic usage info, including default values assigned in MAIN
 sub USAGE() {
@@ -163,7 +379,7 @@ sub USAGE() {
     }
 }
 
-#| Provide error messages that inform the user what unsupported paramater they passed
+#| Provide error messages that inform the user what unsupported parameter they passed
 sub GENERATE-USAGE(&main, |capture) {
     my $last-invalid; my $cap = capture;
     while $cap !~~ &main.signature {
@@ -177,201 +393,4 @@ sub GENERATE-USAGE(&main, |capture) {
          default             { "Invalid option '{$last-invalid.key}={$last-invalid.value}'" }
     })
     ~ "\nUse ./{$*PROGRAM.relative} --help for usage info"
-}
-
-#| Helper sub to dynamically format a number as both a raw number and
-#| as a percent of a dynamic variable
-sub fmt-with-percent-of($num, $name) { # pretty hacky, should be a macro once Raku-AST lands
-    sprintf("%4d (%4.1f%% of $name)", $num, 100 × $num/CALLER::OUTER::("\$*$name"))
-}
-
-#| Helper sub that returns the length of the longest key in a list of pairs
-sub max-len(List $pairs --> Int) { $pairs.max(*.key.chars).key.chars }
-
-#| Appends an 's' to the provided $noun if the closest preceding number in $phrase is ≥ 2
-sub pluralize(Str $phrase, Str $noun --> Str) {
-    $phrase ~~ /(\d+) \D* $noun/;
-    +$0 == 1 ?? $phrase !! $phrase.subst(/$noun/, $noun ~ 's')
-}
-
-multi fmt-report(:$uncheckable) {  "{+$uncheckable} uncheckable method:\n".&pluralize('method').indent(2)
-                                   ~ ($uncheckable.join("\n").indent(4) ~ "\n")
-}
-
-multi fmt-report(:%over-documented) {
-    my (:@non-local, :@non-method-sub, :@doesn't-exist) := %over-documented;
-    ~( if @non-local {
-         ("{+@non-local} non-local method with documentation:\n").&pluralize('method').indent(2)
-         ~ @non-local.sort.join("\n").indent(4) ~ "\n"})
-    ~( if @non-method-sub {
-         ("{+@non-method-sub} non-method with documentation:\n").&pluralize('non-method').indent(2)
-         ~ @non-method-sub.sort.join("\n").indent(4) ~ "\n"})
-    ~( if @doesn't-exist {
-         ("{+@doesn't-exist} non-existing method with documentation:\n").&pluralize('method').indent(2)
-         ~ @doesn't-exist.sort.join("\n").indent(4) ~ "\n"})
-}
-
-multi fmt-report(:%under-documented) {
-    my (:%missing-header, :%missing-signature) := %under-documented;
-    ~ ( if +%missing-header {
-         "{+%missing-header} missing method:\n".&pluralize('method').indent(2)
-         ~ %missing-header.keys.sort.join("\n").indent(4) ~ "\n" })
-    ~ ( if %missing-signature {
-         ("{+%missing-signature} method without signature:\n"
-             ).&pluralize('method').&pluralize('signature').indent(2)
-         ~ %missing-signature.keys.sort.join("\n").indent(4) ~ "\n"})
-}
-
-
-#| Manages the collection and formatting of summary statistics (displayed with --summary)
-class Summary {
-    has Map $!totals;
-    has Map $!under-documented;
-    has Map $!over-documented;
-
-    submethod BUILD() {
-        $!totals           := Map.new(( types   => %(:0skip, :0pass, :0fail),
-                                        methods => %(:0skip, :0pass, :0under, :0over)));
-        $!under-documented := Map.new(( sums    => %(:0doesn't-exist, :0non-method-sub, :0non-local),
-                                        types   => BagHash.new(),
-                                        methods => BagHash.new()));
-        $!over-documented  := Map.new(( sums    => %(:0doesn't-exist, :0non-method-sub, :0non-local),
-                                        types   => BagHash.new()));
-    }
-
-    submethod count-uncheckable-type() { $!totals<types><skip>++ }
-
-    submethod fmt-header() {
-        q:to/EOF/
-         ##################
-         #    SUMMARY     #
-         ##################
-        EOF
-    }
-
-    submethod fmt-totals() {
-        my (:%types, :%methods) := $!totals;
-        do { my $*checked  = %types<pass> + %types<fail>;
-             my $*detected = %types<skip> + $*checked;
-             qq:to/EOF/
-
-              Total types processed:
-              ======================
-              types detected:    $*detected
-              types checked:    {$*checked.&fmt-with-percent-of('detected')}
-              types skipped:    {%types<skip>.&fmt-with-percent-of('detected')}
-              problems found:   {%types<fail>.&fmt-with-percent-of('checked')}
-              no problems found:{%types<pass>.&fmt-with-percent-of('checked')}
-             EOF
-           } ~ do {
-            my $*checked  = %methods<pass> + %methods<over> + %methods<under>;
-            my $*detected = %methods<skip> + $*checked;
-            qq:to/EOF/
-
-             Total methods processed:
-             ========================
-             methods detected:  $*detected
-             methods checked:   {$*checked.&fmt-with-percent-of('detected')}
-             methods skipped:   {%methods<skip>.&fmt-with-percent-of('detected')}
-             over-documented:   {%methods<over>.&fmt-with-percent-of('checked')}
-             under-documented:  {%methods<under>.&fmt-with-percent-of('checked')}
-             no problems found: {%methods<pass>.&fmt-with-percent-of('checked')}
-            EOF
-        }
-    }
-
-    submethod fmt-under-documented() {
-        my (:%sums, :%methods, :%types) := $!under-documented;
-        my $*total = %sums<missing-header> + %sums<missing-signature>;
-        my $top-missing = %methods.grep(*.value ≥ 20).cache;
-        my $top-types = %types.sort(*.value).tail(5).cache;
-        qq:to/EOF/
-
-         UNDER-DOCUMENTED:
-         #################
-
-         (Potentially) under-documented methods:
-         =======================================
-         total under documented:    $*total
-         missing methods:           {%sums<missing-header>.&fmt-with-percent-of('total')}
-         methods with no signature: {%sums<missing-signature>.&fmt-with-percent-of('total')}
-        EOF
-        ~ (if $top-missing {
-                  "\n"
-                  ~ "Methods missing from 20+ types:\n".indent(1)
-                  ~ "===============================\n".indent(1)
-                  ~ $top-missing.sort(*.value).map({ sprintf(" %-*s    %d",
-                                                             $top-missing.&max-len, .key,
-                                                             .value)}).join("\n") ~ "\n"
-                  ~ ('-' x ($top-missing.&max-len + 7)).indent(1) ~ "\n"
-                  ~ "TOTAL".indent($top-missing.&max-len - 1)
-                  ~ $top-missing.map(*.value).sum.&fmt-with-percent-of('total') ~ "\n"
-              })
-        ~ (if $top-types.elems ≥ 3 {
-                  "\n"
-                  ~ " Types with the most missing methods:\n"
-                  ~ " ====================================\n"
-                  ~ $top-types.map({ sprintf(" %-*s %-5d",
-                                             $top-types.&max-len, .key,
-                                             .value)}).join("\n") ~ "\n"})
-    }
-
-    submethod fmt-over-documented() {
-        my (:%sums, :%types) := $!over-documented;
-        my $*total = %sums<non-local> + %sums<non-method-sub> + %sums<doesn't-exist>;
-        my $top-types = %types.sort(*.value).tail(5).cache;
-        qq:to/EOF/
-
-         OVER-DOCUMENTED:
-         ################
-
-         Total over-documented methods:
-         ==============================
-         total over documented:     $*total
-         non-local methods:        {%sums<non-local>.&fmt-with-percent-of('total')}
-         non-method routines:      {%sums<non-method-sub>.&fmt-with-percent-of('total')}
-         non-existent methods:     {%sums<doesn't-exist>.&fmt-with-percent-of('total')}
-        EOF
-        ~ (if $top-types.elems ≥ 3 {
-                  "\n"
-                  ~ "Types with the most over-documented methods:\n".indent(1)
-                  ~ "============================================\n".indent(1)
-                  ~ ($top-types.map({ sprintf(" %-*s %-5d\n",
-                                              $top-types.&max-len, .key,
-                                              .value)}).join)})
-    }
-
-    submethod update-totals(:%local-methods, :%uncheckable-methods, :%under-documented, :%over-documented) {
-        %uncheckable-methods ∪  |%under-documented.values ∪ |%over-documented.values
-                ?? $!totals<types><fail>++
-                !! $!totals<types><pass>++;
-        my $under-count = +.<missing-header> + .<missing-signature>  with %under-documented;
-        my $over-count  = +.<non-local> + .<non-method-sub> + .<doesn't-exist> with %over-documented;
-        $!totals<methods><skip>  += +%uncheckable-methods;
-        $!totals<methods><under> += $under-count;
-        $!totals<methods><over>  += $over-count;
-        $!totals<methods><pass>  += +%local-methods - (%uncheckable-methods + $under-count + $over-count)
-    }
-
-    submethod update-under-documented(:%under-documented, :$type-name) {
-        $!under-documented<sums>{.key} += .value.elems for %under-documented.pairs;
-        $!under-documented<methods>.add($_)         for %under-documented<missing-header>.keys;
-        $!under-documented<types>{$type-name}    += %under-documented<missing-header>.elems;
-    }
-
-    submethod update-over-documented(:%over-documented, :$type-name) {
-        $!over-documented<sums>{.key}                += .value.elems for %over-documented.pairs;
-        $!over-documented<types>{$type-name}  += %over-documented<doesn't-exist>.elems;
-    }
-}
-
-grammar MethodDoc {
-    token TOP { [<in-header>  | <with-signature>]
-                { with $<in-header><method>      { make (in-header      => ~$_) }
-                  with $<with-signature><method> { make (with-signature => ~$_) }}}
-
-    token with-signature { <ws> ['multi' <ws>]? <keyword> <ws> <method> '(' .* }
-    token in-header      { '=head' \d? <ws> <keyword> <ws> <method> }
-    token keyword        { ['method' | 'routine'] }
-    token method         { <[-'\w]>+ }
 }

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -13,6 +13,8 @@ grammar MethodDoc {
     token method         { <[-'\w]>+ }
 }
 
+# TODO: Reorder subs
+
 enum Summary <yes no only>;
 #| Scan a pod6 file or directory of pod6 files for over- and under-documented methods
 sub MAIN(
@@ -23,26 +25,21 @@ sub MAIN(
     :i(:$ignore) = './util/ignored-methods.txt' #= Path to file with methods to skip
 ) {
     # TODO: Comment
-    my %summary = %{
-        totals => %{ :0checked-types, :0unchecked-types, :0checked-methods, :0unchecked-methods },
-        under-documented => %{ sums => BagHash.new(), types => BagHash.new(), methods => BagHash.new() },
-        over-documented  => %{ sums => BagHash.new(), types => BagHash.new() },
-    }
+    my %summary  := Map.new(%{
+        totals => Map.new(%(:0checked-types, :0unchecked-types, :0checked-methods, :0unchecked-methods )),
+        under-documented => Map.new((sums => BagHash.new(), types => BagHash.new(), methods => BagHash.new())),
+        over-documented  => Map.new((sums => BagHash.new(), types => BagHash.new()))
+    });
 
     my $output = $(process($src, EVALFILE($ignore), $exclude)).map( {
         when .<uncheckable>.so {
             %summary<totals><unchecked-types>++;
-            "✗ {.<type-name>} – documented at  ⟨{.<path>.IO}⟩\nSkipped as uncheckable\n";
+            # TODO: Better '?'
+            "⍰ {.<type-name>} – documented at  ⟨{.<path>.IO}⟩\nSkipped as uncheckable\n";
         }
-        %summary<totals><checked-types>++;
-        %summary<totals><checked-methods> += .<local-methods>.elems;
-        %summary<totals><unchecked-methods> += .<uncheckable-method>.elems;
-        %summary<under-documented><sums>{.key} += .value.elems for .<under-documented>.pairs;
-        %summary<over-documented><sums>{.key}  += .value.elems for .<over-documented>.pairs ;
-        %summary<under-documented><methods>.add($_)            for .<under-documented><missing-header>.keys;
-        %summary<under-documented><types>{.<type-name>} += .<under-documented><missing-header>.elems;
-        %summary<over-documented><types>{.<type-name>}  += .<over-documented><doesn't-exist>.elems;
+       %summary.&insert-data($_);
 
+        # TODO: implement $display CSV
         (.<uncheckable-method> ∪  |.<under-documented>.values ∪ |.<over-documented>.values ?? "✗ " !! "✔ ")
          ~ "{.<type-name>} – documented at ⟨{.<path>.IO}⟩\n"
          ~ fmt-uncheckable-methods(.<uncheckable>)
@@ -60,8 +57,23 @@ sub MAIN(
     }
 }
 
+sub insert-data(%summary, $data) {
+    given $data {
+        %summary<totals><checked-types>++;
+        %summary<totals><checked-methods> += .<local-methods>.elems;
+        %summary<totals><unchecked-methods> += .<uncheckable-method>.elems;
+        %summary<under-documented><sums>{.key} += .value.elems for .<under-documented>.pairs;
+        %summary<over-documented><sums>{.key}  += .value.elems for .<over-documented>.pairs ;
+        %summary<under-documented><methods>.add($_)            for .<under-documented><missing-header>.keys;
+        %summary<under-documented><types>{.<type-name>} += .<under-documented><missing-header>.elems;
+        %summary<over-documented><types>{.<type-name>}  += .<over-documented><doesn't-exist>.elems;
+    }
+}
+
+
 sub USAGE() {
     my &fmt-param = { $^a ~ (' ' x (20 - $^a.chars) ~ $^b.WHY ~ (with $^b.default { " [default: {.()}]"})) }
+    # TODO: add info about meaning of output for over- and under-documented methods.
     say qq:to/EOF/
       Usage: $*PROGRAM-NAME [OPTION]... [SRC]
       {&MAIN.WHY}
@@ -101,11 +113,17 @@ my &fmt-under-documented-methods = {
              ).&pluralize('method').&pluralize('signature').indent(2)
          ~ .<missing-signature>.keys.sort.join("\n").indent(4) ~ "\n"})
 }
+
 my &fmt-over-documented-methods = {
     ~( if .<non-local> {
-         ("{+.<non-local>} non-local method with documentation:\n"
-             ).&pluralize('method').indent(2)
-         ~ .<non-local>.sort.join("\n").indent(4) ~ "\n"});
+         ("{+.<non-local>} non-local method with documentation:\n").&pluralize('method').indent(2)
+         ~ .<non-local>.sort.join("\n").indent(4) ~ "\n"})
+    ~( if .<non-method-sub> {
+         ("{+.<non-method-sub>} non-method with documentation:\n").&pluralize('non-method').indent(2)
+         ~ .<non-method-sub>.sort.join("\n").indent(4) ~ "\n"})
+    ~( if .<doesn't-exist> {
+         ("{+.<doesn't-exist>} non-existing method with documentation:\n").&pluralize('method').indent(2)
+         ~ .<doesn't-exist>.sort.join("\n").indent(4) ~ "\n"})
 }
 
 sub fmt-totals-summary(:$checked-types, :$unchecked-types, :$checked-methods, :$unchecked-methods --> Str) {
@@ -134,28 +152,31 @@ sub fmt-under-documented-summary(:%sums, :%methods, :%types) {
          ==========================================
          missing methods:           {%sums<missing-header>}
          methods with no signature: {%sums<missing-signature>}
-
-         {if $top-missing {
-                   "Methods missing from 20+ types:\n"
-                 ~ " ===============================\n"
-                 ~ $top-missing.sort(*.value).map({ sprintf(" %-*s    %d",
-                                                            $top-missing.&max-len, .key,
-                                                            .value)}).join("\n")
-                 ~ sprintf("\n %s\n   %*s  %d\n",
-                           '-' x ($top-missing.&max-len + 7),
-                           $top-missing.&max-len, "TOTAL",
-                           $top-missing.map(*.value).sum) }}
-         Types with the most missing methods:
-         ====================================
-        {$top-types.map({ sprintf(" %-*s %-5d",
-                                  $top-types.&max-len, .key,
-                                  .value)}).join("\n")}
         EOF
+    ~ (if $top-missing {
+             "\n"
+           ~ "Methods missing from 20+ types:\n".indent(1)
+           ~ "===============================\n".indent(1)
+           ~ $top-missing.sort(*.value).map({ sprintf(" %-*s    %d",
+                                                      $top-missing.&max-len, .key,
+                                                      .value)}).join("\n")
+           ~ sprintf("\n %s\n   %*s  %d",
+                     '-' x ($top-missing.&max-len + 7),
+                     $top-missing.&max-len, "TOTAL",
+                     $top-missing.map(*.value).sum) })
+    ~ (if $top-types.elems ≥ 3 {
+             "\n"
+           ~ " Types with the most missing methods:\n"
+           ~ " ====================================\n"
+           ~ $top-types.map({ sprintf(" %-*s %-5d",
+                                      $top-types.&max-len, .key,
+                                      .value)}).join("\n")})
 }
 
 sub fmt-over-documented-summary(:%sums, :%types) {
     my $top-types = %types.sort(*.value).tail(5).cache;
     qq:to/EOF/
+
          OVER-DOCUMENTED:
          ################
 
@@ -164,30 +185,31 @@ sub fmt-over-documented-summary(:%sums, :%types) {
          non-local methods:         {%sums<non-local>}
          non-method routines:       {%sums<non-method-sub>}
          non-existent methods:      {%sums<doesn't-exist>}
-
-         Types with the most over-documented methods:
-         ============================================
-        {$top-types.map({ sprintf(" %-*s %-5d\n",
-                                   $top-types.&max-len, .key,
-                                   .value)}).join}
         EOF
+     ~ (if $top-types.elems ≥ 3 {
+              "\n"
+            ~ "Types with the most over-documented methods:\n".indent(1)
+            ~ "============================================\n".indent(1)
+            ~ ($top-types.map({ sprintf(" %-*s %-5d\n",
+                                        $top-types.&max-len, .key,
+                                        .value)}).join)})
 }
 
-
-multi process($path where {.IO ~~ :d}, %ignored, $exclude) {
+multi process($path where {.IO ~~ :d}, %ignored, $exclude --> List) {
     |(lazy $path.dir
                ==> grep({ .basename ~~ none($exclude.split(',')».trim) })
-               ==> map({ process($^next-path, %ignored, $exclude)}))
+               ==> map({ |process($^next-path, %ignored, $exclude)}))
 }
 
-multi process($path, %ignored, $ --> Hash) {
+multi process($path, %ignored, $ --> List) {
+    # TODO: error if cannot do vvvvv
     my $type-name = (S/.*'doc/Type/'(.*)'.pod6'/$0/).subst(:g, '/', '::') with $path;
 
     try { ::($type-name).raku;
           ::($type-name).HOW.raku;
           ::($type-name).^methods;
           # if we're at a low enough level that this amount of introspection fails, skip the type
-          CATCH { default { return %( uncheckable => True, :$type-name, path => $path)}}
+          CATCH { default { return (%( uncheckable => True, :$type-name, path => $path), )}}
     }
 
     my %uncheckable-method = SetHash.new();
@@ -198,6 +220,8 @@ multi process($path, %ignored, $ --> Hash) {
         CATCH { default { %uncheckable-method{~$method.name}++ unless $method.name eq '<anon>' } }
         try { $method.package.isa($type-name) } // $method.package ~~ ::($type-name)
     })».name).Set (-) %ignored{$type-name};
+
+    # TODO: add support for %ignored<GLOBAL> ^^^^^
 
     my ($in-header, $with-signature) = [Z] $path.IO.lines.map({ MethodDoc.parse($_).made}).grep({.elems == 2});
 
@@ -212,8 +236,8 @@ multi process($path, %ignored, $ --> Hash) {
          }
         "doesn't-exist"
     });
-    %( :$type-name, :$path, :$local-methods, :%uncheckable-method, :%over-documented,
-       under-documented => %{:%missing-header, :%missing-signature} )
+    (    %( :$type-name, :$path, :$local-methods, :%uncheckable-method, :%over-documented,
+       under-documented => %{:%missing-header, :%missing-signature} ),)
 }
 
 sub max-len($pair-list --> Int) { $pair-list.max(*.key.chars).key.chars }

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -414,14 +414,13 @@ class Summary {
 
 #| Parses a Pod6 document and returns all methods mentioned in a header or given a signature
 grammar MethodDoc {
-    token TOP { | [<in-header>     { make (in-header      => ~$<in-header><method>) }
-                | <with-signature> { make (with-signature => ~$<with-signature><method>) } ]}
+    token TOP { <doc-line> { make $<doc-line>.made }}
 
-    token with-signature { <ws> ['multi' <ws>]? <keyword> <ws> <method> '(' .+ }
-    token in-header      { '=head' \d? <ws> <keyword> <ws> <method> }
-    token keyword        { ['method' | 'routine'] }
-    ## TODO use `sym` to simplify
-    token method         { <[-'\w]>+ }
+    proto rule doc-line          {*}
+    rule doc-line:sym<signature> { <.ws>['multi' ]?<keyword> <method>'('.+ { make (with-signature => ~$<method>)}}
+    rule doc-line:sym<in-header> { '=head'\d? <keyword> <method>           { make (in-header => ~$<method>)}}
+    token keyword                                                          { ['method' | 'routine'] }
+    token method                                                           { <[-'\w]>+ }
 }
 
 

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -58,12 +58,10 @@ sub MAIN($source-path = './doc/Type/', Str :$exclude = ".git", :$ignore = 'util/
         .IO.dir(test => exclude)».&?BLOCK when .IO.d
     }
 
-    my $prefix-length = $source-path.ends-with('.pod6') ?? ($source-path.chars - $source-path.IO.basename.chars) !! $source-path.chars;
-
     # lazy list of (type-name, IO::PATH)
     my \types := gather for type-pod-files».IO {
-        my $file-path = .substr($prefix-length);
-        my $type-name = $file-path.chop(5).subst(:g, '/', '::');
+        my $file-path = S/.*'doc/'['Type'|'Language'](.*)'.pod6'/$0/;
+        my $type-name = $file-path.subst(:g, '/', '::');
 
         take ($type-name, .IO)
     }

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -15,104 +15,27 @@ grammar MethodDoc {
 
 # TODO: Reorder subs
 
-enum Summary <yes no only>;
-#| Scan a pod6 file or directory of pod6 files for over- and under-documented methods
-sub MAIN(
-    IO(Str) $src          = './doc/Type/',      #= Path to the file or directory to check
-    Str :e(:$exclude)     = ".git",             #= Comma-separated list of files/directories to ignore
-    Str :report(:$r)      = 'all',              #= Comma-separated list of documentation types to display
-    Summary :s(:$summary) = yes,                #= Whether to display summary statistics
-    :i(:$ignore) = './util/ignored-methods.txt' #= Path to file with methods to skip
-) {
-    my $report = any(|$r.split(',')».trim);
-    my $allowed-report-types = <over under skip pass fail all none>;
-    when ($report ∉ $allowed-report-types).so {
-        say "Invalid --report.  Please provide a comma-seperated list of one or more of "
-          ~ $allowed-report-types.head(*-1).join(', ') ~ ", or " ~  $allowed-report-types.tail;
-    }
-    # TODO: Comment
-    my %summary  := Map.new(%{
-        totals => Map.new(%(:0checked-types, :0unchecked-types, :0checked-methods, :0unchecked-methods )),
-        under-documented => Map.new((sums => BagHash.new(), types => BagHash.new(), methods => BagHash.new())),
-        over-documented  => Map.new((sums => BagHash.new(), types => BagHash.new()))
-    });
-
-    my $output = $(process($src, EVALFILE($ignore), $exclude)).map( {
-        when .<uncheckable>.so {
-            %summary<totals><unchecked-types>++;
-            (if $report ~~ ('all' | 'skip') {
-                    "\n∅ {.<type-name>} – documented at  ⟨{.<path>.IO}⟩\n  Skipped as uncheckable\n" });
-        }
-        %summary<totals>.&update-totals($_);
-        %summary<under-documented>.&update-under-documented($_);
-        %summary<over-documented>.&update-over-documented($_);
-
-        # TODO: implement $display CSV
-        my $status = (.<uncheckable-method> ∪  |.<under-documented>.values ∪ |.<over-documented>.values
-                      ?? '✗'
-                      !! '✔');
-
-        (if (($report ~~ 'all' | 'pass')  && $status eq '✔')
-         || (($report ~~ 'all' | 'skip')  && ?.<uncheckable-method>)
-         || (($report ~~ 'all' | 'under') && ?.<under-documented>.values)
-         || (($report ~~ 'all' | 'over')  && ?.<over-documented>.values) {
-          "\n$status {.<type-name>} – documented at ⟨{.<path>.IO}⟩\n"
-         })
-
-         ~ (if $report ~~ ('all' | 'skip')  { fmt-uncheckable-methods(.<uncheckable>)})
-         ~ (if $report ~~ ('all' | 'under') { fmt-under-documented-methods(.<under-documented>)})
-         ~ (if $report ~~ ('all' | 'over')  { fmt-over-documented-methods(.<over-documented>)})
-    });
-    for $output[] {
-        if $summary ~~ (yes | no) { .print }
-    }
-
-    if $summary ~~ (yes | only) {
-        say fmt-totals-summary(|%summary<totals>);
-        say fmt-under-documented-summary(|%summary<under-documented>);
-        say fmt-over-documented-summary(|%summary<over-documented>);
-    }
-}
-
-sub update-totals(%totals, $data) {
-    given $data {
-        %totals<checked-types>++;
-        %totals<checked-methods> += .<local-methods>.elems;
-        %totals<unchecked-methods> += .<uncheckable-method>.elems;
-    }
-}
-
-sub update-under-documented(%under-documented, $data) {
-    given $data {
-        %under-documented<sums>{.key} += .value.elems for .<under-documented>.pairs;
-        %under-documented<methods>.add($_)            for .<under-documented><missing-header>.keys;
-        %under-documented<types>{.<type-name>} += .<under-documented><missing-header>.elems;
-    }
-}
-
-sub update-over-documented(%over-documented, $data) {
-    given $data {
-        %over-documented<sums>{.key}  += .value.elems for .<over-documented>.pairs ;
-        %over-documented<types>{.<type-name>}  += .<over-documented><doesn't-exist>.elems;
-    }
-}
-
-
 sub USAGE() {
     my &fmt-param = { $^a ~ (' ' x (20 - $^a.chars) ~ $^b.WHY ~ (with $^b.default { " [default: {.()}]"})) }
     # TODO: add info about meaning of output for over- and under-documented methods.
-    say qq:to/EOF/
-      Usage: $*PROGRAM-NAME [OPTION]... [SRC]
-      {&MAIN.WHY}
 
-      ARGS:
-        { &MAIN.signature.params.grep(!*.named).map({ fmt-param(.name.substr(1).uc, $_) }).join("\n")}
-
-      OPTIONS:
-        { &MAIN.signature.params.grep(*.named).map({
+    print do given &MAIN.signature.params {
+      "Usage: ./{$*PROGRAM.relative} [OPTION]... [SRC]\n"
+      ~ "{&MAIN.WHY}\n\n"
+      ~ (with .grep(!*.named) {
+          "ARGS:\n"
+          ~ .map({ fmt-param(.name.substr(1).uc, $_) }).join("\n").indent(2) ~ "\n\n"})
+      ~ (with .grep({.named && .type ~~ Bool}) {
+          "FLAGS:\n"
+          ~ .map({
               fmt-param(.named_names.sort(*.chars).map({'-' x ++$ ~ $_}).join(', '), $_);
-          }).join("\n  ")}
-
+             }).join("\n  ").indent(2) ~ "\n\n"})
+      ~ (with .grep({.named && .type !~~ Bool}) {
+                "OPTIONS:\n"
+                ~ .map({
+              fmt-param(.named_names.sort(*.chars).map({'-' x ++$ ~ $_}).join(', '), $_);
+          }).join("\n").indent(2) ~ "\n\n"})
+      ~ qq:to/EOF/
       By default, this script displays a large amount of information for each type it
       analyzes: all methods potentially missing documentation, all methods that are
       potentially over-documented, and all types that were skipped (typically because
@@ -124,6 +47,107 @@ sub USAGE() {
       analyzed.  To omit this summary info, use `--summary=no`; to display *only* this
       summary info (that is, to hide all type-level info) use `--summary=only`
       EOF
+    }
+}
+
+subset ReportCsv  of Str:D where *.split(',')».trim ⊆ <over under skip pass fail all none>;
+subset SummaryCsv of Str:D where *.split(',')».trim ⊆ <totals over under all none yes>;
+
+multi GENERATE-USAGE(&main, |capture) {
+    my $last-invalid; my $cap = capture;
+    while $cap !~~ &main.signature {
+        $last-invalid = $cap.pairs.tail;
+        $cap = $cap.hash ?? \(|$cap.list, |$cap.hash.head(*-1).hash )
+                         !! \(|$cap.list.head(*-1).list);
+    }
+    (given $last-invalid {
+         when .key ~~ Int    { "Unrecongnized positional argument '{$last-invalid.value}'" }
+         when .value ~~ Bool { "Unrecongnized flag '{$last-invalid.key}'" }
+         default             { "Invalid option '{$last-invalid.key}={$last-invalid.value}'" }
+    })
+    ~ "\nUse ./{$*PROGRAM.relative} --help for usage info"
+}
+
+#| Scan a pod6 file or directory of pod6 files for over- and under-documented methods
+sub MAIN(
+    IO(Str) $src             = './doc/Type/',     #= Path to the file or directory to check
+    Str :e(:$exclude)        = ".git",            #= Comma-separated list of files/directories to ignore
+    ReportCsv :r(:$report)   = 'all',             #= Comma-separated list of documentation types to display
+    SummaryCsv :s(:$summary) = 'all',             #= Whether to display summary statistics
+    Bool :h(:$help),                              #= Display this message and exit
+    :i(:$ignore) = './util/ignored-methods.txt'   #= Path to file with methods to skip
+) {
+    when $help { USAGE }
+    my $report-items  = any(|$report.split(',')».trim);
+    my $summary-items = any(|$summary.split(',')».trim);
+
+    # TODO: Comment
+    my %summary  :=
+        Map.new(%{
+            totals           => Map.new(( types   => %(:0skip, :0pass, :0fail),
+                                          methods => %(:0skip, :0pass, :0under, :0over))),
+            under-documented => Map.new(( sums    => %(:0doesn't-exist, :0non-method-sub, :0non-local),
+                                          types   => BagHash.new(),
+                                          methods => BagHash.new())),
+            over-documented  => Map.new(( sums    => %(:0doesn't-exist, :0non-method-sub, :0non-local),
+                                          types   => BagHash.new()))
+    });
+
+    my $output = $(process($src, EVALFILE($ignore), $exclude)).map( {
+        when .<uncheckable>.so {
+            %summary<totals><types><skip>++;
+            (if $report-items ~~ ('all' | 'skip') {
+                    "\n∅ {.<type-name>} – documented at  ⟨{.<path>.IO}⟩\n  Skipped as uncheckable\n" });
+        }
+        %summary<totals>.&update-totals($_);
+        %summary<under-documented>.&update-under-documented($_);
+        %summary<over-documented>.&update-over-documented($_);
+
+        my $status = (.<uncheckable-method> ∪  |.<under-documented>.values ∪ |.<over-documented>.values
+                      ?? '✗'
+                      !! '✔');
+
+        (if (($report-items ~~ 'all' | 'pass')  && $status eq '✔')
+         || (($report-items ~~ 'all' | 'skip')  && ?.<uncheckable-method>)
+         || (($report-items ~~ 'all' | 'under') && ?.<under-documented>.values)
+         || (($report-items ~~ 'all' | 'over')  && ?.<over-documented>.values) {
+          "\n$status {.<type-name>} – documented at ⟨{.<path>.IO}⟩\n"
+         })
+
+         ~ (if $report-items ~~ ('all' | 'skip')  { fmt-uncheckable-methods(.<uncheckable>)})
+         ~ (if $report-items ~~ ('all' | 'under') { fmt-under-documented-methods(.<under-documented>)})
+         ~ (if $report-items ~~ ('all' | 'over')  { fmt-over-documented-methods(.<over-documented>)})
+    });
+    for $output[] { .print }
+
+    if $summary-items !~~ 'none'          { print fmt-summary-header; }
+    if $summary-items ~~ 'all' | 'totals' { print fmt-totals-summary(|%summary<totals>) };
+    if $summary-items ~~ 'all' | 'under'  { print fmt-under-documented-summary(|%summary<under-documented>) };
+    if $summary-items ~~ 'all' | 'over'   { print fmt-over-documented-summary(|%summary<over-documented>) };
+}
+
+
+sub update-totals(%totals, $data) { given $data {
+    .<uncheckable-method> ∪  |.<under-documented>.values ∪ |.<over-documented>.values
+                      ?? %totals<types><fail>++
+                      !! %totals<types><pass>++;
+    my $under-count = +.<missing-header> + .<missing-signature>  with .<under-documented>;
+    my $over-count  = +.<non-local> + .<non-method-sub> + .<doesn't-exist> with .<over-documented>;
+    %totals<methods><skip>  += +.<uncheckable-method>;
+    %totals<methods><under> += $under-count;
+    %totals<methods><over>  += $over-count;
+    %totals<methods><pass>  += +.<local-methods> - (.<uncheckable-method> + $under-count + $over-count)
+}}
+
+sub update-under-documented(%under-documented, $data) {
+    %under-documented<sums>{.key} += .value.elems for $data.<under-documented>.pairs;
+    %under-documented<methods>.add($data)         for $data.<under-documented><missing-header>.keys;
+    %under-documented<types>{$data.<type-name>}    += $data.<under-documented><missing-header>.elems;
+}
+
+sub update-over-documented(%over-documented, $data) {
+    %over-documented<sums>{.key}                += .value.elems for $data.<over-documented>.pairs;
+    %over-documented<types>{$data.<type-name>}  += $data.<over-documented><doesn't-exist>.elems;
 }
 
 my &fmt-uncheckable-methods = {
@@ -153,32 +177,65 @@ my &fmt-over-documented-methods = {
          ~ .<doesn't-exist>.sort.join("\n").indent(4) ~ "\n"})
 }
 
-sub fmt-totals-summary(:$checked-types, :$unchecked-types, :$checked-methods, :$unchecked-methods --> Str) {
-    qq:to/EOF/
-         ##################
-         #    SUMMARY     #
-         ##################
 
-         Total types/methods processed:
-         ==============================
-         types checked:   $checked-types
-         types skipped:   $unchecked-types
-         methods checked: $checked-methods
-         methods skipped: $unchecked-methods
+
+sub fmt-with-percent-of($num, $name) { # pretty hacky, should be a macro once Raku-AST lands
+    sprintf("%4d (%4.1f%% of $name)", $num, 100 × $num/CALLER::OUTER::("\$*$name"))
+}
+
+sub fmt-summary-header() {
+    q:to/EOF/
+        ##################
+        #    SUMMARY     #
+        ##################
+       EOF
+}
+
+sub fmt-totals-summary(:%types, :%methods --> Str) {
+    do { my $*checked  = %types<pass> + %types<fail>;
+         my $*detected = %types<skip> + $*checked;
+         qq:to/EOF/
+
+         Total types processed:
+         ======================
+         types detected:    $*detected
+         types checked:    {$*checked.&fmt-with-percent-of('detected')}
+         types skipped:    {%types<skip>.&fmt-with-percent-of('detected')}
+         problems found:   {%types<fail>.&fmt-with-percent-of('checked')}
+         no problems found:{%types<pass>.&fmt-with-percent-of('checked')}
         EOF
+    } ~ do {
+        my $*checked  = %methods<pass> + %methods<over> + %methods<under>;
+        my $*detected = %methods<skip> + $*checked;
+        qq:to/EOF/
+
+         Total methods processed:
+         ========================
+         methods detected:  $*detected
+         methods checked:   {$*checked.&fmt-with-percent-of('detected')}
+         methods skipped:   {%methods<skip>.&fmt-with-percent-of('detected')}
+         over-documented:   {%methods<over>.&fmt-with-percent-of('checked')}
+         under-documented:  {%methods<under>.&fmt-with-percent-of('checked')}
+         no problems found: {%methods<pass>.&fmt-with-percent-of('checked')}
+        EOF
+    }
+
 }
 
 sub fmt-under-documented-summary(:%sums, :%methods, :%types) {
+    my $*total = %sums<missing-header> + %sums<missing-signature>;
     my $top-missing = %methods.grep(*.value ≥ 20).cache;
     my $top-types = %types.sort(*.value).tail(5).cache;
     qq:to/EOF/
+
          UNDER-DOCUMENTED:
          #################
 
-         Total (potentially) missing documentation:
-         ==========================================
-         missing methods:           {%sums<missing-header>}
-         methods with no signature: {%sums<missing-signature>}
+         (Potentially) under-documented methods:
+         =======================================
+         total under documented:    $*total
+         missing methods:           {%sums<missing-header>.&fmt-with-percent-of('total')}
+         methods with no signature: {%sums<missing-signature>.&fmt-with-percent-of('total')}
         EOF
     ~ (if $top-missing {
              "\n"
@@ -197,10 +254,11 @@ sub fmt-under-documented-summary(:%sums, :%methods, :%types) {
            ~ " ====================================\n"
            ~ $top-types.map({ sprintf(" %-*s %-5d",
                                       $top-types.&max-len, .key,
-                                      .value)}).join("\n")})
+                                      .value)}).join("\n") ~ "\n"})
 }
 
 sub fmt-over-documented-summary(:%sums, :%types) {
+    my $*total = %sums<non-local> + %sums<non-method-sub> + %sums<doesn't-exist>;
     my $top-types = %types.sort(*.value).tail(5).cache;
     qq:to/EOF/
 
@@ -209,9 +267,10 @@ sub fmt-over-documented-summary(:%sums, :%types) {
 
          Total over-documented methods:
          ==============================
-         non-local methods:         {%sums<non-local>}
-         non-method routines:       {%sums<non-method-sub>}
-         non-existent methods:      {%sums<doesn't-exist>}
+         total over documented:     $*total
+         non-local methods:         {%sums<non-local>.&fmt-with-percent-of('total')}
+         non-method routines:       {%sums<non-method-sub>.&fmt-with-percent-of('total')}
+         non-existent methods:      {%sums<doesn't-exist>.&fmt-with-percent-of('total')}
         EOF
      ~ (if $top-types.elems ≥ 3 {
               "\n"
@@ -254,7 +313,7 @@ multi process($path, %ignored, $ --> List) {
 
     my %missing-header    = $local-methods (-) $in-header;
     my %missing-signature = $local-methods (-) $with-signature (-) %missing-header;
-    my %over-documented  = ($in-header (-) $local-methods (-) Set.new('', Any)).keys.classify(-> $method {
+    ($in-header (-) $local-methods (-) Set.new('', Any)).keys.classify(-> $method {
         # if ^find_method finds it, it's *somewhere* in the inheritance graph, just not local
         when try {::($type-name).^find_method($method).defined} { 'non-local' }
         # If the type matches first item in the signiture, then it's a sub the type can call with .&…
@@ -262,9 +321,11 @@ multi process($path, %ignored, $ --> List) {
              'non-method-sub'
          }
         "doesn't-exist"
-    });
-    (    %( :$type-name, :$path, :$local-methods, :%uncheckable-method, :%over-documented,
-       under-documented => %{:%missing-header, :%missing-signature} ),)
+    },
+    :into( my %over-documented = doesn't-exist => [], non-local => [], non-method-sub => [] )
+);
+    (%( :$type-name, :$path, :$local-methods, :%uncheckable-method, :%over-documented,
+        under-documented => %{:%missing-header, :%missing-signature} ),)
 }
 
 sub max-len($pair-list --> Int) { $pair-list.max(*.key.chars).key.chars }

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -35,18 +35,19 @@ sub MAIN(
         say (+.<errors> || +.<missing-header> || +.<missing-signature> ?? "✗ " !! "✔ ")
         ~ "{.<name>} – documented at ⟨{.<path>.IO}⟩\n"
         ~ ( if +.<errors> {
-                  "{+.<errors>} methods couldn't be checked:\n".indent(2)
+                  "{+.<errors>} uncheckable method:\n".&pluralize('method').indent(2)
                   ~ .<errors>.join("\n").indent(4) ~ "\n" })
         ~ ( if +.<missing-header> {
-                  "{+.<missing-header>} methods were missing:\n".indent(2)
+                  "{+.<missing-header>} missing method:\n".&pluralize('method').indent(2)
                   ~ .<missing-header>.keys.sort.join("\n").indent(4) ~ "\n" })
         ~ ( if .<missing-signature> {
-                  "{+.<missing-signature>} methods lacked signatures:\n".indent(2)
+                  ("{+.<missing-signature>} method without signature:\n"
+                      ).&pluralize('method').&pluralize('signature').indent(2)
                   ~ .<missing-signature>.keys.sort.join("\n").indent(4) ~ "\n"});
     };
 
     say qq:to/EOF/;
-         Summary of missing types: 
+         Summary of missing types:
         ===========================
          UNCHECKABLE types:   {%total<uncheckable>}
          UNCHECKABLE methods: {%total<errors>}
@@ -107,3 +108,8 @@ multi process($path, %ignored, $ --> Hash) {
 }
 
 sub max-len($pair-list --> Int) { $pair-list.max(*.key.chars).key.chars }
+
+#| Appends an 's' to the provided $noun if the closest preceeding number in $phrase is ≥ 2
+sub pluralize(Str $phrase, Str $noun --> Str) {
+    $phrase ~~ /(\d+) \D* $noun/;
+    +$0 == 1 ?? $phrase !! $phrase.subst(/$noun/, $noun ~ 's') }

--- a/util/list-missing-methods.p6
+++ b/util/list-missing-methods.p6
@@ -19,67 +19,129 @@ sub MAIN(
     Str :$exclude = ".git",                 #= Comma-seperated list of files/directories to ignore (default: .git)
     :$ignore = './util/ignored-methods.txt' #= Path to file with methods to ignore (default ./util/ignored-methods.txt)
 ) {
-    my %total is BagHash; my %missing-methods is BagHash; my %missing-methods-per-type is BagHash;
-    for $(process($source-path, EVALFILE($ignore), $exclude)) { my $a = $_;
+    # TODO: Comment
+    my %summary = %{
+        totals => %{ :0checked-types, :0unchecked-types, :0checked-methods, :0unchecked-methods },
+        under-documented => %{ sums => BagHash.new(), types => BagHash.new(), methods => BagHash.new() },
+        over-documented  => %{ sums => BagHash.new(), types => BagHash.new() },
+    }
+
+    my $output = $(process($source-path, EVALFILE($ignore), $exclude)).map( {
         when .<uncheckable>.so {
-            %total.add('uncheckable') for ^.<uncheckable>;
-            say "✗ {.<name>} – documented at  ⟨{.<path>.IO}⟩\n"
-            ~ "Skipped as uncheckable\n"; }
+            %summary<totals><unchecked-types>++;
+            "✗ {.<type-name>} – documented at  ⟨{.<path>.IO}⟩\nSkipped as uncheckable\n";
+        }
+        %summary<totals><checked-types>++;
+        %summary<totals><checked-methods> += .<local-methods>.elems;
+        %summary<totals><unchecked-methods> += .<uncheckable-method>.elems;
 
-        %total.add('errors') for ^+.<errors>;
-        %total.add('missing-header') for ^+.<missing-header>;
-        %total.add('phantom-method') for ^+.<phantom-method>;
-        %missing-methods-per-type.add($a.<name>) for ^+.<missing-header>;
-        for .<missing-header>.keys { %missing-methods.add($_)};
-        %total.add('missing-signature') for ^+.<missing-signature>;
+        for .<under-documented>.pairs { %summary<under-documented><sums>{.key}+= .value.elems };
+        for .<over-documented>.pairs {  %summary<over-documented><sums>{.key} += .value.elems };
+        %summary<under-documented><types>{.<type-name>} += .<under-documented><missing-header>.elems;
+        %summary<over-documented><types>{.<type-name>}  += .<over-documented><doesn't-exist>.elems;
+        for .<under-documented><missing-header>.keys { %summary<under-documented><methods>.add($_)};
 
-        say (+.<errors> || +.<missing-header> || +.<missing-signature> ?? "✗ " !! "✔ ")
-        ~ "{.<name>} – documented at ⟨{.<path>.IO}⟩\n"
-        ~ ( if +.<errors> {
-                  "{+.<errors>} uncheckable method:\n".&pluralize('method').indent(2)
-                  ~ .<errors>.join("\n").indent(4) ~ "\n" })
-        ~ ( if +.<missing-header> {
-                  "{+.<missing-header>} missing method:\n".&pluralize('method').indent(2)
-                  ~ .<missing-header>.keys.sort.join("\n").indent(4) ~ "\n" })
-        ~ ( if .<missing-signature> {
-                  ("{+.<missing-signature>} method without signature:\n"
-                      ).&pluralize('method').&pluralize('signature').indent(2)
-                  ~ .<missing-signature>.keys.sort.join("\n").indent(4) ~ "\n"})
-        ~ ( if .<phantom-method> {
-                  ("{+.<phantom-method>} non-local method with documentation:\n"
-                      ).&pluralize('method').indent(2)
-                  ~ .<phantom-method>.keys.sort.join("\n").indent(4) ~ "\n"});
-    };
+        (.<uncheckable-method> ∪  |.<under-documented>.values ∪ |.<over-documented>.values ?? "✗ " !! "✔ ")
+         ~ "{.<type-name>} – documented at ⟨{.<path>.IO}⟩\n"
+         ~ fmt-uncheckable-methods(.<uncheckable>)
+         ~ fmt-under-documented-methods(.<under-documented>)
+         ~ fmt-over-documented-methods(.<over-documented>)
+    });
 
-    say qq:to/EOF/;
-         Summary of missing types:
-        ===========================
-         UNCHECKABLE types:   {%total<uncheckable>}
-         UNCHECKABLE methods: {%total<errors>}
-         MISSING methods:     {%total<missing-header>}
-         SIGNATURE errors:    {%total<missing-signature>}
-         NON-LOCAL methods:   {%total<phantom-method>}
+    .say for $output[];
+    say fmt-totals-summary(|%summary<totals>);
+    say fmt-under-documented-summary(|%summary<under-documented>);
+    say fmt-over-documented-summary(|%summary<over-documented>);
+}
+
+my &fmt-uncheckable-methods = {
+    ~ ( if $_ {  "{+$_} uncheckable method:\n".&pluralize('method').indent(2)
+                 ~ ($_.join("\n").indent(4) ~ "\n") } )
+}
+
+my &fmt-under-documented-methods = {
+    ~ ( if +.<missing-header> {
+         "{+.<missing-header>} missing method:\n".&pluralize('method').indent(2)
+         ~ .<missing-header>.keys.sort.join("\n").indent(4) ~ "\n" })
+    ~ ( if .<missing-signature> {
+         ("{+.<missing-signature>} method without signature:\n"
+             ).&pluralize('method').&pluralize('signature').indent(2)
+         ~ .<missing-signature>.keys.sort.join("\n").indent(4) ~ "\n"})
+}
+my &fmt-over-documented-methods = {
+    ~( if .<non-local> {
+         ("{+.<non-local>} non-local method with documentation:\n"
+             ).&pluralize('method').indent(2)
+         ~ .<non-local>.sort.join("\n").indent(4) ~ "\n"});
+}
+
+sub fmt-totals-summary(:$checked-types, :$unchecked-types, :$checked-methods, :$unchecked-methods --> Str) {
+    qq:to/EOF/
+
+
+         ##################
+         #    SUMMARY     #
+         ##################
+
+         Total types/methods processed:
+         ==============================
+         types checked:   $checked-types
+         types skipped:   $unchecked-types
+         methods checked: $checked-methods
+         methods skipped: $unchecked-methods
         EOF
+}
 
-    my $top-missing = %missing-methods.grep(*.value ≥ 10).cache;
+sub fmt-under-documented-summary(:%sums, :%methods, :%types) {
+    my $top-missing = %methods.grep(*.value ≥ 20).cache;
+    my $top-types = %types.sort(*.value).tail(5).cache;
+    qq:to/EOF/
 
-    if $top-missing {
-       say " Methods missing from 10+ types: \n"
-          ~"=================================\n"
-          ~ $top-missing.sort(*.value).map({ sprintf(" %-*s    %d\n",
-                                                     $top-missing.&max-len, .key,
-                                                     .value)}).join
-          ~ sprintf("%s\n   %*s  %d\n",
-                    '-' x ($top-missing.&max-len + 8),
-                    $top-missing.&max-len, "TOTAL",
-                    $top-missing.map(*.value).sum) };
+         UNDER-DOCUMENTED:
+         #################
 
-    my $top-types = %missing-methods-per-type.sort(*.value).tail(10).cache;
-    say " Types with the most missing methods: \n"
-       ~"======================================\n"
-       ~ $top-types.map({ sprintf(" %-*s %-5d\n",
-                                  $top-types.max(*.key.chars).key.chars, .key,
-                                  .value)}).join;
+         Total (potentially) missing documentation:
+         ==========================================
+         missing methods:           {%sums<missing-header>}
+         methods with no signature: {%sums<missing-signature>}
+
+         {if $top-missing {
+                   "Methods missing from 20+ types:\n"
+                 ~ " ===============================\n"
+                 ~ $top-missing.sort(*.value).map({ sprintf(" %-*s    %d",
+                                                            $top-missing.&max-len, .key,
+                                                            .value)}).join("\n")
+                 ~ sprintf("\n %s\n   %*s  %d\n",
+                           '-' x ($top-missing.&max-len + 7),
+                           $top-missing.&max-len, "TOTAL",
+                           $top-missing.map(*.value).sum) }}
+         Types with the most missing methods:
+         ====================================
+        {$top-types.map({ sprintf(" %-*s %-5d",
+                                  $top-types.&max-len, .key,
+                                  .value)}).join("\n")}
+        EOF
+}
+
+sub fmt-over-documented-summary(:%sums, :%types) {
+    my $top-types = %types.sort(*.value).tail(5).cache;
+    qq:to/EOF/
+
+         OVER-DOCUMENTED:
+         ################
+
+         Total over-documented methods:
+         ==============================
+         non-local methods:         {%sums<non-local>}
+         non-method routines:       {%sums<non-method-sub>}
+         non-existant methods:      {%sums<doesn't-exist>}
+
+         Types with the most over-documented methods:
+         ============================================
+         {$top-types.map({ sprintf(" %-*s %-5d\n",
+                                   $top-types.&max-len, .key,
+                                   .value)}).join}
+         EOF
 }
 
 
@@ -91,21 +153,38 @@ multi process($path where {.IO ~~ :d}, %ignored, $exclude) {
 
 multi process($path, %ignored, $ --> Hash) {
     my $type-name = (S/.*'doc/Type/'(.*)'.pod6'/$0/).subst(:g, '/', '::') with $path;
-    when $type-name eq 'independent-routines' | 'Routine::WrapHandle' {
-        %( uncheckable => True, name => $type-name, path => $path )#`(TODO) }
-    CATCH { default { return %( uncheckable => True, name => $type-name, path => $path ) } }
-    my @errors =[];
-    my @real-methods = ::($type-name).^methods(:local).grep(-> $method {
-        # Some builtins don't support the introspection we need (e.g., NQPRoutine)
-        CATCH { default { @errors.push(~$method.name) unless $method.name eq '<anon>' } }
-        ($method.package eqv ::($type-name))
-    })».name;
-    my ($in-header, $with-signature) = [Z] $path.IO.lines.map({ MethodDoc.parse($_).made}).grep({.elems == 2});
-    my Set $missing-header      = @real-methods (-) %ignored{$type-name} (-) $in-header;
-    my Set $missing-signature   = @real-methods (-) %ignored{$type-name} (-) $with-signature (-) $missing-header;
-    my Set $phantom-method      = $in-header (-) @real-methods (-) Set.new('', Any);
 
-    %( name => $type-name, :$path, :@errors, :$missing-header, :$missing-signature, :$phantom-method )
+    try { ::($type-name).raku;
+          ::($type-name).HOW.raku;
+          ::($type-name).^methods;
+          # if we're at a low enough level that this amount of introspection fails, skip the type
+          CATCH { default { return %( uncheckable => True, :$type-name, path => $path)}}
+    }
+
+    my %uncheckable-method = SetHash.new();
+    # Confusingly, many methods returned by ^methods(:local) are *not* local, so we filter by packaged
+    my Set $local-methods = (::($type-name).^methods(:local).grep(-> $method {
+        # Some builtins don't support the introspection we need, mostly ones that call ForeignCode
+        # (which inclueds NQP methods).  ForeignCode methods typically have the name `<anon>`
+        CATCH { default { %uncheckable-method{~$method.name}++ unless $method.name eq '<anon>' } }
+        try { $method.package.isa($type-name) } // $method.package ~~ ::($type-name)
+    })».name).Set (-) %ignored{$type-name};
+
+    my ($in-header, $with-signature) = [Z] $path.IO.lines.map({ MethodDoc.parse($_).made}).grep({.elems == 2});
+
+    my %missing-header    = $local-methods (-) $in-header;
+    my %missing-signature = $local-methods (-) $with-signature (-) %missing-header;
+    my %over-documented  = ($in-header (-) $local-methods (-) Set.new('', Any)).keys.classify(-> $method {
+        # if ^find_method finds it, it's *somewhere* in the inheritance graph, just not local
+        when try {::($type-name).^find_method($method).defined} { 'non-local' }
+        # If the type matches first item in the signiture, then it's a sub the type can call with .&…
+        when try { any(&::($method).candidates.map(-> $a {::($type-name) ~~ $a.signature.params.head.type}))} {
+             'non-method-sub'
+         }
+        "doesn't-exist"
+    });
+    %( :$type-name, :$path, :$local-methods, :%uncheckable-method, :%over-documented,
+       under-documented => %{:%missing-header, :%missing-signature} )
 }
 
 sub max-len($pair-list --> Int) { $pair-list.max(*.key.chars).key.chars }


### PR DESCRIPTION
This PR grew significantly as I was working on it.  A while ago, I opened #3529, and said that I would add the ability to detect methods that exist in the doc but that have been removed from Raku and "address several minor issues" with the script.  Somehow, that's not quite what ended up happening.

Now, 48 commits later, I have a significantly overhauled version of the script.  This version does significantly more to screen out false positives – specifically, there are many methods that the `.^methods(:local)` method (and the old script) consider to be local to a Type but that are actually implemented on a closely related Role.  The previous script listed these as methods missing documentation, even though they are properly documented on the Role.  Correcting this should make the script significantly more helpful for targeting our documentation efforts.

The new script also adds two new categories of information for each Type: over-documented methods that no longer exist in Raku (my original goal!) and methods without enough introspection to be able to tell, or where the introspection results appear to be inconsistent, which caused the false-positives issue described above.

I've also added the ability to print summary information for all scanned types, which should be useful both in keeping track of our overall progress and in targeting our efforts.  When run on the full `doc/Type` directory, this summary info shows that the script was able to check 3,522 methods.  Of these, 8% were over-documented, 57% were under-documented and 35% had no detected issues.

 That 35% number is perhaps artificially low, however, as additional summary info shows.  Of the under-documented methods, over a third come from methods that are missing from 20+ types.  These are not false positives – they really are implemented on the Type – but they may not be in need of documentation.  Examples include `gist`, `message`, `raku`, etc.  The previous version of the script included support for an `ignored-methods.txt` file that could ignore methods from specific types; I've expanded that feature to also allow ignoring methods from all types at once, and we may want to add many of these don't-need-to-be-documented methods to that file.  (I added `BUILD_ALL`, which was previously "missing" from 184 types but is clearly an implementation detail, but have mostly refrained from adding ignored methods because I didn't want to make that call without discussing the issue – although the script _does_ now allow specifying a location for the ignored-methods file, which would let us use more than one.)

I've also added several new CLI options for filtering or otherwise limiting output; please consult the `--help` message for detailed info.

The cost of all of this added functionality is that the script is now much larger – nearly 700 lines.  Many of those are comments, and much of the rest is devoted to the unavoidably verbose output/formatting; the script's core logic is only ~200 lines.  Nevertheless, I would normally split a program of this size up into multiple modules, and strongly considered doing so here (including for performance reasons).  However, I've kept this as a single file, at least for now.  That's how it was, and I didn't want to add sub-directories to the `docs/util` directory without a clear need.

Finally, I want to mention that this is the first non-trivial Raku program I've written and that I greatly appreciate all the help I got from kind people on the #raku IRC channel.  I ended up diving pretty deep into Raku's introspection abilities – as @lizmat put it when she was helping me with a particularly hairy bit, I got down to where the turtles are showing.  And that was quite a way to learn the language.  So thanks, all!  And I'm definitely open to any feedback others might have on this script.