### PR TITLE
Remove gratuitous Perl mention from Tests

### DIFF
--- a/doc/Language/testing.pod6
+++ b/doc/Language/testing.pod6
@@ -29,7 +29,8 @@ ok check-name($meta, :$relaxed-name), "name has a hyphen rather than '::'" \
 
 =head1 Writing tests
 
-As with any Perl project, the tests live under the C<t> directory in the
+Although it is possible to orginize your tests differently, the typical 
+Raku convention is for tests to live under the C<t> directory in the
 project's base directory.
 
 A typical test file looks something like this:


### PR DESCRIPTION
The Test module previously included the language "as with any Perl project", which outdatedly implied that Raku projects are Perl projects.



