### PR TITLE
Restore epub and bigpage

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,7 @@
   "auth": "perl6",
   "depends": [
     "File::Temp",
-    "Pod::To::BigPage:ver<0.5.1+>",
+    "Pod::To::BigPage:ver<0.5.2+>",
     "Pod::To::HTML:ver<0.6.1+>",
     "Test::META",
     "Perl6::TypeGraph"

--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,6 @@
   "auth": "perl6",
   "depends": [
     "File::Temp",
-    "Pod::To::BigPage:ver<0.5.2+>",
     "Pod::To::HTML:ver<0.6.1+>",
     "Test::META",
     "Perl6::TypeGraph"

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help:
 	@echo "docker-testall:      run all tests (in container)"
 	@echo "docker-run:          run the development webserver (in container)"
 
-html: for-documentable bigpage
+html: for-documentable
 	documentable start -a -v --highlight
 
 update-html:

--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,19 @@ else
 SELINUX_OPT          :=
 endif
 
-.PHONY: html init-highlights assets \
+.PHONY: html init-highlights assets bigpage epub \
 	test xtest ctest help run clean-html clean-images \
 	clean-search clean test-links push \
 	clean-cache \
 	docker-image docker-test docker-xtest docker-ctest docker-testall docker-run
 
 help:
-	@echo "Usage: make [html|test|xtest|ctest]"
+	@echo "Usage: make [html|epub|bigpage|test|xtest|ctest]"
 	@echo ""
 	@echo "Options:"
 	@echo "   html:             generate the HTML documentation"
+	@echo "   epub:             generate EPUB documentation (html/raku.epub)"
+	@echo "bigpage:             generate HTML documentation in one large file (html/raku.html)"
 	@echo "   assets:           generate CSS/JS assets"
 	@echo "init-highlights:     install prereqs for highlights (runs as part of 'make html')"
 	@echo "   test:             run the test suite"
@@ -50,6 +52,12 @@ assets assets/assetpack.db:
 	./app.pl assets
 
 for-documentable: highlights/package-lock.json assets/assetpack.db
+
+bigpage:
+	pod2onepage --html -v --source-path=./doc --exclude=404.pod6 > html/raku.html
+
+epub: bigpage
+	pandoc html/raku.html -o raku.epub
 
 # Common tests that are run by travis with every commit
 test:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help:
 	@echo "docker-testall:      run all tests (in container)"
 	@echo "docker-run:          run the development webserver (in container)"
 
-html: for-documentable
+html: for-documentable bigpage
 	documentable start -a -v --highlight
 
 update-html:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,35 @@ based on Mojolicious using
 
 This will serve the documentation in port 3000.
 
+## Building the EPUB and/or the "single big page HTML" documentation
+
+The documentation can also be generated in the EPUB format as well as the
+"single big page HTML" format. Please note that some features (eg. inherited
+methods and type graph in the Types section, or syntax highlighting of the code
+examples) are not (yet) available in these formats.
+
+These are the prerequisites you need to install:
+
+* Pod::To::BigPage 0.5.2 or later
+* Pandoc (EPUB only)
+
+You can follow these instructions to install them on Ubuntu or Debian:
+
+    zef install "Pod::To::BigPage:ver<0.5.2+>"
+    sudo apt install pandoc     # only if you want to generate EPUB
+
+Now that you have the dependencies installed, clone this repository and
+generate the EPUB or "single big page HTML" documentation:
+
+    git clone https://github.com/Raku/doc.git # clone this repo
+    cd doc      # enter the cloned repo
+    make epub           # for the EPUB format,
+                        # for the "single big page HTML" format use `make bigpage` instead
+
+The generated EPUB output you will find in the `raku.epub` file in the root of
+the repository and the generated "single big page HTML" output in
+`html/raku.html`.
+
 ## nginx configuration
 
 Latest version of the generated documentation consists only of static

--- a/doc/HomePage.pod6
+++ b/doc/HomePage.pod6
@@ -3,7 +3,7 @@
 Welcome to the official documentation of the <a href="https://raku.org">Raku</a>
 programming language!
 Besides online browsing and searching, you can also
-<del><a href="/perl6.html">view everything in one file</a> or</del>(See <a href="https://github.com/Raku/doc/issues/1981">Raku/doc#1981</a>)
+<a href="/perl6.html">view everything in one file</a> or
 <a href="https://github.com/Raku/doc">contribute</a>
 by reporting issues or sending patches.
 

--- a/doc/HomePage.pod6
+++ b/doc/HomePage.pod6
@@ -3,7 +3,7 @@
 Welcome to the official documentation of the <a href="https://raku.org">Raku</a>
 programming language!
 Besides online browsing and searching, you can also
-<a href="/perl6.html">view everything in one file</a> or
+<a href="/raku.html">view everything in one file</a> or
 <a href="https://github.com/Raku/doc">contribute</a>
 by reporting issues or sending patches.
 


### PR DESCRIPTION
The Makefile targets for generating EPUB and "bigpage" (one-page HTML) were removed as they were broken. Now they may be restored - but only after (or if) https://github.com/perl6/perl6-pod-to-bigpage/pull/36 is merged & released.

This should solve #1981.


