### PR TITLE
Make `make update-html` generate syntax highlighting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ html: for-documentable
 	documentable start -a -v --highlight
 
 update-html:
-	documentable update
+	documentable update --highlight
 
 init-highlights highlights/package-lock.json:
 	ATOMDIR="./highlights/atom-language-perl6";  \


### PR DESCRIPTION
This passes the `--highlight` flag to Documentable via the `update-html` target, which is consistent with how the `html` target 
invokes Documentable.

Closes #3586 