### PR TITLE
Fix typo in SetHash.unset method

### DIFF
--- a/doc/Type/SetHash.pod6
+++ b/doc/Type/SetHash.pod6
@@ -185,10 +185,10 @@ Defined as:
 
     method unset(SetHash:D: \to-unset --> Nil)
 
-When given single key, C<set> removes it from the C<SetHash>.  When
+When given single key, C<unset> removes it from the C<SetHash>.  When
 given a C<List>, C<Array>, C<Seq>, or any other type that C<does> the
-L<C«Iterator»|/type/Iterator> Role, C<set> removes each element of the
-C<Iterator> from the C<SetHash> (if it was present as a key).
+L<C«Iterator»|/type/Iterator> Role, C<unset> removes each element of
+the C<Iterator> from the C<SetHash> (if it was present as a key).
 
 I<Note:> since version 2020.02.
 


### PR DESCRIPTION
The previous version of this file inadvertently refereed to the `unset` method as the `set` method.  This is now fixed.
