### PR TITLE
Provide a length hint for aspell

### DIFF
--- a/xt/pws/words.pws
+++ b/xt/pws/words.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 0 utf-8
+personal_ws-1.1 en 2172 utf-8
 abab
 ababab
 abcd


### PR DESCRIPTION
When looking into aspell for #3593, I discovered that the header in an aspell word list  can optionally have a hint about the length of the list.  Giving aspell this hint allows it to perform very slightly (but measurably) faster.  This appears to improve the speed of our spelling test by ~2%.  The hint does not need to be perfectly accurate to be helpful, so it won't be a problem if the hint isn't updated as contributors add more words to the aspell word list.

See [the relevant aspell docs](http://aspell.net/man-html/Format-of-the-Personal-and-Replacement-Dictionaries.html#Format-of-the-Personal-and-Replacement-Dictionaries).
