### PR TITLE
Update method signatures to include *%_

### DIFF
--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -223,7 +223,7 @@ In the case of C<Associative>s, it will be applied to its values:
 
 Defined as:
 
-    method duckmap(&block) is rw is nodal
+    method duckmap(&block, *%_) is rw is nodal
 
 C<duckmap> will apply C<&block> on each element that behaves in such a way that
 C<&block> can be applied. If it fails, it will descend recursively if possible,
@@ -679,7 +679,7 @@ don't really have keys.
 
 Defined as:
 
-    method flatmap(&block, :$label)
+    method flatmap(&block, :$label, *%_)
 
 B<DEPRECATION NOTICE>: This method is deprecated in 6.d and will be removed in
 6.e. Use C<.map> followed by C<.flat> instead.
@@ -941,7 +941,7 @@ list containing an empty list or a list with a single element.
 
 Defined as
 
-    method join($separator = '') is nodal
+    method join($separator = '', *%_) is nodal
 
 Converts the object to a list by calling
 L<C<self.list>|/type/Any#routine_list>,

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -36,7 +36,7 @@ Many built-in types override this for more specific comparisons.
 
 Defined as:
 
-    method any(--> Junction:D)
+    method Any(Any: *%_ --> Junction:D)
 
 Interprets the invocant as a list and creates an
 L<any|/routine/any>-L<Junction|/type/Junction> from it.
@@ -48,7 +48,7 @@ L<any|/routine/any>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-    method all(--> Junction:D)
+    method Any(Any: *%_ --> Junction:D)
 
 Interprets the invocant as a list and creates an
 L<all|/routine/all>-L<Junction|/type/Junction> from it.
@@ -60,7 +60,7 @@ L<all|/routine/all>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-    method one(--> Junction:D)
+    method Any(Any: *%_ --> Junction:D)
 
 Interprets the invocant as a list and creates a
 L<one|/routine/one>-L<Junction|/type/Junction> from it.
@@ -72,7 +72,7 @@ L<one|/routine/one>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-    method none(--> Junction:D)
+    method Any(Any: *%_ --> Junction:D)
 
 Interprets the invocant as a list and creates a
 L<none|/routine/none>-L<Junction|/type/Junction> from it.
@@ -408,7 +408,7 @@ You can also use C<$> as item contextualizer.
 
 Defined as:
 
-    method Array(--> Array:D) is nodal
+    method Any(Any: *%_ --> Array:D) is nodal
 
 Coerces the invocant to an L<Array|/type/Array>.
 
@@ -416,7 +416,7 @@ Coerces the invocant to an L<Array|/type/Array>.
 
 Defined as:
 
-    method List(--> List:D) is nodal
+    method Any(Any: *%_ --> List:D) is nodal
 
 Coerces the invocant to L<List|/type/List>, using the L<list|/routine/list>
 method.
@@ -481,7 +481,7 @@ say %m.Hash;  # {a => 42, b => 666}
 
 Defined as:
 
-    method Slip(--> Slip:D) is nodal
+    method Any(Any: *%_ --> Slip:D) is nodal
 
 Coerces the invocant to L<Slip|/type/Slip>.
 
@@ -489,7 +489,7 @@ Coerces the invocant to L<Slip|/type/Slip>.
 
 Defined as:
 
-    method Map(--> Map:D) is nodal
+    method Any(Any: *%_ --> Map:D) is nodal
 
 Coerces the invocant to L<Map|/type/Map>.
 
@@ -497,7 +497,7 @@ Coerces the invocant to L<Map|/type/Map>.
 
 Defined as:
 
-    method Bag(--> Bag:D) is nodal
+    method Any(Any: *%_ --> Bag:D) is nodal
 
 Coerces the invocant to L<Bag|/type/Bag>, whereby
 L<Positionals|/type/Positional> are treated as lists of values.
@@ -506,7 +506,7 @@ L<Positionals|/type/Positional> are treated as lists of values.
 
 Defined as:
 
-    method BagHash(--> BagHash:D) is nodal
+    method Any(Any: *%_ --> BagHash:D) is nodal
 
 Coerces the invocant to L<BagHash|/type/BagHash>, whereby
 L<Positionals|/type/Positional> are treated as lists of values.
@@ -515,7 +515,7 @@ L<Positionals|/type/Positional> are treated as lists of values.
 
 Defined as:
 
-    method Set(--> Set:D) is nodal
+    method Any(Any: *%_ --> Set:D) is nodal
 
 Coerces the invocant to L<Set|/type/Set>, whereby L<Positionals|/type/Positional>
 are treated as lists of values.
@@ -524,7 +524,7 @@ are treated as lists of values.
 
 Defined as:
 
-    method SetHash(--> SetHash:D) is nodal
+    method Any(Any: *%_ --> SetHash:D) is nodal
 
 Coerces the invocant to L<SetHash|/type/SetHash>, whereby
 L<Positionals|/type/Positional> are treated as lists of values.
@@ -533,7 +533,7 @@ L<Positionals|/type/Positional> are treated as lists of values.
 
 Defined as:
 
-    method Mix(--> Mix:D) is nodal
+    method Any(Any: *%_ --> Mix:D) is nodal
 
 Coerces the invocant to L<Mix|/type/Mix>, whereby L<Positionals|/type/Positional>
 are treated as lists of values.
@@ -542,7 +542,7 @@ are treated as lists of values.
 
 Defined as:
 
-    method MixHash(--> MixHash:D) is nodal
+    method Any(Any: *%_ --> MixHash:D) is nodal
 
 Coerces the invocant to L<MixHash|/type/MixHash>, whereby
 L<Positionals|/type/Positional> are treated as lists of values.
@@ -551,7 +551,7 @@ L<Positionals|/type/Positional> are treated as lists of values.
 
 Defined as:
 
-    method Supply(--> Supply:D) is nodal
+    method Any(Any: *%_ --> Supply:D) is nodal
 
 First, it coerces the invocant to a C<list> by applying its
 L«C<.list>|/routine/list» method, and then to a L<Supply|/type/Supply>.
@@ -1343,7 +1343,7 @@ complex, multi-level, data structures.
 
 Defined as:
 
-    method nl-out(--> Str)
+    method Any(Any: *%_ --> Str)
 
 Returns C<Str> with the value of "\n". See
 L«C<IO::Handle.nl-out>|/type/IO::Handle#method_nl-out» for the

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -115,7 +115,7 @@ scalar in a list context by calling C<.list> and turning it into an C<Array>.
 
 Defined as:
 
-    method push(|values --> Positional:D)
+    method push(|values, *%_ --> Positional:D)
 
 The method push is defined for undefined invocants and allows for autovivifying
 undefined to an empty L<Array|/type/Array>, unless the undefined value
@@ -203,7 +203,7 @@ the C<Seq> will be iterating over its elements, calling C<.take> on them.
 
 Defined as:
 
-    method deepmap(&block --> List) is nodal
+    method deepmap(&block, *%_ --> List) is nodal
 
 C<deepmap> will apply C<&block> to each element and return a new
 L<List|/type/List> with the return values of C<&block>, unless the element does
@@ -267,7 +267,7 @@ the type of the item.
 
 Defined as:
 
-    method nodemap(&block --> List) is nodal
+    method nodemap(&block, *%_ --> List) is nodal
 
 C<nodemap> will apply C<&block> to each element and return a new
 L<List|/type/List> with the return values of C<&block>. In contrast to
@@ -1176,7 +1176,7 @@ In the case of C<Positional>s, the indices will be considered I<keys>.
 
 Defined as:
 
-    method toggle(Any:D: *@conditions where .all ~~ Callable:D, Bool :$off  --> Seq:D)
+    method toggle(Any:D: *@conditions where .all ~~ Callable:D, Bool :$off  *%_ --> Seq:D)
 
 L<Iterates|/routine/iterator> over the invocant, producing a L<Seq|/type/Seq>,
 toggling whether the received values are propagated to the result on and off,
@@ -1376,7 +1376,7 @@ element.
 
 Defined as:
 
-    method grep(Mu $matcher, :$k, :$kv, :$p, :$v --> Seq)
+    method grep(Mu $matcher, :$k, :$kv, :$p, :$v, *%_ --> Seq)
 
 Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -115,7 +115,7 @@ scalar in a list context by calling C<.list> and turning it into an C<Array>.
 
 Defined as:
 
-    method push(|values, *%_ --> Positional:D)
+    method push(Any:U \SELF: |values --> Positional:D)
 
 The method push is defined for undefined invocants and allows for autovivifying
 undefined to an empty L<Array|/type/Array>, unless the undefined value
@@ -203,7 +203,7 @@ the C<Seq> will be iterating over its elements, calling C<.take> on them.
 
 Defined as:
 
-    method deepmap(&block, *%_ --> List) is nodal
+    method deepmap(Any: &block, *%_ --> List) is nodal
 
 C<deepmap> will apply C<&block> to each element and return a new
 L<List|/type/List> with the return values of C<&block>, unless the element does
@@ -223,7 +223,7 @@ In the case of C<Associative>s, it will be applied to its values:
 
 Defined as:
 
-    method duckmap(&block, *%_) is rw is nodal
+    method duckmap(Any: &block, *%_) is rw is nodal
 
 C<duckmap> will apply C<&block> on each element that behaves in such a way that
 C<&block> can be applied. If it fails, it will descend recursively if possible,
@@ -267,7 +267,7 @@ the type of the item.
 
 Defined as:
 
-    method nodemap(&block, *%_ --> List) is nodal
+    method nodemap(Any: &block, *%_ --> List) is nodal
 
 C<nodemap> will apply C<&block> to each element and return a new
 L<List|/type/List> with the return values of C<&block>. In contrast to
@@ -679,7 +679,7 @@ don't really have keys.
 
 Defined as:
 
-    method flatmap(&block, :$label, *%_)
+    method flatmap(Any: &block, :$label, *%_)
 
 B<DEPRECATION NOTICE>: This method is deprecated in 6.d and will be removed in
 6.e. Use C<.map> followed by C<.flat> instead.
@@ -921,7 +921,7 @@ examples.
 
 Defined as:
 
-    method permutations(|c)
+    method permutations(Any: |c)
 
 Coerces the invocant to a C<list> by applying its
 L«C<.list>|/routine/list» method and uses
@@ -941,7 +941,7 @@ list containing an empty list or a list with a single element.
 
 Defined as
 
-    method join($separator = '', *%_) is nodal
+    method join(Any: $separator = '', *%_) is nodal
 
 Converts the object to a list by calling
 L<C<self.list>|/type/Any#routine_list>,
@@ -1357,7 +1357,7 @@ details.
 
 Defined as:
 
-    method combinations(|c)
+    method combinations(Any: |c)
 
 Coerces the invocant to a C<list> by applying its L«C<.list>|/routine/list»
 method and uses L«C<List.combinations>|/type/List#routine_combinations» on it.
@@ -1376,7 +1376,7 @@ element.
 
 Defined as:
 
-    method grep(Mu $matcher, :$k, :$kv, :$p, :$v, *%_ --> Seq)
+    method grep(Any: Mu $matcher, :$k, :$kv, :$p, :$v, *%_ --> Seq)
 
 Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -36,7 +36,7 @@ Many built-in types override this for more specific comparisons.
 
 Defined as:
 
-    method Any(Any: *%_ --> Junction:D)
+    method any(Any: *%_ --> Junction:D)
 
 Interprets the invocant as a list and creates an
 L<any|/routine/any>-L<Junction|/type/Junction> from it.
@@ -48,7 +48,7 @@ L<any|/routine/any>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-    method Any(Any: *%_ --> Junction:D)
+    method all(Any: *%_ --> Junction:D)
 
 Interprets the invocant as a list and creates an
 L<all|/routine/all>-L<Junction|/type/Junction> from it.
@@ -60,7 +60,7 @@ L<all|/routine/all>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-    method Any(Any: *%_ --> Junction:D)
+    method one(Any: *%_ --> Junction:D)
 
 Interprets the invocant as a list and creates a
 L<one|/routine/one>-L<Junction|/type/Junction> from it.
@@ -72,7 +72,7 @@ L<one|/routine/one>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-    method Any(Any: *%_ --> Junction:D)
+    method none(Any: *%_ --> Junction:D)
 
 Interprets the invocant as a list and creates a
 L<none|/routine/none>-L<Junction|/type/Junction> from it.
@@ -408,7 +408,7 @@ You can also use C<$> as item contextualizer.
 
 Defined as:
 
-    method Any(Any: *%_ --> Array:D) is nodal
+    method Array(Any: *%_ --> Array:D) is nodal
 
 Coerces the invocant to an L<Array|/type/Array>.
 
@@ -416,7 +416,7 @@ Coerces the invocant to an L<Array|/type/Array>.
 
 Defined as:
 
-    method Any(Any: *%_ --> List:D) is nodal
+    method List(Any: *%_ --> List:D) is nodal
 
 Coerces the invocant to L<List|/type/List>, using the L<list|/routine/list>
 method.
@@ -481,7 +481,7 @@ say %m.Hash;  # {a => 42, b => 666}
 
 Defined as:
 
-    method Any(Any: *%_ --> Slip:D) is nodal
+    method Slip(Any: *%_ --> Slip:D) is nodal
 
 Coerces the invocant to L<Slip|/type/Slip>.
 
@@ -489,7 +489,7 @@ Coerces the invocant to L<Slip|/type/Slip>.
 
 Defined as:
 
-    method Any(Any: *%_ --> Map:D) is nodal
+    method Map(Any: *%_ --> Map:D) is nodal
 
 Coerces the invocant to L<Map|/type/Map>.
 
@@ -497,7 +497,7 @@ Coerces the invocant to L<Map|/type/Map>.
 
 Defined as:
 
-    method Any(Any: *%_ --> Bag:D) is nodal
+    method Bag(Any: *%_ --> Bag:D) is nodal
 
 Coerces the invocant to L<Bag|/type/Bag>, whereby
 L<Positionals|/type/Positional> are treated as lists of values.
@@ -506,7 +506,7 @@ L<Positionals|/type/Positional> are treated as lists of values.
 
 Defined as:
 
-    method Any(Any: *%_ --> BagHash:D) is nodal
+    method BagHash(Any: *%_ --> BagHash:D) is nodal
 
 Coerces the invocant to L<BagHash|/type/BagHash>, whereby
 L<Positionals|/type/Positional> are treated as lists of values.
@@ -515,7 +515,7 @@ L<Positionals|/type/Positional> are treated as lists of values.
 
 Defined as:
 
-    method Any(Any: *%_ --> Set:D) is nodal
+    method Set(Any: *%_ --> Set:D) is nodal
 
 Coerces the invocant to L<Set|/type/Set>, whereby L<Positionals|/type/Positional>
 are treated as lists of values.
@@ -524,7 +524,7 @@ are treated as lists of values.
 
 Defined as:
 
-    method Any(Any: *%_ --> SetHash:D) is nodal
+    method as(Any: *%_ --> SetHash:D) is nodal
 
 Coerces the invocant to L<SetHash|/type/SetHash>, whereby
 L<Positionals|/type/Positional> are treated as lists of values.
@@ -533,7 +533,7 @@ L<Positionals|/type/Positional> are treated as lists of values.
 
 Defined as:
 
-    method Any(Any: *%_ --> Mix:D) is nodal
+    method Mix(Any: *%_ --> Mix:D) is nodal
 
 Coerces the invocant to L<Mix|/type/Mix>, whereby L<Positionals|/type/Positional>
 are treated as lists of values.
@@ -542,7 +542,7 @@ are treated as lists of values.
 
 Defined as:
 
-    method Any(Any: *%_ --> MixHash:D) is nodal
+    method MixHash(Any: *%_ --> MixHash:D) is nodal
 
 Coerces the invocant to L<MixHash|/type/MixHash>, whereby
 L<Positionals|/type/Positional> are treated as lists of values.
@@ -551,7 +551,7 @@ L<Positionals|/type/Positional> are treated as lists of values.
 
 Defined as:
 
-    method Any(Any: *%_ --> Supply:D) is nodal
+    method Supply(Any: *%_ --> Supply:D) is nodal
 
 First, it coerces the invocant to a C<list> by applying its
 L«C<.list>|/routine/list» method, and then to a L<Supply|/type/Supply>.
@@ -1176,7 +1176,7 @@ In the case of C<Positional>s, the indices will be considered I<keys>.
 
 Defined as:
 
-    method toggle(Any:D: *@conditions where .all ~~ Callable:D, Bool :$off  *%_ --> Seq:D)
+    method toggle(Any:D: *@conditions where .all ~~ Callable:D, Bool :$off, *%_ --> Seq:D)
 
 L<Iterates|/routine/iterator> over the invocant, producing a L<Seq|/type/Seq>,
 toggling whether the received values are propagated to the result on and off,
@@ -1343,7 +1343,7 @@ complex, multi-level, data structures.
 
 Defined as:
 
-    method Any(Any: *%_ --> Str)
+    method nl-out(Any: *%_ --> Str)
 
 Returns C<Str> with the value of "\n". See
 L«C<IO::Handle.nl-out>|/type/IO::Handle#method_nl-out» for the

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -300,7 +300,7 @@ When applied to C<Associative>s, it will act on the values:
 
 Defined as:
 
-    method flat() is nodal
+    method flat(Any: *%_) is nodal
 
 Interprets the invocant as a list, flattens
 L<non-containerized|/language/containers> L<Iterable|/type/Iterable>s into a
@@ -328,7 +328,7 @@ L<signature destructuring|/type/Signature#Destructuring_Parameters>
 
 Defined as:
 
-    method eager() is nodal
+    method eager(Any: *%_) is nodal
 
 Interprets the invocant as a L<List|/type/List>, evaluates it eagerly, and
 returns that L<List|/type/List>.
@@ -1422,7 +1422,7 @@ converted to a list otherwise.
 
 Defined as:
 
-    method collate()
+    method collate(Any: *%_)
 
 Collate sorts taking into account Unicode grapheme characteristics; that is,
 sorting more or less as one would expect instead of using the order in which
@@ -1459,7 +1459,7 @@ this method.
 
 Defined as:
 
-    method cache()
+    method cache(Any: *%_)
 
 Provides a L<List|/type/List> representation of the object itself, calling
 the method C<list> on the instance.
@@ -1526,7 +1526,7 @@ lists.
 
 Defined as:
 
-    method sum() is nodal
+    method sum(Any: *%_) is nodal
 
 If the content is iterable, it returns the sum of the values after pulling them
 one by one.

--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -105,7 +105,7 @@ Example:
 
 Defined as:
 
-    method elems(Array:D: --> Int:D)
+    method elems(Array:D: *%_ --> Int:D)
 
 Returns the number of elements in the invocant. Throws C<X::Cannot::Lazy>
 exception if the invocant L<is lazy|/routine/is-lazy>. For shaped arrays,
@@ -122,7 +122,7 @@ all dimensions.
 
 Defined as:
 
-    method clone(Array:D: --> Array:D)
+    method clone(Array:D: *%_ --> Array:D)
 
 Clones the original C<Array>. Modifications of elements in the clone
 are not propagated to the original and vice-versa:
@@ -349,7 +349,7 @@ returns C<(Mu)>.
 
 Defined as:
 
-    method dynamic(Array:D: --> Bool:D)
+    method dynamic(Array:D: *%_ --> Bool:D)
 
 Returns C<True> if the invocant has been declared with the L<is dynamic|/routine/is dynamic>
 trait, that is, if it's a dynamic variable that can be accessed from the

--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -290,7 +290,7 @@ it's large enough to have one:
 
 Defined as:
 
-    method shape() { (*,) }
+    method shape(Array: *%_) { (*,) }
 
 Returns the shape of the array as a list.
 

--- a/doc/Type/Associative.pod6
+++ b/doc/Type/Associative.pod6
@@ -37,7 +37,7 @@ will be syntactically correct.
 
 Defined as:
 
-    method of()
+    method of(Associative: *%_)
 
 C<Associative> is actually a
 L<parameterized role|/language/objects#Parameterized_roles>
@@ -59,7 +59,7 @@ particular classes:
 
 Defined as:
 
-    method keyof()
+    method keyof(Associative: *%_)
 
 Returns the parameterized key used for the Associative role, which is C<Any>
 coerced to C<Str> by default. This is the class used as second parameter when

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -228,7 +228,7 @@ Returns C<True> for attributes that have the "is rw" trait applied to them.
 
 Defined as:
 
-    method readonly(Attribute:D: --> Bool:D)
+    method readonly(Attribute:D: *%_ --> Bool:D)
 
 Returns C<True> for readonly attributes, which is the default, or C<False> for
 attributes marked as C<is rw>.

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -284,7 +284,7 @@ Returns the type constraint of the attribute.
 
 Defined as:
 
-    method get_value(Mu $obj)
+    method get_value(Mu $obj, *%_)
 
 Returns the value stored in this attribute of object C<$obj>.
 
@@ -301,7 +301,7 @@ used with care.  Here be dragons.
 
 Defined as:
 
-    method set_value(Mu $obj, Mu \new_val)
+    method set_value(Mu $obj, Mu \new_val, *%_)
 
 Binds the value C<new_val> to this attribute of object C<$obj>.
 

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -180,7 +180,7 @@ so if an attribute is declared as C<has $.a>, the name returned is C<$!a>.
 
 Defined as:
 
-    method package()
+    method package(Attribute: *%_)
 
 Returns the package (class/grammar/role) to which this attribute belongs.
 

--- a/doc/Type/Backtrace.pod6
+++ b/doc/Type/Backtrace.pod6
@@ -136,7 +136,7 @@ Returns a list of L<Backtrace::Frame|/type/Backtrace::Frame> objects for this ba
 
 Defined as:
 
-    method summary(Backtrace:D: --> Str:D)
+    method summary(Backtrace:D: *%_ --> Str:D)
 
 Returns a summary string representation of the backtrace, filtered
 by C<!.is-hidden && (.is-routine || !.is-setting)>.

--- a/doc/Type/Backtrace.pod6
+++ b/doc/Type/Backtrace.pod6
@@ -70,7 +70,7 @@ the implementation, also some routines from the setting.
 
 Defined as:
 
-    method next-interesting-index(Backtrace:D: Int $idx = 0, :$named, :$noproto, :$setting)
+    method next-interesting-index(Backtrace:D: Int $idx = 0, :$named, :$noproto, :$setting, *%_)
 
 Returns the index of the next C<interesting> frame, once hidden and other
 settings are taken into account. C<$named> will decide whether to printed only
@@ -87,7 +87,7 @@ say $!.backtrace.next-interesting-index( :named ); #  OUTPUT: «4␤»
 
 Defined as:
 
-     method outer-caller-idx(Backtrace:D: Int $startidx)
+    method outer-caller-idx(Backtrace:D: Int $startidx, *%_)
 
 Returns as a list the index of the frames that called the current one.
 
@@ -100,7 +100,7 @@ say $!.backtrace.outer-caller-idx( 4 ); # OUTPUT: «[6]␤»
 
 Defined as:
 
-    method nice(Backtrace:D: :$oneline)
+    method nice(Backtrace:D: :$oneline, *%_)
 
 Returns the backtrace as a list of I<interesting> frames. If C<:$oneline> is
 set, will stop after the first frame.

--- a/doc/Type/Backtrace.pod6
+++ b/doc/Type/Backtrace.pod6
@@ -160,7 +160,7 @@ in block <unit> at test.p6 line 3
 
 Defined as:
 
-    method concise(Backtrace:D:)
+    method concise(Backtrace:D: *%_)
 
 Returns a concise string representation of the backtrace, filtered
 by C<!.is-hidden && .is-routine && !.is-setting>.

--- a/doc/Type/Baggy.pod6
+++ b/doc/Type/Baggy.pod6
@@ -15,7 +15,7 @@ L<Mixy|/type/Mixy>.
 
 Defined as:
 
-    method new-from-pairs(*@pairs, *%_ --> Baggy:D)
+    method new-from-pairs(Baggy: *@pairs, *%_ --> Baggy:D)
 
 Constructs a Baggy objects from a list of L«C<Pair> objects|/type/Pair»
 given as positional arguments:

--- a/doc/Type/Baggy.pod6
+++ b/doc/Type/Baggy.pod6
@@ -15,7 +15,7 @@ L<Mixy|/type/Mixy>.
 
 Defined as:
 
-    method new-from-pairs(*@pairs --> Baggy:D)
+    method new-from-pairs(*@pairs, *%_ --> Baggy:D)
 
 Constructs a Baggy objects from a list of L«C<Pair> objects|/type/Pair»
 given as positional arguments:
@@ -328,7 +328,7 @@ Returns a C<Seq> of keys and values interleaved.
 
 Defined as:
 
-    method kxxv(Baggy:D: --> Seq:D)
+    method kxxv(Baggy:D: *%_ --> Seq:D)
 
 Returns a C<Seq> of the keys of the invocant, with each key multiplied by its
 weight. Note that C<kxxv> only works for C<Baggy> types which have integer
@@ -374,7 +374,7 @@ object.
 
 Defined as:
 
-    method default(Baggy:D: --> 0)
+    method default(Baggy:D: *%_ --> 0)
 
 Returns zero.
 

--- a/doc/Type/Blob.pod6
+++ b/doc/Type/Blob.pod6
@@ -69,7 +69,7 @@ Returns C<False> if and only if the buffer is empty.
 
 Defined as:
 
-    method Capture(Blob:D)
+    method Capture(Blob:D, *%_)
 
 Equivalent to calling L«C<.List.Capture>|/type/List#method_Capture»
 on the invocant.

--- a/doc/Type/Blob.pod6
+++ b/doc/Type/Blob.pod6
@@ -69,7 +69,7 @@ Returns C<False> if and only if the buffer is empty.
 
 Defined as:
 
-    method Capture(Blob:D, *%_)
+    method Capture(Blob:D: *%_)
 
 Equivalent to calling L«C<.List.Capture>|/type/List#method_Capture»
 on the invocant.

--- a/doc/Type/Blob.pod6
+++ b/doc/Type/Blob.pod6
@@ -92,7 +92,7 @@ It will also return 1 on the class object.
 
 Defined as:
 
-    method bytes(Blob:D: --> Int:D)
+    method bytes(Blob:D: *%_ --> Int:D)
 
 Returns the number of bytes used by the elements in the buffer.
 
@@ -295,7 +295,7 @@ L<unpack|/routine/unpack>.
 
 Defined as:
 
-    method reverse(Blob:D: --> Blob:D)
+    method reverse(Blob:D: *%_ --> Blob:D)
 
 Returns a Blob with all elements in reversed order.
 
@@ -322,7 +322,7 @@ C<LittleEndian> and C<BigEndian>.
 
 Defined as:
 
-    method read-uint8(blob8:D: uint $pos, $endian = NativeEndian --> uint)
+    method read-uint8(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> uint)
 
 Returns an unsigned native integer value for the byte at the given position.
 The C<$endian> parameter has no meaning, but is available for consistency.
@@ -331,7 +331,7 @@ The C<$endian> parameter has no meaning, but is available for consistency.
 
 Defined as:
 
-    method read-int8(blob8:D: uint $pos, $endian = NativeEndian --> int)
+    method read-int8(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> int)
 
 Returns a native C<int> value for the byte at the given position.
 The C<$endian> parameter has no meaning, but is available for consistency.
@@ -340,7 +340,7 @@ The C<$endian> parameter has no meaning, but is available for consistency.
 
 Defined as:
 
-    method read-uint16(blob8:D: uint $pos, $endian = NativeEndian --> uint)
+    method read-uint16(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> uint)
 
 Returns a native C<uint> value for the B<two> bytes starting at the
 given position.
@@ -349,7 +349,7 @@ given position.
 
 Defined as:
 
-    method read-int16(blob8:D: uint $pos, $endian = NativeEndian --> int)
+    method read-int16(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> int)
 
 Returns a native C<int> value for the B<two> bytes starting at the given
 position.
@@ -358,7 +358,7 @@ position.
 
 Defined as:
 
-    method read-uint32(blob8:D: uint $pos, $endian = NativeEndian --> uint)
+    method read-uint32(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> uint)
 
 Returns a native C<uint> value for the B<four> bytes starting at the
 given position.
@@ -367,7 +367,7 @@ given position.
 
 Defined as:
 
-    method read-int32(blob8:D: uint $pos, $endian = NativeEndian --> int)
+    method read-int32(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> int)
 
 Returns a native C<int> value for the B<four> bytes starting at the given
 position.
@@ -376,7 +376,7 @@ position.
 
 Defined as:
 
-    method read-uint64(blob8:D: uint $pos, $endian = NativeEndian --> UInt:D)
+    method read-uint64(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> UInt:D)
 
 Returns an unsigned integer value for the B<eight> bytes starting at the
 given position.
@@ -385,7 +385,7 @@ given position.
 
 Defined as:
 
-    method read-int64(blob8:D: uint $pos, $endian = NativeEndian --> int)
+    method read-int64(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> int)
 
 Returns a native C<int> value for the B<eight> bytes starting at the given
 position.
@@ -394,7 +394,7 @@ position.
 
 Defined as:
 
-    method read-uint128(blob8:D: uint $pos, $endian = NativeEndian --> UInt:D)
+    method read-uint128(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> UInt:D)
 
 Returns an unsigned integer value for the B<sixteen> bytes starting at the
 given position.
@@ -403,7 +403,7 @@ given position.
 
 Defined as:
 
-    method read-int128(blob8:D: uint $pos, $endian = NativeEndian --> Int:D)
+    method read-int128(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> Int:D)
 
 Returns an integer value for the B<sixteen> bytes starting at the given
 position.
@@ -412,7 +412,7 @@ position.
 
 Defined as:
 
-    method read-num32(blob8:D: uint $pos, $endian = NativeEndian --> int)
+    method read-num32(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> int)
 
 Returns a native C<num> value for the B<four> bytes starting at the given
 position.
@@ -421,7 +421,7 @@ position.
 
 Defined as:
 
-    method read-num64(blob8:D: uint $pos, $endian = NativeEndian --> int)
+    method read-num64(blob8:D: uint $pos, $endian = NativeEndian, *%_ --> int)
 
 Returns a native C<num> value for the B<eight> bytes starting at the given
 position.
@@ -432,7 +432,7 @@ position.
 
 Defined as:
 
-    method read-ubits(blob8:D: uint $pos, uint $bits --> UInt:D)
+    method read-ubits(blob8:D: uint $pos, uint $bits, *%_ --> UInt:D)
 
 Returns an unsigned integer value for the B<bits> from the given B<bit> offset
 and given number of bits.  The endianness of the bits is assumed to be
@@ -442,7 +442,7 @@ C<BigEndian>.
 
 Defined as:
 
-    method read-bits(blob8:D: uint $pos, uint $bits --> Int:D)
+    method read-bits(blob8:D: uint $pos, uint $bits, *%_ --> Int:D)
 
 Returns a signed integer value for the B<bits> from the given B<bit> offset
 and given number of bits.  The endianness of the bits is assumed to be

--- a/doc/Type/Blob.pod6
+++ b/doc/Type/Blob.pod6
@@ -104,7 +104,7 @@ Returns the number of bytes used by the elements in the buffer.
 
 Defined as:
 
-    method chars(Blob:D:)
+    method chars(Blob:D: *%_)
 
 Throws C<X::Buf::AsStr> with C<chars> as payload.
 

--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -40,7 +40,7 @@ True ~~ $b;      # False
 
 =head2 routine succ
 
-    method Bool(Bool: *%_ --> Bool:D)
+    method succ(Bool: *%_ --> Bool:D)
 
 Returns C<True>.
 
@@ -54,7 +54,7 @@ Bool enum value, its own successor is also C<True>.
 
 =head2 routine pred
 
-    method Bool(Bool: *%_ --> Bool:D)
+    method pred(Bool: *%_ --> Bool:D)
 
 Returns C<False>.
 
@@ -68,7 +68,7 @@ the "lowest" Bool enum value, its own predecessor is also C<False>.
 
 =head2 routine enums
 
-    method Bool(Bool: *%_ --> Hash:D)
+    method enums(Bool: *%_ --> Hash:D)
 
 Returns a L<Hash|/type/Hash> of enum-pairs. Works on both the C<Bool> type
 and any key.

--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -40,7 +40,7 @@ True ~~ $b;      # False
 
 =head2 routine succ
 
-    method succ(--> Bool:D)
+    method Bool(Bool: *%_ --> Bool:D)
 
 Returns C<True>.
 
@@ -54,7 +54,7 @@ Bool enum value, its own successor is also C<True>.
 
 =head2 routine pred
 
-    method pred(--> Bool:D)
+    method Bool(Bool: *%_ --> Bool:D)
 
 Returns C<False>.
 
@@ -68,7 +68,7 @@ the "lowest" Bool enum value, its own predecessor is also C<False>.
 
 =head2 routine enums
 
-    method enums(--> Hash:D)
+    method Bool(Bool: *%_ --> Hash:D)
 
 Returns a L<Hash|/type/Hash> of enum-pairs. Works on both the C<Bool> type
 and any key.

--- a/doc/Type/Buf.pod6
+++ b/doc/Type/Buf.pod6
@@ -183,7 +183,7 @@ say $bú.raku; # OUTPUT: «Buf.new(0,1,1,2,3,5,8,13,21,34,55,89)»
 
 =head2 method splice
 
-    method splice( Buf:D: $start = 0, $elems?, *@replacement --> Buf)
+    method splice( Buf:D: $start = 0, $elems?, *@replacement, *%_ --> Buf)
 
 Substitutes elements of the buffer by other elements
 
@@ -211,7 +211,7 @@ if it is not large enough yet.
 
 Defined as:
 
-    method write-uint8(buf8:D: uint $pos, uint8 $value, $endian = NativeEndian --> Nil)
+    method write-uint8(buf8:D: uint $pos, uint8 $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes an unsigned 8-bit integer value at the given position.  The C<$endian>
 parameter has no meaning, but is available for consistency.
@@ -220,7 +220,7 @@ parameter has no meaning, but is available for consistency.
 
 Defined as:
 
-    method write-int8(buf8:D: uint $pos, int8 $value, $endian = NativeEndian --> Nil)
+    method write-int8(buf8:D: uint $pos, int8 $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes a signed 8-bit integer value at the given position.  The C<$endian>
 parameter has no meaning, but is available for consistency.
@@ -229,7 +229,7 @@ parameter has no meaning, but is available for consistency.
 
 Defined as:
 
-    method write-uint16(buf8:D: uint $pos, uint16 $value, $endian = NativeEndian --> Nil)
+    method write-uint16(buf8:D: uint $pos, uint16 $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes an unsigned 16-bit integer value at the given position with the given
 endianness.
@@ -238,7 +238,7 @@ endianness.
 
 Defined as:
 
-    method write-int16(buf8:D: uint $pos, int16 $value, $endian = NativeEndian --> Nil)
+    method write-int16(buf8:D: uint $pos, int16 $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes a signed 16-bit integer value at the given position with the given
 endianness.
@@ -247,7 +247,7 @@ endianness.
 
 Defined as:
 
-    method write-uint32(buf8:D: uint $pos, uint32 $value, $endian = NativeEndian --> Nil)
+    method write-uint32(buf8:D: uint $pos, uint32 $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes an unsigned 32-bit integer value at the given position with the given
 endianness.
@@ -256,7 +256,7 @@ endianness.
 
 Defined as:
 
-    method write-int32(buf8:D: uint $pos, int32 $value, $endian = NativeEndian --> Nil)
+    method write-int32(buf8:D: uint $pos, int32 $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes a signed 32-bit integer value at the given position with the given
 endianness.
@@ -265,7 +265,7 @@ endianness.
 
 Defined as:
 
-    method write-uint64(buf8:D: uint $pos, uint64 $value, $endian = NativeEndian --> Nil)
+    method write-uint64(buf8:D: uint $pos, uint64 $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes an unsigned 64-bit integer value at the given position with the given
 endianness.
@@ -274,7 +274,7 @@ endianness.
 
 Defined as:
 
-    method write-int64(buf8:D: uint $pos, Int:D $value, $endian = NativeEndian --> Nil)
+    method write-int64(buf8:D: uint $pos, Int:D $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes a signed 64-bit integer value at the given position with the given
 endianness.
@@ -283,7 +283,7 @@ endianness.
 
 Defined as:
 
-    method write-uint128(buf8:D: uint $pos, UInt:D $value, $endian = NativeEndian --> Nil)
+    method write-uint128(buf8:D: uint $pos, UInt:D $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes an unsigned 128-bit integer value at the given position with the given
 endianness.
@@ -292,7 +292,7 @@ endianness.
 
 Defined as:
 
-    method write-int128(buf8:D: uint $pos, Int:D $value, $endian = NativeEndian --> Nil)
+    method write-int128(buf8:D: uint $pos, Int:D $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes a signed 128-bit integer value at the given position with the given
 endianness.
@@ -301,7 +301,7 @@ endianness.
 
 Defined as:
 
-    method write-num32(buf8:D: uint $pos, num32 $value, $endian = NativeEndian --> Nil)
+    method write-num32(buf8:D: uint $pos, num32 $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes a native C<num32> IEEE floating point value at the given position with
 the given endianness.
@@ -310,7 +310,7 @@ the given endianness.
 
 Defined as:
 
-    method write-num64(buf8:D: uint $pos, num64 $value, $endian = NativeEndian --> Nil)
+    method write-num64(buf8:D: uint $pos, num64 $value, $endian = NativeEndian, *%_ --> Nil)
 
 Writes a native C<num64> IEEE floating point value at the given position with
 the given endianness.
@@ -321,7 +321,7 @@ the given endianness.
 
 Defined as:
 
-    method write-ubits(buf8:D: uint $pos, uint $bits, UInt:D $value --> Nil)
+    method write-ubits(buf8:D: uint $pos, uint $bits, UInt:D $value, *%_ --> Nil)
 
 Writes an unsigned integer value to the B<bits> from the given B<bit> offset
 and given number of bits.  The endianness of the bits is assumed to be
@@ -331,7 +331,7 @@ C<BigEndian>.  Always returns Nil.
 
 Defined as:
 
-    method write-bits(buf8:D: uint $pos, uint $bits, Int:D $value --> Nil)
+    method write-bits(buf8:D: uint $pos, uint $bits, Int:D $value, *%_ --> Nil)
 
 Writes a signed integer value for the B<bits> from the given B<bit> offset
 and given number of bits.  The endianness of the bits is assumed to be
@@ -360,7 +360,7 @@ C<LittleEndian> and C<BigEndian>.
 
 Defined as:
 
-    method write-uint8(buf8: uint $pos, uint8 $value, $endian = NativeEndian --> buf8:D)
+    method write-uint8(buf8: uint $pos, uint8 $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes an unsigned 8-bit integer value at the given position.  The C<$endian>
 parameter has no meaning, but is available for consistency.
@@ -369,7 +369,7 @@ parameter has no meaning, but is available for consistency.
 
 Defined as:
 
-    method write-int8(buf8: uint $pos, int8 $value, $endian = NativeEndian --> buf8:D)
+    method write-int8(buf8: uint $pos, int8 $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes a signed 8-bit integer value at the given position.  The C<$endian>
 parameter has no meaning, but is available for consistency.
@@ -378,7 +378,7 @@ parameter has no meaning, but is available for consistency.
 
 Defined as:
 
-    method write-uint16(buf8: uint $pos, uint16 $value, $endian = NativeEndian --> buf8:D)
+    method write-uint16(buf8: uint $pos, uint16 $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes an unsigned 16-bit integer value at the given position with the given
 endianness.
@@ -387,7 +387,7 @@ endianness.
 
 Defined as:
 
-    method write-int16(buf8: uint $pos, int16 $value, $endian = NativeEndian --> buf8:D)
+    method write-int16(buf8: uint $pos, int16 $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes a signed 16-bit integer value at the given position with the given
 endianness.
@@ -396,7 +396,7 @@ endianness.
 
 Defined as:
 
-    method write-uint32(buf8: uint $pos, uint32 $value, $endian = NativeEndian --> buf8:D)
+    method write-uint32(buf8: uint $pos, uint32 $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes an unsigned 32-bit integer value at the given position with the given
 endianness.
@@ -405,7 +405,7 @@ endianness.
 
 Defined as:
 
-    method write-int32(buf8: uint $pos, int32 $value, $endian = NativeEndian --> buf8:D)
+    method write-int32(buf8: uint $pos, int32 $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes a signed 32-bit integer value at the given position with the given
 endianness.
@@ -414,7 +414,7 @@ endianness.
 
 Defined as:
 
-    method write-uint64(buf8: uint $pos, uint64 $value, $endian = NativeEndian --> buf8:D)
+    method write-uint64(buf8: uint $pos, uint64 $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes an unsigned 64-bit integer value at the given position with the given
 endianness.
@@ -423,7 +423,7 @@ endianness.
 
 Defined as:
 
-    method write-int64(buf8: uint $pos, Int:D $value, $endian = NativeEndian --> buf8:D)
+    method write-int64(buf8: uint $pos, Int:D $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes a signed 64-bit integer value at the given position with the given
 endianness.
@@ -432,7 +432,7 @@ endianness.
 
 Defined as:
 
-    method write-uint128(buf8: uint $pos, UInt:D $value, $endian = NativeEndian --> buf8:D)
+    method write-uint128(buf8: uint $pos, UInt:D $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes an unsigned 128-bit integer value at the given position with the given
 endianness.
@@ -441,7 +441,7 @@ endianness.
 
 Defined as:
 
-    method write-int128(buf8: uint $pos, Int:D $value, $endian = NativeEndian --> buf8:D)
+    method write-int128(buf8: uint $pos, Int:D $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes a signed 128-bit integer value at the given position with the given
 endianness.
@@ -450,7 +450,7 @@ endianness.
 
 Defined as:
 
-    method write-num32(buf8: uint $pos, num32 $value, $endian = NativeEndian --> buf8:D)
+    method write-num32(buf8: uint $pos, num32 $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes a native C<num32> IEEE floating point value at the given position with
 the given endianness.
@@ -459,7 +459,7 @@ the given endianness.
 
 Defined as:
 
-    method write-num64(buf8: uint $pos, num64 $value, $endian = NativeEndian --> buf8:D)
+    method write-num64(buf8: uint $pos, num64 $value, $endian = NativeEndian, *%_ --> buf8:D)
 
 Writes a native C<num64> IEEE floating point value at the given position with
 the given endianness.
@@ -468,7 +468,7 @@ the given endianness.
 
 Defined as:
 
-    method write-ubits(buf8: uint $pos, uint $bits, UInt:D $value --> buf8:D)
+    method write-ubits(buf8: uint $pos, uint $bits, UInt:D $value, *%_ --> buf8:D)
 
 Writes an unsigned integer value to the B<bits> from the given B<bit> offset
 and given number of bits.  The endianness of the bits is assumed to be
@@ -478,7 +478,7 @@ C<BigEndian>.
 
 Defined as:
 
-    method write-bits(buf8: uint $pos, uint $bits, Int:D $value --> buf8:D)
+    method write-bits(buf8: uint $pos, uint $bits, Int:D $value, *%_ --> buf8:D)
 
 Writes a signed integer value for the B<bits> from the given B<bit> offset
 and given number of bits.  The endianness of the bits is assumed to be

--- a/doc/Type/Buf.pod6
+++ b/doc/Type/Buf.pod6
@@ -43,7 +43,7 @@ cases where it is the best representation for a particular encoding.
 
 =head2 method subbuf-rw
 
-    method subbuf-rw($?CLASS: $from = 0, $elems = self.elems - $from, *%_) is rw
+    method subbuf-rw(Buf: $from = 0, $elems = self.elems - $from, *%_) is rw
 
 A mutable version of C<subbuf> that returns a L<Proxy|/type/Proxy>
 functioning as a writable reference to a part of a buffer. Its first
@@ -183,7 +183,7 @@ say $bú.raku; # OUTPUT: «Buf.new(0,1,1,2,3,5,8,13,21,34,55,89)»
 
 =head2 method splice
 
-    method splice( Buf:D: $start = 0, $elems?, *@replacement, *%_ --> Buf)
+    method splice(Buf:D: $start = 0, $elems?, *@replacement, *%_ --> Buf)
 
 Substitutes elements of the buffer by other elements
 

--- a/doc/Type/Buf.pod6
+++ b/doc/Type/Buf.pod6
@@ -43,7 +43,7 @@ cases where it is the best representation for a particular encoding.
 
 =head2 method subbuf-rw
 
-    method subbuf-rw($from = 0, $elems = self.elems - $from) is rw
+    method subbuf-rw($from = 0, $elems = self.elems - $from, *%_) is rw
 
 A mutable version of C<subbuf> that returns a L<Proxy|/type/Proxy>
 functioning as a writable reference to a part of a buffer. Its first
@@ -90,7 +90,7 @@ Invokes the C<subbuf-rw> method on the specified C<Buf>:
 
 =head2 method reallocate
 
-    method reallocate($elems)
+    method reallocate($elems, *%_)
 
 Change the number of elements of the C<Buf>, returning the changed
 C<Buf>. The size of C<Buf> will be adapted depending on the number of
@@ -122,7 +122,7 @@ Returns a C<List> of integers.
 
 =head2 method push
 
-    method push( $elems )
+    method push( $elems , *%_)
 
 Adds elements at the end of the buffer
 
@@ -143,7 +143,7 @@ say $bú.raku; # OUTPUT: «Buf.new(1,1,2,3,5)»
 
 =head2 method append
 
-    method append( $elems )
+    method append( $elems , *%_)
 
 Appends at the end of the buffer
 
@@ -153,7 +153,7 @@ say $bú.raku; # OUTPUT: «Buf.new(1,1,2,3,5,8,13,21,34,55,89)»
 
 =head2 method prepend
 
-    method prepend( $elems )
+    method prepend( $elems , *%_)
 
 Adds elements at the beginning of the buffer
 

--- a/doc/Type/Buf.pod6
+++ b/doc/Type/Buf.pod6
@@ -43,7 +43,7 @@ cases where it is the best representation for a particular encoding.
 
 =head2 method subbuf-rw
 
-    method subbuf-rw($from = 0, $elems = self.elems - $from, *%_) is rw
+    method subbuf-rw($?CLASS: $from = 0, $elems = self.elems - $from, *%_) is rw
 
 A mutable version of C<subbuf> that returns a L<Proxy|/type/Proxy>
 functioning as a writable reference to a part of a buffer. Its first
@@ -90,7 +90,7 @@ Invokes the C<subbuf-rw> method on the specified C<Buf>:
 
 =head2 method reallocate
 
-    method reallocate($elems, *%_)
+    method reallocate(Buf:D: $elems, *%_)
 
 Change the number of elements of the C<Buf>, returning the changed
 C<Buf>. The size of C<Buf> will be adapted depending on the number of
@@ -122,7 +122,7 @@ Returns a C<List> of integers.
 
 =head2 method push
 
-    method push( $elems , *%_)
+    method push(Buf: $elems , *%_)
 
 Adds elements at the end of the buffer
 
@@ -143,7 +143,7 @@ say $bú.raku; # OUTPUT: «Buf.new(1,1,2,3,5)»
 
 =head2 method append
 
-    method append( $elems , *%_)
+    method append(Buf: $elems , *%_)
 
 Appends at the end of the buffer
 
@@ -153,7 +153,7 @@ say $bú.raku; # OUTPUT: «Buf.new(1,1,2,3,5,8,13,21,34,55,89)»
 
 =head2 method prepend
 
-    method prepend( $elems , *%_)
+    method prepend(Buf: $elems , *%_)
 
 Adds elements at the beginning of the buffer
 

--- a/doc/Type/Buf.pod6
+++ b/doc/Type/Buf.pod6
@@ -133,7 +133,7 @@ Adds elements at the end of the buffer
 
 =head2 method pop
 
-    method pop()
+    method pop(Buf: *%_)
 
 Extracts the last element of the buffer
 
@@ -163,7 +163,7 @@ say $bú.raku; # OUTPUT: «Buf.new(0,1,1,2,3,5,8,13,21,34,55,89)»
 
 =head2 method shift
 
-    method shift()
+    method shift(Buf: *%_)
 
 Takes out the first element of the buffer
 
@@ -173,7 +173,7 @@ say $bú.raku; # OUTPUT: «Buf.new(1,1,2,3,5,8,13,21,34,55,89)»
 
 =head2 method unshift
 
-    method unshift()
+    method unshift(Buf: *%_)
 
 Adds elements at the beginning of the buffer
 

--- a/doc/Type/CallFrame.pod6
+++ b/doc/Type/CallFrame.pod6
@@ -67,7 +67,7 @@ called on C<CallFrame>.
 
 =head2 method code
 
-    method code()
+    method code(CallFrame: *%_)
 
 Return the callable code for the current block. When called on the object
 returned by C<callframe(0)>, this will be the same value found in
@@ -83,7 +83,7 @@ this case.
 
 =head2 method file
 
-    method file()
+    method file(CallFrame: *%_)
 
 This is a shortcut for looking up the C<file> annotation. Therefore, the
 following code prints C<True>.
@@ -93,7 +93,7 @@ following code prints C<True>.
 
 =head2 method line
 
-    method line()
+    method line(CallFrame: *%_)
 
 This is a shortcut for looking up the C<line> annotation. For example, the
 following two calls are identical.
@@ -103,7 +103,7 @@ following two calls are identical.
 
 =head2 method annotations
 
-    method annotations()
+    method annotations(CallFrame: *%_)
 
 Returns a L<Map|/type/Map> containing the invocants annotations, i.e. C<line>
 and C<file>. An easier way to get hold of the annotation information is to use
@@ -114,7 +114,7 @@ one of the convenience methods instead.
 
 =head2 method my
 
-    method my()
+    method my(CallFrame: *%_)
 
 Return a L<Hash|/type/Hash> that names all the variables and their values
 associated with the lexical scope of the frame.

--- a/doc/Type/Callable.pod6
+++ b/doc/Type/Callable.pod6
@@ -58,7 +58,7 @@ container, the submethod C<CALL-ME> can be used for that.
 
 Defined as:
 
-    method Capture()
+    method Capture(Callable: *%_)
 
 Throws C<X::Cannot::Capture>.
 

--- a/doc/Type/Cancellation.pod6
+++ b/doc/Type/Cancellation.pod6
@@ -18,7 +18,7 @@ Boolean that is true after L<#cancel> is called.
 
 Defined as:
 
-    method cancel()
+    method cancel(Cancellation: *%_)
 
 Usage:
 

--- a/doc/Type/Capture.pod6
+++ b/doc/Type/Capture.pod6
@@ -118,7 +118,7 @@ not just literal values:
 
 Defined as:
 
-    method list(Capture:D:)
+    method list(Capture:D: *%_)
 
 Returns the positional part of the C<Capture>.
 
@@ -129,7 +129,7 @@ Returns the positional part of the C<Capture>.
 
 Defined as:
 
-    method hash(Capture:D:)
+    method hash(Capture:D: *%_)
 
 Returns the named/hash part of the C<Capture>.
 

--- a/doc/Type/Capture.pod6
+++ b/doc/Type/Capture.pod6
@@ -140,7 +140,7 @@ Returns the named/hash part of the C<Capture>.
 
 Defined as:
 
-    method elems(Capture:D: --> Int:D)
+    method elems(Capture:D: *%_ --> Int:D)
 
 Returns the number of positional elements in the C<Capture>.
 
@@ -218,7 +218,7 @@ method.
 
 Defined as:
 
-    method Bool(Capture:D: --> Bool:D)
+    method Bool(Capture:D: *%_ --> Bool:D)
 
 Returns C<True> if the C<Capture> contains at least one named or one
 positional argument.
@@ -230,7 +230,7 @@ positional argument.
 
 Defined as:
 
-    method Capture(Capture:D: --> Capture:D)
+    method Capture(Capture:D: *%_ --> Capture:D)
 
 Returns itself, i.e. the invocant.
 
@@ -240,7 +240,7 @@ Returns itself, i.e. the invocant.
 
 Defined as:
 
-    method Numeric(Capture:D: --> Int:D)
+    method Numeric(Capture:D: *%_ --> Int:D)
 
 Returns the number of positional elements in the C<Capture>.
 

--- a/doc/Type/Channel.pod6
+++ b/doc/Type/Channel.pod6
@@ -120,7 +120,7 @@ phaser to enforce the C<.close> call in this case.
 
 Defined as:
 
-    method list(Channel:D: --> List:D)
+    method list(Channel:D: *%_ --> List:D)
 
 Returns a list based on the C<Seq> which will iterate items in the queue and
 remove each item from it as it iterates. This can only terminate once the
@@ -134,7 +134,7 @@ C<close> method has been called.
 
 Defined as:
 
-    method closed(Channel:D: --> Promise:D)
+    method closed(Channel:D: *%_ --> Promise:D)
 
 Returns a promise that will be kept once the channel is closed by a call to
 method C<close>.
@@ -165,7 +165,7 @@ been closed or C<.fail> has already been called on it.
 
 Defined as:
 
-    method Capture(Channel:D --> Capture:D)
+    method Capture(Channel:D *%_ --> Capture:D)
 
 Equivalent to calling L«C<.List.Capture>|/type/List#method_Capture»
 on the invocant.

--- a/doc/Type/Channel.pod6
+++ b/doc/Type/Channel.pod6
@@ -165,7 +165,7 @@ been closed or C<.fail> has already been called on it.
 
 Defined as:
 
-    method Capture(Channel:D *%_ --> Capture:D)
+    method Capture(Channel:D: *%_ --> Capture:D)
 
 Equivalent to calling L«C<.List.Capture>|/type/List#method_Capture»
 on the invocant.

--- a/doc/Type/Channel.pod6
+++ b/doc/Type/Channel.pod6
@@ -49,7 +49,7 @@ care should be taken to prevent runaway queueing.
 
 Defined as:
 
-    method receive(Channel:D:)
+    method receive(Channel:D: *%_)
 
 Receives and removes an item from the channel. It blocks if no item is
 present, waiting for a C<send> from another thread.
@@ -73,7 +73,7 @@ See method C<poll> for a non-blocking version that won't throw exceptions.
 
 Defined as:
 
-    method poll(Channel:D:)
+    method poll(Channel:D: *%_)
 
 Receives and removes an item from the channel. If no item is present, returns
 C<Nil> instead of waiting.
@@ -94,7 +94,7 @@ closing and failure.
 
 Defined as:
 
-    method close(Channel:D:)
+    method close(Channel:D: *%_)
 
 Close the C<Channel>, normally.  This makes subsequent C<send> calls die with
 L<X::Channel::SendOnClosed|/type/X::Channel::SendOnClosed>.  Subsequent calls of
@@ -174,7 +174,7 @@ on the invocant.
 
 Defined as:
 
-    method Supply(Channel:D:)
+    method Supply(Channel:D: *%_)
 
 This returns an C<on-demand> L<Supply|/type/Supply> that emits a value for every value
 received on the Channel. C<done> will be called on the C<Supply> when the L<Channel|/type/Channel>

--- a/doc/Type/Channel.pod6
+++ b/doc/Type/Channel.pod6
@@ -31,7 +31,7 @@ Further examples can be found in the L<concurrency page|/language/concurrency#Ch
 
 Defined as:
 
-    method send(Channel:D: \item)
+    method send(Channel:D: \item, *%_)
 
 Enqueues an item into the C<Channel>. Throws an exception of type
 L<X::Channel::SendOnClosed|/type/X::Channel::SendOnClosed> if the channel has been
@@ -148,7 +148,7 @@ method C<close>.
 
 Defined as:
 
-    method fail(Channel:D: $error)
+    method fail(Channel:D: $error, *%_)
 
 Closes the C<Channel> (that is, makes subsequent C<send> calls die), and enqueues
 the error to be thrown as the final element in the channel. Method C<receive>

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -189,7 +189,7 @@ Returns the line number in which the code object was declared.
 
 =head2 method is-implementation-detail
 
-    method is-implementation-detail(--> False)
+    method Code(Code: *%_ --> False)
 
 Note: this trait has been available in Rakudo compiler starting from 2020.05 release.
 

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -139,7 +139,7 @@ its parameters.
 
 =head2 method cando
 
-    method cando(Capture $c)
+    method cando(Capture $c, *%_)
 
 Returns a list of candidates that can be called with the given
 L<Capture|/type/Capture>.  Since C<Code> objects do not have any multiple

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -42,7 +42,7 @@ code object's C<Signature> do not contribute, nor do named parameters.
 
 =head2 method assuming
 
-    method assuming(Callable:D $self: |primers)
+    method assuming(Code:D $self: |primers)
 
 Returns a C<Callable> that implements the same behavior as the
 original, but has the values passed to .assuming already bound to the
@@ -139,7 +139,7 @@ its parameters.
 
 =head2 method cando
 
-    method cando(Capture $c, *%_)
+    method cando(Code: Capture $c, *%_)
 
 Returns a list of candidates that can be called with the given
 L<Capture|/type/Capture>.  Since C<Code> objects do not have any multiple

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -27,7 +27,7 @@ result of the call is returned.
 
 Defined as:
 
-    method arity(Code:D: --> Int:D)
+    method arity(Code:D: *%_ --> Int:D)
 
 Returns the minimum number of positional arguments that must be passed
 in order to call the code object. Any optional or slurpy parameters in the
@@ -100,7 +100,7 @@ including L<Methods|/type/Method> and L<Blocks|/type/Block>:
 
 Defined as:
 
-    method count(Code:D: --> Real:D)
+    method count(Code:D: *%_ --> Real:D)
 
 Returns the maximum number of positional arguments that may be passed
 when calling the code object. For code objects that can accept any
@@ -118,7 +118,7 @@ C<count> will return C<Inf>. Named parameters do not contribute.
 
 Defined as:
 
-    method of(Code:D: --> Mu)
+    method of(Code:D: *%_ --> Mu)
 
 Returns the L<return type constraint|/type/Signature#Constraining_return_types>
 of the C<Code>:
@@ -171,7 +171,7 @@ C<.gist> instead.
 
 Defined as:
 
-    method file(Code:D: --> Str:D)
+    method file(Code:D: *%_ --> Str:D)
 
 Returns the name of the file in which the code object was declared.
 
@@ -181,7 +181,7 @@ Returns the name of the file in which the code object was declared.
 
 Defined as
 
-    method line(Code:D: --> Int:D)
+    method line(Code:D: *%_ --> Int:D)
 
 Returns the line number in which the code object was declared.
 

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -189,7 +189,7 @@ Returns the line number in which the code object was declared.
 
 =head2 method is-implementation-detail
 
-    method Code(Code: *%_ --> False)
+    method is-implementation-detail(Code: *%_ --> False)
 
 Note: this trait has been available in Rakudo compiler starting from 2020.05 release.
 

--- a/doc/Type/CompUnit.pod6
+++ b/doc/Type/CompUnit.pod6
@@ -14,54 +14,54 @@ rather than code that is executed using an C<EVAL> statement.
 
 =head2 method auth
 
-    method auth(--> Str:D)
+    method CompUnit(CompUnit: *%_ --> Str:D)
 
 Returns the authority information with which the C<CompUnit> object was created
 (if any).
 
 =head2 method distribution
 
-    method distribution(--> Distribution:D)
+    method CompUnit(CompUnit: *%_ --> Distribution:D)
 
 Returns the L<Distribution|/type/Distribution> object with which the C<CompUnit> object was
 created (if any).
 
 =head2 method from
 
-    method from(--> Str:D)
+    method CompUnit(CompUnit: *%_ --> Str:D)
 
 Returns the name of the language with which the C<CompUnit> object was created
 (if any). It will be C<Perl6> by default.
 
 =head2 method precompiled
 
-    method precompiled(--> Bool:D)
+    method CompUnit(CompUnit: *%_ --> Bool:D)
 
 Returns whether the C<CompUnit> object originated from a precompiled source.
 
 =head2 method repo
 
-    method repo(--> CompUnit::Repository:D)
+    method CompUnit(CompUnit: *%_ --> CompUnit::Repository:D)
 
 Returns the L<CompUnit::Repository|/type/CompUnit::Repository> object with which the C<CompUnit> object
 was created.
 
 =head2 method repo-id
 
-    method repo-id(--> Str:D)
+    method CompUnit(CompUnit: *%_ --> Str:D)
 
 Returns the identification string with which the C<CompUnit> object can be
 identified in the associated L<repo|#method_repo>.
 
 =head2 method short-name
 
-    method short-name(--> Str:D)
+    method CompUnit(CompUnit: *%_ --> Str:D)
 
 Returns The short name with which the C<CompUnit> object was created (if any).
 
 =head2 method version
 
-    method version(--> Version:D)
+    method CompUnit(CompUnit: *%_ --> Version:D)
 
 Returns the version information with which the C<CompUnit> object was created
 (if any).

--- a/doc/Type/CompUnit.pod6
+++ b/doc/Type/CompUnit.pod6
@@ -14,54 +14,54 @@ rather than code that is executed using an C<EVAL> statement.
 
 =head2 method auth
 
-    method CompUnit(CompUnit: *%_ --> Str:D)
+    method auth(CompUnit: *%_ --> Str:D)
 
 Returns the authority information with which the C<CompUnit> object was created
 (if any).
 
 =head2 method distribution
 
-    method CompUnit(CompUnit: *%_ --> Distribution:D)
+    method distribution(CompUnit: *%_ --> Distribution:D)
 
 Returns the L<Distribution|/type/Distribution> object with which the C<CompUnit> object was
 created (if any).
 
 =head2 method from
 
-    method CompUnit(CompUnit: *%_ --> Str:D)
+    method from(CompUnit: *%_ --> Str:D)
 
 Returns the name of the language with which the C<CompUnit> object was created
 (if any). It will be C<Perl6> by default.
 
 =head2 method precompiled
 
-    method CompUnit(CompUnit: *%_ --> Bool:D)
+    method precompiled(CompUnit: *%_ --> Bool:D)
 
 Returns whether the C<CompUnit> object originated from a precompiled source.
 
 =head2 method repo
 
-    method CompUnit(CompUnit: *%_ --> CompUnit::Repository:D)
+    method repo(CompUnit: *%_ --> CompUnit::Repository:D)
 
 Returns the L<CompUnit::Repository|/type/CompUnit::Repository> object with which the C<CompUnit> object
 was created.
 
 =head2 method repo-id
 
-    method CompUnit(CompUnit: *%_ --> Str:D)
+    method repo-id(CompUnit: *%_ --> Str:D)
 
 Returns the identification string with which the C<CompUnit> object can be
 identified in the associated L<repo|#method_repo>.
 
 =head2 method short-name
 
-    method CompUnit(CompUnit: *%_ --> Str:D)
+    method short-name(CompUnit: *%_ --> Str:D)
 
 Returns The short name with which the C<CompUnit> object was created (if any).
 
 =head2 method version
 
-    method CompUnit(CompUnit: *%_ --> Version:D)
+    method version(CompUnit: *%_ --> Version:D)
 
 Returns the version information with which the C<CompUnit> object was created
 (if any).

--- a/doc/Type/Compiler.pod6
+++ b/doc/Type/Compiler.pod6
@@ -49,7 +49,7 @@ Up to Rakudo version 2019.03.1, it returned the date when it was built.
 
 =head2 method verbose-config
 
-    method verbose-config(:$say)
+    method verbose-config(:$say, *%_)
 
 If C<$say> is C<True>, it prints the different items included in the
 configuration of the compiler; if it is not, returns a C<Hash> with the same

--- a/doc/Type/Compiler.pod6
+++ b/doc/Type/Compiler.pod6
@@ -34,7 +34,7 @@ It's empty, but it might contain the codename for specific releases.
 
 =head2 method backend
 
-    method backend()
+    method backend(Compiler: *%_)
 
 Since Rakudo version 2020.02, returns the name of the compiler's backend.
 

--- a/doc/Type/Compiler.pod6
+++ b/doc/Type/Compiler.pod6
@@ -49,7 +49,7 @@ Up to Rakudo version 2019.03.1, it returned the date when it was built.
 
 =head2 method verbose-config
 
-    method verbose-config(:$say, *%_)
+    method verbose-config(Compiler: :$say, *%_)
 
 If C<$say> is C<True>, it prints the different items included in the
 configuration of the compiler; if it is not, returns a C<Hash> with the same

--- a/doc/Type/Complex.pod6
+++ b/doc/Type/Complex.pod6
@@ -40,7 +40,7 @@ When created without arguments, both parts are considered to be zero.
 
 Defined as:
 
-    method re(Complex:D: --> Real:D)
+    method re(Complex:D: *%_ --> Real:D)
 
 Returns the real part of the complex number.
 
@@ -50,7 +50,7 @@ Returns the real part of the complex number.
 
 Defined as:
 
-    method im(Complex:D: --> Real:D)
+    method im(Complex:D: *%_ --> Real:D)
 
 Returns the imaginary part of the complex number.
 
@@ -60,7 +60,7 @@ Returns the imaginary part of the complex number.
 
 Defined as:
 
-    method reals(Complex:D: --> Positional:D)
+    method reals(Complex:D: *%_ --> Positional:D)
 
 Returns a two-element list containing the real and imaginary parts for this value.
 
@@ -70,7 +70,7 @@ Returns a two-element list containing the real and imaginary parts for this valu
 
 Defined as:
 
-    method isNaN(Complex:D: --> Bool:D)
+    method isNaN(Complex:D: *%_ --> Bool:D)
 
 Returns true if the real or imaginary part is L<C<NaN>|/type/Num#NaN> (not a number).
 
@@ -81,7 +81,7 @@ Returns true if the real or imaginary part is L<C<NaN>|/type/Num#NaN> (not a num
 
 Defined as:
 
-    method polar(Complex:D: --> Positional:D)
+    method polar(Complex:D: *%_ --> Positional:D)
 
 Returns a two-element list of the polar coordinates for this value,
 i.e. magnitude and angle in radians.
@@ -92,7 +92,7 @@ i.e. magnitude and angle in radians.
 
 Defined as:
 
-    method floor(Complex:D: --> Complex:D)
+    method floor(Complex:D: *%_ --> Complex:D)
 
 Returns C<self.re.floor + self.im.floor>. That is, each of the real and
 imaginary parts is rounded to the highest integer not greater than
@@ -104,7 +104,7 @@ the value of that part.
 
 Defined as:
 
-    method ceiling(Complex:D: --> Complex:D)
+    method ceiling(Complex:D: *%_ --> Complex:D)
 
 Returns C<self.re.ceiling + self.im.ceiling>. That is, each of the real and
 imaginary parts is rounded to the lowest integer not less than the value
@@ -131,7 +131,7 @@ algorithm as L<Real.round|/type/Real#method_round> on each part of the number.
 
 Defined as:
 
-    method truncate(Complex:D: --> Complex:D)
+    method truncate(Complex:D: *%_ --> Complex:D)
 
 Removes the fractional part of both the real and imaginary parts of the
 number, using L<Real.truncate|/type/Real#method_truncate>, and returns the result as a new C<Complex>.
@@ -142,7 +142,7 @@ number, using L<Real.truncate|/type/Real#method_truncate>, and returns the resul
 
 Defined as:
 
-    method abs(Complex:D: --> Num:D)
+    method abs(Complex:D: *%_ --> Num:D)
     multi sub abs(Complex:D $z --> Num:D)
 
 Returns the absolute value of the invocant (or the argument in sub form).
@@ -156,7 +156,7 @@ C<sqrt($z.re * $z.re + $z.im * $z.im)>.
 
 Defined as:
 
-    method conj(Complex:D: --> Complex:D)
+    method conj(Complex:D: *%_ --> Complex:D)
 
 Returns the complex conjugate of the invocant (that is, the number with the
 sign of the imaginary part negated).
@@ -167,7 +167,7 @@ sign of the imaginary part negated).
 
 Defined as:
 
-    method sqrt(Complex:D: --> Complex:D)
+    method sqrt(Complex:D: *%_ --> Complex:D)
 
 Returns the complex square root of the invocant, i.e. the root
 where the real part is ≥ 0 and the imaginary part has the same
@@ -180,7 +180,7 @@ sign as the imaginary part of the invocant.
 
 Defined as:
 
-    method gist(Complex:D: --> Str:D)
+    method gist(Complex:D: *%_ --> Str:D)
 
 Returns a string representation of the form "1+2i", without internal spaces.
 (Str coercion also returns this.)
@@ -191,7 +191,7 @@ Returns a string representation of the form "1+2i", without internal spaces.
 
 Defined as:
 
-    method perl(Complex:D: --> Str:D)
+    method perl(Complex:D: *%_ --> Str:D)
 
 Returns an implementation-specific string that produces an L<equivalent|/routine/eqv> object
 when given to L<EVAL|/routine/EVAL>.

--- a/doc/Type/ComplexStr.pod6
+++ b/doc/Type/ComplexStr.pod6
@@ -51,7 +51,7 @@ is not considered.
 
 Defined as:
 
-    method Capture(ComplexStr:D --> Capture:D)
+    method Capture(ComplexStr:D *%_ --> Capture:D)
 
 Equivalent to L«C<Mu.Capture>|/type/Mu#method_Capture».
 

--- a/doc/Type/ComplexStr.pod6
+++ b/doc/Type/ComplexStr.pod6
@@ -27,7 +27,7 @@ variants:
 
 =head2 method new
 
-    method new(Complex $i, Str $s, *%_)
+    method new(ComplexStr: Complex $c, Str $s, *%_)
 
 The constructor requires both the C<Complex> and the C<Str> value, when constructing one
 directly the values can be whatever is required:
@@ -51,7 +51,7 @@ is not considered.
 
 Defined as:
 
-    method Capture(ComplexStr:D *%_ --> Capture:D)
+    method Capture(ComplexStr:D: *%_ --> Capture:D)
 
 Equivalent to L«C<Mu.Capture>|/type/Mu#method_Capture».
 

--- a/doc/Type/ComplexStr.pod6
+++ b/doc/Type/ComplexStr.pod6
@@ -27,7 +27,7 @@ variants:
 
 =head2 method new
 
-    method new(Complex $i, Str $s)
+    method new(Complex $i, Str $s, *%_)
 
 The constructor requires both the C<Complex> and the C<Str> value, when constructing one
 directly the values can be whatever is required:

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -148,7 +148,7 @@ imaginary part negated).
 Defined as:
 
 =for code :method
-method EVAL(*%_)
+method EVAL(Cool: *%opts)
 
 It calls the L<subroutine form|/language/independent-routines#routine_EVAL> with the
 invocant as the first argument, C<$code>, passing along named args, if any.
@@ -286,7 +286,7 @@ radians.
 Defined as:
 
     sub atan2($y, $x = 1e0)
-    method atan2($x = 1e0, *%_)
+    method atan2(Cool: $x = 1e0, *%_)
 
 The sub should usually be written with two arguments for clarity as it
 is seen in other languages and in mathematical texts, but the
@@ -678,7 +678,7 @@ the nearest integer.
 
 Defined as:
 
-    method fmt($format = '%s', *%_)
+    method fmt(Cool: $format = '%s', *%_)
 
 Uses C<$format> to return a formatted representation of the invocant; equivalent
 to calling L<sprintf|/routine/sprintf> with C<$format> as format and the
@@ -944,7 +944,7 @@ of the string case-folded to lower case.
 Defined as:
 
     sub wordcase(Str(Cool) $input, :&filter = &tclc, Mu :$where = True)
-    method wordcase(:&filter = &tclc, Mu :$where = True, *%_)
+    method wordcase(Cool: :&filter = &tclc, Mu :$where = True, *%_)
 
 Coerces the invocant (or in sub form, the first argument) to L<Str|/type/Str>, and filters each word that
 smartmatches against C<$where> through the C<&filter>. With the default
@@ -1112,7 +1112,7 @@ returns it with the last character removed, if it is a logical newline.
 Defined as:
 
     sub substr(Str(Cool) $str, |c)
-    method substr(|c)
+    method substr(Cool: |c)
 
 Coerces the invocant (or in the sub form, the first argument) to
 L<Str|/type/Str>, and calls L<Str.substr|/type/Str#routine_substr> with
@@ -1269,7 +1269,7 @@ for $*IN.lines -> $_ is copy { s/(\w+)/{$0 ~ $0}/; .say }
 
 Defined as:
 
-    method words(Cool:D: |c)
+    method words(Cool:D: *%_)
 
 Coerces the invocant (or first argument, if it is called as a subroutine) to
 L<Str|/type/Str>, and returns a list of words that make up the string. Check
@@ -1436,20 +1436,11 @@ for @roots -> $r {
 # OUTPUT:«1.04441561648202e-14␤»
 =end code
 
-=head2 method match
-
-Defined as:
-
-    method match(|)
-
-Coerces the invocant to L<Stringy|/type/Stringy> and calls
-L<Str.match|/type/Str#method_match>.
-
 =head2 method subst
 
 Defined as:
 
-    method subst(|)
+    method subst(Cool: |)
 
 Coerces the invocant to L<Stringy|/type/Stringy> and calls L<Str.subst|/type/Str#method_subst>.
 
@@ -1457,7 +1448,7 @@ Coerces the invocant to L<Stringy|/type/Stringy> and calls L<Str.subst|/type/Str
 
 Defined as:
 
-    method trans(|)
+    method trans(Cool: |)
 
 Coerces the invocant to L<Str|/type/Str> and calls L<Str.trans|/type/Str#method_trans>
 

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -771,7 +771,7 @@ Defined as:
     multi sub chars(Cool $x)
     multi sub chars(Str:D $x)
     multi sub chars(str $x --> int)
-    method chars(--> Int:D)
+    method chars(Cool: *%_ --> Int:D)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns the number of characters in the string. Please note that on the JVM, you

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -122,7 +122,7 @@ what type they coerce to:
 Defined as:
 
     sub abs(Numeric() $x)
-    method abs()
+    method abs(Cool: *%_)
 
 Coerces the invocant (or in the sub form, the argument) to
 L<Numeric|/type/Numeric> and returns the absolute value (that is, a
@@ -135,7 +135,7 @@ non-negative number).
 
 Defined as:
 
-    method conj()
+    method conj(Cool: *%_)
 
 Coerces the invocant to L<Numeric|/type/Numeric> and returns the
 L<complex|/type/Complex> conjugate (that is, the number with the sign of the
@@ -159,7 +159,7 @@ invocant as the first argument, C<$code>, passing along named args, if any.
 Defined as:
 
     sub sqrt(Numeric(Cool) $x)
-    method sqrt()
+    method sqrt(Cool: *%_)
 
 Coerces the invocant to L<Numeric|/type/Numeric> (or in the sub form, the
 argument) and returns the square root, that is, a non-negative number that, when
@@ -172,7 +172,7 @@ multiplied with itself, produces the original number.
 
 Defined as:
 
-    method sign()
+    method sign(Cool: *%_)
 
 Coerces the invocant to L<Numeric|/type/Real> and returns its sign, that
 is, 0 if the number is 0, 1 for positive and -1 for negative values.
@@ -185,7 +185,7 @@ is, 0 if the number is 0, 1 for positive and -1 for negative values.
 
 Defined as:
 
-    method rand()
+    method rand(Cool: *%_)
 
 Coerces the invocant to L<Num|/type/Num> and returns a pseudo-random value
 between zero and the number.
@@ -197,7 +197,7 @@ between zero and the number.
 Defined as:
 
     sub sin(Numeric(Cool))
-    method sin()
+    method sin(Cool: *%_)
 
 Coerces the invocant (or in the sub form, the argument) to L<Numeric|/type/Numeric>, interprets it as radians,
 returns its L<sine|https://en.wikipedia.org/wiki/Sine>.
@@ -215,7 +215,7 @@ number|/type/Num>.
 Defined as:
 
     sub asin(Numeric(Cool))
-    method asin()
+    method asin(Cool: *%_)
 
 Coerces the invocant (or in the sub form, the argument) to
 L<Numeric|/type/Numeric>, and returns its
@@ -230,7 +230,7 @@ radians.
 Defined as:
 
     sub cos(Numeric(Cool))
-    method cos()
+    method cos(Cool: *%_)
 
 Coerces the invocant (or in sub form, the argument) to L<Numeric|/type/Numeric>,
 interprets it as radians, returns its
@@ -245,7 +245,7 @@ L<cosine|https://en.wikipedia.org/wiki/Cosine>.
 Defined as:
 
     sub acos(Numeric(Cool))
-    method acos()
+    method acos(Cool: *%_)
 
 Coerces the invocant (or in sub form, the argument) to L<Numeric|/type/Numeric>, and returns its
 L<arc-cosine|https://en.wikipedia.org/wiki/Inverse_trigonometric_functions> in
@@ -259,7 +259,7 @@ radians.
 Defined as:
 
     sub tan(Numeric(Cool))
-    method tan()
+    method tan(Cool: *%_)
 
 Coerces the invocant (or in sub form, the argument) to L<Numeric|/type/Numeric>, interprets it as radians,
 returns its L<tangent|https://en.wikipedia.org/wiki/Tangent>.
@@ -272,7 +272,7 @@ returns its L<tangent|https://en.wikipedia.org/wiki/Tangent>.
 Defined as:
 
     sub atan(Numeric(Cool))
-    method atan()
+    method atan(Cool: *%_)
 
 Coerces the invocant (or in sub form, the argument) to L<Numeric|/type/Numeric>, and returns its
 L<arc-tangent|https://en.wikipedia.org/wiki/Inverse_trigonometric_functions> in
@@ -314,7 +314,7 @@ between the x-axis and a vector that goes from the origin to the point
 Defined as:
 
     sub sec(Numeric(Cool))
-    method sec()
+    method sec(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, interprets it as radians,
 returns its L<secant|https://en.wikipedia.org/wiki/Trigonometric_functions#Reciprocal_functions>,
@@ -328,7 +328,7 @@ that is, the reciprocal of its cosine.
 Defined as:
 
     sub asec(Numeric(Cool))
-    method asec()
+    method asec(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 and returns its
@@ -343,7 +343,7 @@ radians.
 Defined as:
 
     sub cosec(Numeric(Cool))
-    method cosec()
+    method cosec(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 interprets it as radians, returns its
@@ -358,7 +358,7 @@ that is, the reciprocal of its sine.
 Defined as:
 
     sub acosec(Numeric(Cool))
-    method acosec()
+    method acosec(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 and returns its
@@ -373,7 +373,7 @@ radians.
 Defined as:
 
     sub cotan(Numeric(Cool))
-    method cotan()
+    method cotan(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 interprets it as radians, returns its
@@ -388,7 +388,7 @@ that is, the reciprocal of its tangent.
 Defined as:
 
     sub acotan(Numeric(Cool))
-    method acotan()
+    method acotan(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 and returns its
@@ -403,7 +403,7 @@ in radians.
 Defined as:
 
     sub sinh(Numeric(Cool))
-    method sinh()
+    method sinh(Cool: *%_)
 
 Coerces the invocant (or in method form, its argument) to
 L<Numeric|/type/Numeric>, and returns its
@@ -417,7 +417,7 @@ L<Sine hyperbolicus|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 Defined as:
 
     sub asinh(Numeric(Cool))
-    method asinh()
+    method asinh(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse Sine hyperbolicus|https://en.wikipedia.org/wiki/Inverse_hyperbolic_function>.
@@ -430,7 +430,7 @@ L<Inverse Sine hyperbolicus|https://en.wikipedia.org/wiki/Inverse_hyperbolic_fun
 Defined as:
 
     sub cosh(Numeric(Cool))
-    method cosh()
+    method cosh(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Cosine hyperbolicus|https://en.wikipedia.org/wiki/Hyperbolic_function>.
@@ -442,7 +442,7 @@ L<Cosine hyperbolicus|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 Defined as:
 
     sub acosh(Numeric(Cool))
-    method acosh()
+    method acosh(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse Cosine hyperbolicus|https://en.wikipedia.org/wiki/Inverse_hyperbolic_function>.
@@ -454,7 +454,7 @@ L<Inverse Cosine hyperbolicus|https://en.wikipedia.org/wiki/Inverse_hyperbolic_f
 Defined as:
 
     sub tanh(Numeric(Cool))
-    method tanh()
+    method tanh(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, interprets it as
 radians and returns its L<Tangent hyperbolicus|https://en.wikipedia.org/wiki/Hyperbolic_function>.
@@ -467,7 +467,7 @@ radians and returns its L<Tangent hyperbolicus|https://en.wikipedia.org/wiki/Hyp
 Defined as:
 
     sub atanh(Numeric(Cool))
-    method atanh()
+    method atanh(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse tangent hyperbolicus|https://en.wikipedia.org/wiki/Inverse_hyperbolic_function>.
@@ -479,7 +479,7 @@ L<Inverse tangent hyperbolicus|https://en.wikipedia.org/wiki/Inverse_hyperbolic_
 Defined as:
 
     sub sech(Numeric(Cool))
-    method sech()
+    method sech(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Secant hyperbolicus|https://en.wikipedia.org/wiki/Hyperbolic_function>.
@@ -491,7 +491,7 @@ L<Secant hyperbolicus|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 Defined as:
 
     sub asech(Numeric(Cool))
-    method asech()
+    method asech(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse hyperbolic secant|https://en.wikipedia.org/wiki/Hyperbolic_function>.
@@ -503,7 +503,7 @@ L<Inverse hyperbolic secant|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 Defined as:
 
     sub cosech(Numeric(Cool))
-    method cosech()
+    method cosech(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Hyperbolic cosecant|https://en.wikipedia.org/wiki/Hyperbolic_function>.
@@ -515,7 +515,7 @@ L<Hyperbolic cosecant|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 Defined as:
 
     sub acosech(Numeric(Cool))
-    method acosech()
+    method acosech(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse hyperbolic cosecant|https://en.wikipedia.org/wiki/Inverse_hyperbolic_function>.
@@ -527,7 +527,7 @@ L<Inverse hyperbolic cosecant|https://en.wikipedia.org/wiki/Inverse_hyperbolic_f
 Defined as:
 
     sub cotanh(Numeric(Cool))
-    method cotanh()
+    method cotanh(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Hyperbolic cotangent|https://en.wikipedia.org/wiki/Hyperbolic_function>.
@@ -539,7 +539,7 @@ L<Hyperbolic cotangent|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 Defined as:
 
     sub acotanh(Numeric(Cool))
-    method acotanh()
+    method acotanh(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse hyperbolic cotangent|https://en.wikipedia.org/wiki/Inverse_hyperbolic_function>.
@@ -551,7 +551,7 @@ L<Inverse hyperbolic cotangent|https://en.wikipedia.org/wiki/Inverse_hyperbolic_
 Defined as:
 
     sub cis(Numeric(Cool))
-    method cis()
+    method cis(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns
 L<cos(argument) + i*sin(argument)|https://en.wikipedia.org/wiki/Cis_%28mathematics%29>.
@@ -722,7 +722,7 @@ L<Numeric|/type/Numeric>, and rounds it towards zero.
 Defined as:
 
     sub ord(Str(Cool))
-    method ord()
+    method ord(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns the L<Unicode code point|https://en.wikipedia.org/wiki/Code_point>
@@ -738,7 +738,7 @@ Mnemonic: returns an ordinal number
 
 Defined as:
 
-    method path()
+    method path(Cool: *%_)
 
 B<DEPRECATED>. I<It's been deprecated as of the 6.d version. Will be removed in
 the next ones.>
@@ -751,7 +751,7 @@ Use the L«C<.IO method>|/routine/IO» instead.
 Defined as:
 
     sub chr(Int(Cool))
-    method chr()
+    method chr(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Int|/type/Int>,
 interprets it as a
@@ -811,7 +811,7 @@ which Raku tightly follows, using a method called L<NFG, normal form graphemes|/
 Defined as:
 
     sub codes(Str(Cool))
-    method codes()
+    method codes(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns the number of L<Unicode code points|https://en.wikipedia.org/wiki/Code_point>.
@@ -829,7 +829,7 @@ L<ords|/routine/ords> first obtains the actual codepoints, so there might be a d
 Defined as:
 
     sub flip(Cool $s --> Str:D)
-    method flip()
+    method flip(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns a reversed version.
@@ -841,7 +841,7 @@ returns a reversed version.
 Defined as:
 
     sub trim(Str(Cool))
-    method trim()
+    method trim(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns the string with both leading and trailing whitespace stripped.
@@ -854,7 +854,7 @@ returns the string with both leading and trailing whitespace stripped.
 Defined as:
 
     sub trim-leading(Str(Cool))
-    method trim-leading()
+    method trim-leading(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns the string with leading whitespace stripped.
@@ -867,7 +867,7 @@ returns the string with leading whitespace stripped.
 Defined as:
 
     sub trim-trailing(Str(Cool))
-    method trim-trailing()
+    method trim-trailing(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns the string with trailing whitespace stripped.
@@ -880,7 +880,7 @@ returns the string with trailing whitespace stripped.
 Defined as:
 
     sub lc(Str(Cool))
-    method lc()
+    method lc(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns it case-folded to lower case.
@@ -892,7 +892,7 @@ returns it case-folded to lower case.
 Defined as:
 
     sub uc(Str(Cool))
-    method uc()
+    method uc(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns it case-folded to upper case (capital letters).
@@ -904,7 +904,7 @@ returns it case-folded to upper case (capital letters).
 Defined as:
 
     sub fc(Str(Cool))
-    method fc()
+    method fc(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns the result a Unicode "case fold" operation suitable for doing caseless
@@ -918,7 +918,7 @@ for any purpose other than comparison.)
 Defined as:
 
     sub tc(Str(Cool))
-    method tc()
+    method tc(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns it with the first letter case-folded to title case (or where not
@@ -931,7 +931,7 @@ available, upper case).
 Defined as:
 
     sub tclc(Str(Cool))
-    method tclc()
+    method tclc(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and returns it with the first letter
 case-folded to title case (or where not available, upper case), and the rest
@@ -1047,7 +1047,7 @@ codepoints, and L<uniparse|/routine/uniparse> for the opposite direction.
 Defined as:
 
     sub uninames(Str:D)
-    method uninames()
+    method uninames(Cool: *%_)
 
 Returns of a Seq of Unicode names for the all the codepoints in the Str
 provided.
@@ -1087,7 +1087,7 @@ returns false.
 Defined as:
 
     sub chop(Str(Cool))
-    method chop()
+    method chop(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns it with the last character removed.
@@ -1099,7 +1099,7 @@ returns it with the last character removed.
 Defined as:
 
     sub chomp(Str(Cool))
-    method chomp()
+    method chomp(Cool: *%_)
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns it with the last character removed, if it is a logical newline.
@@ -1134,7 +1134,7 @@ the arguments.
 Defined as:
 
     sub ords(Str(Cool) $str)
-    method ords()
+    method ords(Cool: *%_)
 
 Coerces the invocant (or in the sub form, the first argument) to
 L<Str|/type/Str>, and returns a list of Unicode codepoints for each character.
@@ -1151,7 +1151,7 @@ L<codes|/routine/codes> is a possibly faster option.
 Defined as:
 
     sub chrs(*@codepoints --> Str:D)
-    method chrs()
+    method chrs(Cool: *%_)
 
 Coerces the invocant (or in the sub form, the argument list) to a list of
 integers, and returns the string created by interpreting each integer as a
@@ -1235,7 +1235,7 @@ For that behavior, use the C<:skip-empty> named argument:
 Defined as:
 
     sub lines(Str(Cool))
-    method lines()
+    method lines(Cool: *%_)
 
 Coerces the invocant (and in sub form, the argument) to L<Str|/type/Str>,
 decomposes it into lines (with the newline characters stripped), and returns

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -286,7 +286,7 @@ radians.
 Defined as:
 
     sub atan2($y, $x = 1e0)
-    method atan2($x = 1e0)
+    method atan2($x = 1e0, *%_)
 
 The sub should usually be written with two arguments for clarity as it
 is seen in other languages and in mathematical texts, but the
@@ -622,7 +622,7 @@ Number) is used.
 
 Defined as:
 
-    method unpolar(Numeric(Cool))
+    method unpolar(Numeric(Cool), *%_)
 
 Coerces the arguments (including the invocant in the method form) to L<Numeric|/type/Numeric>, and returns
 a complex number from the given polar coordinates. The invocant (or the first argument in sub form) is the magnitude while
@@ -678,7 +678,7 @@ the nearest integer.
 
 Defined as:
 
-    method fmt($format = '%s')
+    method fmt($format = '%s', *%_)
 
 Uses C<$format> to return a formatted representation of the invocant; equivalent
 to calling L<sprintf|/routine/sprintf> with C<$format> as format and the
@@ -944,7 +944,7 @@ of the string case-folded to lower case.
 Defined as:
 
     sub wordcase(Str(Cool) $input, :&filter = &tclc, Mu :$where = True)
-    method wordcase(:&filter = &tclc, Mu :$where = True)
+    method wordcase(:&filter = &tclc, Mu :$where = True, *%_)
 
 Coerces the invocant (or in sub form, the first argument) to L<Str|/type/Str>, and filters each word that
 smartmatches against C<$where> through the C<&filter>. With the default
@@ -968,7 +968,7 @@ With a customer filter too:
 Defined as:
 
     sub samecase(Cool $string, Cool $pattern)
-    method samecase(Cool:D: Cool $pattern)
+    method samecase(Cool:D: Cool $pattern, *%_)
 
 Coerces the invocant (or in sub form, the first argument) to L<Str|/type/Str>,
 and returns a copy of C<$string> with case information for each individual

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -1025,7 +1025,7 @@ string.
 Defined as:
 
     sub uniname(Str(Cool) --> Str)
-    method uniname(--> Str)
+    method Cool(Cool: *%_ --> Str)
 
 Interprets the invocant or first argument as a L<Str|/type/Str>, and returns the
 Unicode codepoint name of the first codepoint of the first character. See
@@ -1465,7 +1465,7 @@ Coerces the invocant to L<Str|/type/Str> and calls L<Str.trans|/type/Str#method_
 
 Defined as:
 
-    method IO(--> IO::Path:D)
+    method Cool(Cool: *%_ --> IO::Path:D)
 
 Coerces the invocant to L<IO::Path|/type/IO::Path>.
 

--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -58,7 +58,8 @@ or DateTime object.  Optionally accepts a formatter as a named parameter.
 
 Defined as:
 
-    method new-from-daycount($daycount,:&formatter, *%_ --> Date:D)
+    multi method new-from-daycount(Date:U: $daycount, :&formatter, *%_ --> Date:D)
+    multi method new-from-daycount(Date:D: $daycount, :&formatter, *%_ --> Date:D)
 
 Creates a new C<Date> object given C<$daycount> which is the number
 of days from epoch Nov. 17, 1858, i.e. the
@@ -100,7 +101,7 @@ the invocant if the day value is already the first day of the month.
 
 Defined as:
 
-    method clone(:$year, :$month, :$day, :&formatter, *%_)
+    method clone(Date:D: :$year, :$month, :$day, :&formatter, *%_)
 
 Creates a new C<Date> object based on the invocant, but with the given
 arguments overriding the values from the invocant.
@@ -111,7 +112,7 @@ arguments overriding the values from the invocant.
 
 Defined as:
 
-    method today(:&formatter, *%_ --> Date:D)
+    method today(Date: :&formatter, *%_ --> Date:D)
 
 Returns a C<Date> object for the current day.  Optionally accepts a
 formatter named parameter.

--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -100,7 +100,7 @@ the invocant if the day value is already the first day of the month.
 
 Defined as:
 
-    method clone(:$year, :$month, :$day, :&formatter)
+    method clone(:$year, :$month, :$day, :&formatter, *%_)
 
 Creates a new C<Date> object based on the invocant, but with the given
 arguments overriding the values from the invocant.
@@ -164,7 +164,7 @@ towards the past applied. See L<#method later> for usage.
 
 Defined as:
 
-    method truncated-to(Date:D: Cool $unit)
+    method truncated-to(Date:D: Cool $unit, *%_)
 
 Returns a C<Date> truncated to the first day of its year, month or week.
 For example

--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -224,7 +224,7 @@ Returns the date in C<YYYY-MM-DD> format (L<ISO 8601|https://en.wikipedia.org/wi
 
 Defined as:
 
-    method Date(--> Date)
+    method Date(Date: *%_ --> Date)
 
 Returns the invocant.
 

--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -58,7 +58,7 @@ or DateTime object.  Optionally accepts a formatter as a named parameter.
 
 Defined as:
 
-    method new-from-daycount($daycount,:&formatter --> Date:D)
+    method new-from-daycount($daycount,:&formatter, *%_ --> Date:D)
 
 Creates a new C<Date> object given C<$daycount> which is the number
 of days from epoch Nov. 17, 1858, i.e. the
@@ -71,7 +71,7 @@ Optionally accepts a formatter as a named parameter.
 
 Defined as:
 
-    method last-date-in-month(Date:D: --> Date:D)
+    method last-date-in-month(Date:D: *%_ --> Date:D)
 
 Returns the last date in the month of the C«Date» object. Otherwise, returns
 the invocant if the day value is already the last day of the month.
@@ -89,7 +89,7 @@ for all remaining dates in the month.
 
 Defined as:
 
-    method first-date-in-month(Date:D: --> Date:D)
+    method first-date-in-month(Date:D: *%_ --> Date:D)
 
 Returns the first date in the month of the C«Date» object. Otherwise, returns
 the invocant if the day value is already the first day of the month.
@@ -111,7 +111,7 @@ arguments overriding the values from the invocant.
 
 Defined as:
 
-    method today(:&formatter --> Date:D)
+    method today(:&formatter, *%_ --> Date:D)
 
 Returns a C<Date> object for the current day.  Optionally accepts a
 formatter named parameter.
@@ -178,7 +178,7 @@ For example
 
 Defined as:
 
-    method succ(Date:D: --> Date:D)
+    method succ(Date:D: *%_ --> Date:D)
 
 Returns a C<Date> of the following day. "succ" is short for "successor".
 
@@ -188,7 +188,7 @@ Returns a C<Date> of the following day. "succ" is short for "successor".
 
 Defined as:
 
-    method pred(Date:D: --> Date:D)
+    method pred(Date:D: *%_ --> Date:D)
 
 Returns a C<Date> of the previous day. "pred" is short for "predecessor".
 

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -119,7 +119,7 @@ values, e.g.,
 
 Defined as:
 
-    method clone(:$year, :$month, :$day, :$hour, :$minute, :$second, :$timezone, :&formatter)
+    method clone(:$year, :$month, :$day, :$hour, :$minute, :$second, :$timezone, :&formatter, *%_)
 
 Creates a new C<DateTime> object based on the invocant, but with the given
 arguments overriding the values from the invocant.
@@ -334,7 +334,7 @@ Negative offsets are allowed, though L<later|/routine/later> is more idiomatic f
 
 Defined as:
 
-    method truncated-to(DateTime:D: Cool $unit)
+    method truncated-to(DateTime:D: Cool $unit, *%_)
 
 Returns a copy of the invocant, with everything smaller than the specified
 unit truncated to the smallest possible value.

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -367,7 +367,7 @@ say DateTime.Date;                                    # OUTPUT: «(Date)␤»
 
 Defined as:
 
-    method DateTime(--> DateTime)
+    method DateTime(DateTime: *%_ --> DateTime)
 
 Returns the invocant.
 

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -101,7 +101,7 @@ L<X::DateTime::TimezoneClash|/type/X::DateTime::TimezoneClash> is thrown.
 
 Defined as:
 
-    method now(:$timezone = $*TZ, :&formatter, *%_ --> DateTime:D)
+    method now(DateTime: :$timezone = $*TZ, :&formatter, *%_ --> DateTime:D)
 
 Creates a new C<DateTime> object from the current system time. A custom
 L<formatter|/routine/formatter> and L<timezone|/routine/timezone> can be provided. The C<:$timezone> is
@@ -119,7 +119,7 @@ values, e.g.,
 
 Defined as:
 
-    method clone(:$year, :$month, :$day, :$hour, :$minute, :$second, :$timezone, :&formatter, *%_)
+    method clone(DateTime: :$year, :$month, :$day, :$hour, :$minute, :$second, :$timezone, :&formatter, *%_)
 
 Creates a new C<DateTime> object based on the invocant, but with the given
 arguments overriding the values from the invocant.

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -168,7 +168,7 @@ Returns the minute component.
 
 Defined as:
 
-    method second(DateTime:D:)
+    method second(DateTime:D: *%_)
 
 Returns the second component, including potentially fractional seconds.
 
@@ -180,7 +180,7 @@ Returns the second component, including potentially fractional seconds.
 
 Defined as:
 
-    method whole-second(DateTime:D:)
+    method whole-second(DateTime:D: *%_)
 
 Returns the second component, rounded down to an L<Int|/type/Int>.
 

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -101,7 +101,7 @@ L<X::DateTime::TimezoneClash|/type/X::DateTime::TimezoneClash> is thrown.
 
 Defined as:
 
-    method now(:$timezone = $*TZ, :&formatter --> DateTime:D)
+    method now(:$timezone = $*TZ, :&formatter, *%_ --> DateTime:D)
 
 Creates a new C<DateTime> object from the current system time. A custom
 L<formatter|/routine/formatter> and L<timezone|/routine/timezone> can be provided. The C<:$timezone> is
@@ -137,7 +137,7 @@ Note that this can lead to invalid dates in some circumstances:
 
 Defined as:
 
-    method hh-mm-ss(DateTime:D: --> Str:D)
+    method hh-mm-ss(DateTime:D: *%_ --> Str:D)
 
 Returns the time represented by the object as a string in 24-hour HH:MM:SS format:
 
@@ -148,7 +148,7 @@ Returns the time represented by the object as a string in 24-hour HH:MM:SS forma
 
 Defined as:
 
-    method hour(DateTime:D: --> Int:D)
+    method hour(DateTime:D: *%_ --> Int:D)
 
 Returns the hour component.
 
@@ -158,7 +158,7 @@ Returns the hour component.
 
 Defined as:
 
-    method minute(DateTime:D: --> Int:D)
+    method minute(DateTime:D: *%_ --> Int:D)
 
 Returns the minute component.
 
@@ -190,7 +190,7 @@ Returns the second component, rounded down to an L<Int|/type/Int>.
 
 Defined as:
 
-    method timezone(DateTime:D: --> Int:D)
+    method timezone(DateTime:D: *%_ --> Int:D)
 
 Returns the time zone B<in seconds> as an offset from UTC.
 
@@ -200,7 +200,7 @@ Returns the time zone B<in seconds> as an offset from UTC.
 
 Defined as:
 
-    method offset(DateTime:D: --> Int:D)
+    method offset(DateTime:D: *%_ --> Int:D)
 
 Returns the time zone B<in seconds> as an offset from UTC. This is an alias for
 L<#method timezone>.
@@ -211,7 +211,7 @@ L<#method timezone>.
 
 Defined as:
 
-    method offset-in-minutes(DateTime:D: --> Real:D)
+    method offset-in-minutes(DateTime:D: *%_ --> Real:D)
 
 Returns the time zone in minutes as an offset from UTC.
 
@@ -221,7 +221,7 @@ Returns the time zone in minutes as an offset from UTC.
 
 Defined as:
 
-    method offset-in-hours(DateTime:D: --> Real:D)
+    method offset-in-hours(DateTime:D: *%_ --> Real:D)
 
 Returns the time zone in hours as an offset from UTC.
 
@@ -232,7 +232,7 @@ say DateTime.new('2015-12-24T12:23:00+0200').offset-in-hours;   # OUTPUT: «2␤
 
 Defined as:
 
-    method Str(DateTime:D: --> Str:D)
+    method Str(DateTime:D: *%_ --> Str:D)
 
 Returns a string representation of the invocant, as done by
 L<the formatter|/type/Dateish#method_formatter>.
@@ -246,7 +246,7 @@ say DateTime.new('2015-12-24T12:23:00+0200').Str;
 
 Defined as:
 
-    method Instant(DateTime:D: --> Instant:D)
+    method Instant(DateTime:D: *%_ --> Instant:D)
 
 Returns an L<Instant|/type/Instant> object based on the invocant.
 
@@ -256,7 +256,7 @@ Returns an L<Instant|/type/Instant> object based on the invocant.
 
 Defined as:
 
-    method posix(Bool:D: $ignore-timezone = False --> Int:D)
+    method posix(Bool:D: $ignore-timezone = False, *%_ --> Int:D)
 
 Returns the date and time as a POSIX/UNIX timestamp (seconds since the Epoch,
 1st January 1970 UTC).
@@ -380,7 +380,7 @@ Returns the invocant.
 
 Defined as:
 
-    method utc(DateTime:D: --> DateTime:D)
+    method utc(DateTime:D: *%_ --> DateTime:D)
 
 Returns a DateTime object for the same time, but in time zone UTC.
 
@@ -391,7 +391,7 @@ Returns a DateTime object for the same time, but in time zone UTC.
 
 Defined as:
 
-    method in-timezone(DateTime:D: Int(Cool) $timezone = 0 --> DateTime:D)
+    method in-timezone(DateTime:D: Int(Cool) $timezone = 0 *%_ --> DateTime:D)
 
 Returns a DateTime object for the same time, but in the specified C<$timezone>,
 which is the offset B<in seconds> from
@@ -409,7 +409,7 @@ not respect local time and always occur at the end of the I<UTC> day:
 
 Defined as:
 
-    method local(DateTime:D: --> DateTime:D)
+    method local(DateTime:D: *%_ --> DateTime:D)
 
 Returns a DateTime object for the same time, but in the local time zone
 (L«C<$*TZ>|/language/variables#index-entry-%24*TZ»).

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -71,7 +71,7 @@ invocant as its only argument.
 
 Defined as:
 
-    method is-leap-year(--> Bool:D)
+    method Dateish(Dateish: *%_ --> Bool:D)
 
 Returns C<True> if the year of the Dateish object is a leap year.
 

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -82,7 +82,7 @@ Returns C<True> if the year of the Dateish object is a leap year.
 
 Defined as:
 
-    method day-of-month(Date:D: --> Int:D)
+    method day-of-month(Date:D:, *%_ --> Int:D)
 
 Returns the day of the month of the date (1..31). Synonymous to the C<day>
 method.
@@ -94,7 +94,7 @@ method.
 
 Defined as:
 
-    method day-of-week(Date:D: --> Int:D)
+    method day-of-week(Date:D:, *%_ --> Int:D)
 
 Returns the day of the week, where 1 is Monday, 2 is Tuesday and Sunday is 7.
 
@@ -105,7 +105,7 @@ Returns the day of the week, where 1 is Monday, 2 is Tuesday and Sunday is 7.
 
 Defined as:
 
-    method day-of-year(Date:D: --> Int:D)
+    method day-of-year(Date:D:, *%_ --> Int:D)
 
 Returns the day of the year (1..366).
 
@@ -116,7 +116,7 @@ Returns the day of the year (1..366).
 
 Defined as:
 
-    method days-in-month(Dateish:D: --> Int:D)
+    method days-in-month(Dateish:D: *%_ --> Int:D)
 
 Returns the number of days in the month represented by the Dateish object:
 
@@ -141,7 +141,7 @@ at the start or end of a year, the week may actually belong to the other year.
 
 Defined as:
 
-    method week-number(Date:D: --> Int:D)
+    method week-number(Date:D:, *%_ --> Int:D)
 
 Returns the week number (1..53) of the date specified by the invocant. The first
 week of the year is defined by ISO as the one which contains the fourth day of
@@ -156,7 +156,7 @@ week of the next year.
 
 Defined as:
 
-    method week-year(Date:D: --> Int:D)
+    method week-year(Date:D:, *%_ --> Int:D)
 
 Returns the week year of the date specified by the invocant. Normally C<week-year>
 is equal to C<Date.year>. Note however that dates early in January often end up in
@@ -171,7 +171,7 @@ may be placed in the first week of the next year.
 
 Defined as:
 
-    method weekday-of-month(Date:D: --> Int:D)
+    method weekday-of-month(Date:D:, *%_ --> Int:D)
 
 Returns a number (1..5) indicating the number of times a particular day-of-week
 has occurred so far during that month, the day itself included.
@@ -183,7 +183,7 @@ has occurred so far during that month, the day itself included.
 Defined as:
 
 =for code :ok-test<dd>
-method yyyy-mm-dd(str $sep = "-" --> Str:D)
+    method yyyy-mm-dd(str $sep = "-", *%_ --> Str:D)
 
 Returns the date in C<YYYY-MM-DD> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>).
 The optional positional argument C<$sep>, which defaults to C«-», is a one-character
@@ -200,7 +200,7 @@ say Date.today.yyyy-mm-dd("/");          # OUTPUT: «2020/03/14␤»
 Defined as:
 
 =for code :ok-test<dd>
-method mm-dd-yyyy(str $sep = "-" --> Str:D)
+    method mm-dd-yyyy(str $sep = "-", *%_ --> Str:D)
 
 Returns the date in C<MM-DD-YYYY> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>).
 The optional positional argument C<$sep>, which defaults to C«-», is a one-character
@@ -217,7 +217,7 @@ say Date.today.mm-dd-yyyy("/");          # OUTPUT: «03/14/2020␤»
 Defined as:
 
 =for code :ok-test<dd>
-method dd-mm-yyyy(str $sep = "-" --> Str:D)
+    method dd-mm-yyyy(str $sep = "-", *%_ --> Str:D)
 
 Returns the date in C<DD-MM-YYYY> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>).
 The optional positional argument C<$sep>, which defaults to C«-», is a one-character
@@ -233,7 +233,7 @@ say Date.today.dd-mm-yyyy("/");           # OUTPUT: «14/03/2020␤»
 
 Defined as:
 
-    method daycount(Dateish:D: --> Int:D)
+    method daycount(Dateish:D: *%_ --> Int:D)
 
 Returns the number of days from the epoch Nov. 17, 1858 to the
 day of the invocant. The daycount returned by this method is the
@@ -248,7 +248,7 @@ chronological calculations.
 
 Defined as:
 
-    method IO(Dateish:D: --> IO::Path:D)
+    method IO(Dateish:D: *%_ --> IO::Path:D)
 
 Returns an L<IO::Path|/type/IO::Path> object representing the stringified
 value of the Dateish object:

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -71,7 +71,7 @@ invocant as its only argument.
 
 Defined as:
 
-    method Dateish(Dateish: *%_ --> Bool:D)
+    method is-leap-year(Dateish: *%_ --> Bool:D)
 
 Returns C<True> if the year of the Dateish object is a leap year.
 
@@ -82,7 +82,7 @@ Returns C<True> if the year of the Dateish object is a leap year.
 
 Defined as:
 
-    method day-of-month(Date:D:, *%_ --> Int:D)
+    method day-of-month(Date:D: *%_ --> Int:D)
 
 Returns the day of the month of the date (1..31). Synonymous to the C<day>
 method.
@@ -94,7 +94,7 @@ method.
 
 Defined as:
 
-    method day-of-week(Dateish:D:, *%_ --> Int:D)
+    method day-of-week(Dateish:D: *%_ --> Int:D)
 
 Returns the day of the week, where 1 is Monday, 2 is Tuesday and Sunday is 7.
 
@@ -105,7 +105,7 @@ Returns the day of the week, where 1 is Monday, 2 is Tuesday and Sunday is 7.
 
 Defined as:
 
-    method day-of-year(Date:D:, *%_ --> Int:D)
+    method day-of-year(Date:D: *%_ --> Int:D)
 
 Returns the day of the year (1..366).
 
@@ -141,7 +141,7 @@ at the start or end of a year, the week may actually belong to the other year.
 
 Defined as:
 
-    method week-number(Dateish:D:, *%_ --> Int:D)
+    method week-number(Dateish:D: *%_ --> Int:D)
 
 Returns the week number (1..53) of the date specified by the invocant. The first
 week of the year is defined by ISO as the one which contains the fourth day of
@@ -156,7 +156,7 @@ week of the next year.
 
 Defined as:
 
-    method week-year(Date:D:, *%_ --> Int:D)
+    method week-year(Date:D: *%_ --> Int:D)
 
 Returns the week year of the date specified by the invocant. Normally C<week-year>
 is equal to C<Date.year>. Note however that dates early in January often end up in
@@ -171,7 +171,7 @@ may be placed in the first week of the next year.
 
 Defined as:
 
-    method weekday-of-month(Date:D:, *%_ --> Int:D)
+    method weekday-of-month(Date:D: *%_ --> Int:D)
 
 Returns a number (1..5) indicating the number of times a particular day-of-week
 has occurred so far during that month, the day itself included.

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -94,7 +94,7 @@ method.
 
 Defined as:
 
-    method day-of-week(Date:D:, *%_ --> Int:D)
+    method day-of-week(Dateish:D:, *%_ --> Int:D)
 
 Returns the day of the week, where 1 is Monday, 2 is Tuesday and Sunday is 7.
 
@@ -141,7 +141,7 @@ at the start or end of a year, the week may actually belong to the other year.
 
 Defined as:
 
-    method week-number(Date:D:, *%_ --> Int:D)
+    method week-number(Dateish:D:, *%_ --> Int:D)
 
 Returns the week number (1..53) of the date specified by the invocant. The first
 week of the year is defined by ISO as the one which contains the fourth day of
@@ -183,7 +183,7 @@ has occurred so far during that month, the day itself included.
 Defined as:
 
 =for code :ok-test<dd>
-    method yyyy-mm-dd(str $sep = "-", *%_ --> Str:D)
+    method yyyy-mm-dd(Dateish: str $sep = "-", *%_ --> Str:D)
 
 Returns the date in C<YYYY-MM-DD> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>).
 The optional positional argument C<$sep>, which defaults to C«-», is a one-character
@@ -200,7 +200,7 @@ say Date.today.yyyy-mm-dd("/");          # OUTPUT: «2020/03/14␤»
 Defined as:
 
 =for code :ok-test<dd>
-    method mm-dd-yyyy(str $sep = "-", *%_ --> Str:D)
+    method mm-dd-yyyy(Dateish: str $sep = "-", *%_ --> Str:D)
 
 Returns the date in C<MM-DD-YYYY> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>).
 The optional positional argument C<$sep>, which defaults to C«-», is a one-character
@@ -217,7 +217,7 @@ say Date.today.mm-dd-yyyy("/");          # OUTPUT: «03/14/2020␤»
 Defined as:
 
 =for code :ok-test<dd>
-    method dd-mm-yyyy(str $sep = "-", *%_ --> Str:D)
+    method dd-mm-yyyy(Dateish: str $sep = "-", *%_ --> Str:D)
 
 Returns the date in C<DD-MM-YYYY> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>).
 The optional positional argument C<$sep>, which defaults to C«-», is a one-character

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -127,7 +127,7 @@ Returns the number of days in the month represented by the Dateish object:
 
 Defined as:
 
-    method week()
+    method week(Dateish: *%_)
 
 Returns a list of two integers: the year, and the week number. This is because
 at the start or end of a year, the week may actually belong to the other year.

--- a/doc/Type/Distribution.pod6
+++ b/doc/Type/Distribution.pod6
@@ -20,7 +20,7 @@ tar file or socket.
 
 =head2 method meta
 
-    method Distribution(Distribution: *%_ --> Hash:D) { ... }
+    method meta(Distribution: *%_ --> Hash:D) { ... }
 
 Returns a Hash with the representation of the metadata. Please note that an
 actual C<META6.json> file does not need to exist, just a representation in that

--- a/doc/Type/Distribution.pod6
+++ b/doc/Type/Distribution.pod6
@@ -28,7 +28,7 @@ format.
 
 =head2 method content
 
-    method content($name-path --> IO::Handle:D) { ... }
+    method content($name-path, *%_ --> IO::Handle:D) { ... }
 
 Returns an C<IO::Handle> to the file represented by C<$name-path>. C<$name-path>
 is a relative path as it would be found in the metadata such as C<lib/Foo.rakumod>

--- a/doc/Type/Distribution.pod6
+++ b/doc/Type/Distribution.pod6
@@ -20,7 +20,7 @@ tar file or socket.
 
 =head2 method meta
 
-    method meta(--> Hash:D) { ... }
+    method Distribution(Distribution: *%_ --> Hash:D) { ... }
 
 Returns a Hash with the representation of the metadata. Please note that an
 actual C<META6.json> file does not need to exist, just a representation in that

--- a/doc/Type/Distribution/Hash.pod6
+++ b/doc/Type/Distribution/Hash.pod6
@@ -15,7 +15,7 @@ L<C<Distribution::Path>|/type/Distribution::Path>.
 
 =head2 method new
 
-    method new($hash, :$prefix)
+    method new($hash, :$prefix, *%_)
 
 Creates a new C<Distribution::Hash> instance from the metadata contained in
 C<$hash>. All paths in the metadata will be prefixed with C<:$prefix>.

--- a/doc/Type/Encoding.pod6
+++ b/doc/Type/Encoding.pod6
@@ -20,7 +20,7 @@ consumers of the role.
 
 =head2 method name
 
-    method name(Encoding: *%_ --> Str)
+    method name($?CLASS: *%_ --> Str)
 
 Abstract method that would return the primary name of the encoding.
 
@@ -32,7 +32,7 @@ Abstract methods that should get a list of alternative names for the encoding.
 
 =head2 method decoder
 
-    method decoder(*%options, *%_ --> Encoding::Decoder)
+    method decoder($?CLASS: *%options --> Encoding::Decoder)
 
 Should get a character decoder instance for this encoding, configured with the
 provided options. Options vary by encoding. The built-in encodings all
@@ -43,7 +43,7 @@ C<\n> while decoding.
 
 Defined as:
 
-    method encoder(*%options, *%_ --> Encoding::Encoder)
+    method encoder($?CLASS: %options --> Encoding::Encoder)
 
 Gets a character encoder instance for this encoding, configured with the
 provided options. Options vary by encoding. The built-in encodings all support

--- a/doc/Type/Encoding.pod6
+++ b/doc/Type/Encoding.pod6
@@ -20,7 +20,7 @@ consumers of the role.
 
 =head2 method name
 
-    method name($?CLASS: *%_ --> Str)
+    method name(Encoding: *%_ --> Str)
 
 Abstract method that would return the primary name of the encoding.
 
@@ -32,7 +32,7 @@ Abstract methods that should get a list of alternative names for the encoding.
 
 =head2 method decoder
 
-    method decoder($?CLASS: *%options --> Encoding::Decoder)
+    method decoder(Encoding: *%options --> Encoding::Decoder)
 
 Should get a character decoder instance for this encoding, configured with the
 provided options. Options vary by encoding. The built-in encodings all
@@ -43,7 +43,7 @@ C<\n> while decoding.
 
 Defined as:
 
-    method encoder($?CLASS: %options --> Encoding::Encoder)
+    method encoder(Encoding: *%options --> Encoding::Encoder)
 
 Gets a character encoder instance for this encoding, configured with the
 provided options. Options vary by encoding. The built-in encodings all support

--- a/doc/Type/Encoding.pod6
+++ b/doc/Type/Encoding.pod6
@@ -26,7 +26,7 @@ Abstract method that would return the primary name of the encoding.
 
 =head2 method alternative-names
 
-    method alternative-names()
+    method alternative-names(Encoding: *%_)
 
 Abstract methods that should get a list of alternative names for the encoding.
 

--- a/doc/Type/Encoding.pod6
+++ b/doc/Type/Encoding.pod6
@@ -32,7 +32,7 @@ Abstract methods that should get a list of alternative names for the encoding.
 
 =head2 method decoder
 
-    method decoder(*%options --> Encoding::Decoder)
+    method decoder(*%options, *%_ --> Encoding::Decoder)
 
 Should get a character decoder instance for this encoding, configured with the
 provided options. Options vary by encoding. The built-in encodings all
@@ -43,7 +43,7 @@ C<\n> while decoding.
 
 Defined as:
 
-    method encoder(*%options --> Encoding::Encoder)
+    method encoder(*%options, *%_ --> Encoding::Encoder)
 
 Gets a character encoder instance for this encoding, configured with the
 provided options. Options vary by encoding. The built-in encodings all support

--- a/doc/Type/Encoding.pod6
+++ b/doc/Type/Encoding.pod6
@@ -20,7 +20,7 @@ consumers of the role.
 
 =head2 method name
 
-    method name(--> Str)
+    method name(Encoding: *%_ --> Str)
 
 Abstract method that would return the primary name of the encoding.
 

--- a/doc/Type/Enumeration.pod6
+++ b/doc/Type/Enumeration.pod6
@@ -97,7 +97,7 @@ C<Oðin> gets 1 since it is the second in the C<enum>.
 
 Defined as:
 
-    method enums()
+    method enums(Enumeration: *%_)
 
 Returns a L<Map|/type/Map> of enum values. Works both on the enum type
 and any key.

--- a/doc/Type/Enumeration.pod6
+++ b/doc/Type/Enumeration.pod6
@@ -121,7 +121,7 @@ say g.kv; # OUTPUT: «(g 1)␤»
 
 Defined as:
 
-    method pair(::?CLASS:D:)
+    method pair(::?CLASS:D: *%_)
 
 Returns it as a C<Pair>.
 
@@ -170,7 +170,7 @@ say Norse-gods.roll() for ^3;  # OUTPUT: «Freija␤Freija␤Oðin␤»
 
 Defined as:
 
-    method pred(::?CLASS:D:)
+    method pred(::?CLASS:D: *%_)
 
 =for code :preamble«enum Norse-gods <Þor Oðin Freija>;»
 say Freija.pred;  # OUTPUT: «Oðin␤»
@@ -179,7 +179,7 @@ say Freija.pred;  # OUTPUT: «Oðin␤»
 
 Defined as:
 
-    method succ(::?CLASS:D:)
+    method succ(::?CLASS:D: *%_)
 
 =for code :preamble«enum Norse-gods <Þor Oðin Freija>;»
 say Oðin.succ;  # OUTPUT: «Freija␤»

--- a/doc/Type/Exception.pod6
+++ b/doc/Type/Exception.pod6
@@ -26,7 +26,7 @@ define at least a method C<message>.
 
 Defined as:
 
-    method message(Exception:D: --> Str:D)
+    method message(Exception:D: *%_ --> Str:D)
 
 This is a stub that must be overwritten by subclasses, and should
 return the exception message.

--- a/doc/Type/Exception.pod6
+++ b/doc/Type/Exception.pod6
@@ -43,7 +43,7 @@ an exception itself.
 
 Defined as:
 
-    method backtrace(Exception:D:)
+    method backtrace(Exception:D: *%_)
 
 Returns the backtrace associated with the exception in a
 L<C<Backtrace>|/type/Backtrace> object or an empty string if there is none. Only
@@ -56,7 +56,7 @@ makes sense on exceptions that have been thrown at least once.
 
 Defined as:
 
-    method throw(Exception:D:)
+    method throw(Exception:D: *%_)
 
 Throws the exception.
 
@@ -68,7 +68,7 @@ Throws the exception.
 
 Defined as:
 
-    method resume(Exception:D:)
+    method resume(Exception:D: *%_)
 
 Resumes control flow where C<.throw> left it when handled in a C<CATCH> block.
 
@@ -79,7 +79,7 @@ Resumes control flow where C<.throw> left it when handled in a C<CATCH> block.
 
 Defined as:
 
-    method rethrow(Exception:D:)
+    method rethrow(Exception:D: *%_)
 
 Rethrows an exception that has already been thrown at least once.
 This is different from C<throw> in that it preserves the original
@@ -95,7 +95,7 @@ backtrace.
 Defined as:
 
     multi sub    fail(Exception $e)
-    method       fail(Exception:D:)
+    method fail(Exception:D: *%_)
 
 Exits the calling C<Routine> and returns a L<Failure|/type/Failure> object wrapping the
 exception.
@@ -142,7 +142,7 @@ Defined as:
     multi sub die()
     multi sub die(*@message)
     multi sub die(Exception:D $e)
-    method    die(Exception:D:)
+    method die(Exception:D: *%_)
 
 Throws a fatal L<Exception|/type/Exception>. The default exception handler prints each
 element of the list to

--- a/doc/Type/Exception.pod6
+++ b/doc/Type/Exception.pod6
@@ -15,7 +15,7 @@ User-defined exception classes should inherit from C<Exception> too, and
 define at least a method C<message>.
 
     class X::YourApp::SomeError is Exception {
-        method message() {
+    method message(Exception: *%_) {
             "A YourApp-Specific error occurred: out of coffee!";
         }
     }

--- a/doc/Type/Exception.pod6
+++ b/doc/Type/Exception.pod6
@@ -15,7 +15,7 @@ User-defined exception classes should inherit from C<Exception> too, and
 define at least a method C<message>.
 
     class X::YourApp::SomeError is Exception {
-    method message(Exception: *%_) {
+        method message() {
             "A YourApp-Specific error occurred: out of coffee!";
         }
     }

--- a/doc/Type/ForeignCode.pod6
+++ b/doc/Type/ForeignCode.pod6
@@ -41,7 +41,7 @@ Returns the number of arguments the enclosed code needs.
 
 =head2 method signature
 
-    method signature( ForeignCode:D: )
+    method signature( ForeignCode:D: *%_)
 
 Returns the signature of the enclosed code.
 
@@ -53,13 +53,13 @@ Returns the name of the enclosed code, or C«<anon>» if it has not received any
 
 =head2 method gist
 
-    method gist( ForeignCode:D: )
+    method gist( ForeignCode:D: *%_)
 
 Returns the name of the code by calling C<name>.
 
 =head2 method Str
 
-    method Str( ForeignCode:D: )
+    method Str( ForeignCode:D: *%_)
 
 Returns the name of the code by calling C<name>.
 

--- a/doc/Type/ForeignCode.pod6
+++ b/doc/Type/ForeignCode.pod6
@@ -41,7 +41,7 @@ Returns the number of arguments the enclosed code needs.
 
 =head2 method signature
 
-    method signature( ForeignCode:D: *%_)
+    method signature(ForeignCode:D: *%_)
 
 Returns the signature of the enclosed code.
 
@@ -53,7 +53,7 @@ Returns the name of the enclosed code, or C«<anon>» if it has not received any
 
 =head2 method gist
 
-    method gist( ForeignCode:D: *%_)
+    method gist(ForeignCode:D: *%_)
 
 Returns the name of the code by calling C<name>.
 

--- a/doc/Type/ForeignCode.pod6
+++ b/doc/Type/ForeignCode.pod6
@@ -29,13 +29,13 @@ L<C<Method>s|/type/Method>.
 
 =head2 method arity
 
-    method arity()
+    method arity(ForeignCode: *%_)
 
 Returns the arity of the enclosed code.
 
 =head2 method count
 
-    method count()
+    method count(ForeignCode: *%_)
 
 Returns the number of arguments the enclosed code needs.
 
@@ -47,7 +47,7 @@ Returns the signature of the enclosed code.
 
 =head2 method name
 
-    method name()
+    method name(ForeignCode: *%_)
 
 Returns the name of the enclosed code, or C«<anon>» if it has not received any.
 

--- a/doc/Type/Grammar.pod6
+++ b/doc/Type/Grammar.pod6
@@ -29,7 +29,7 @@ More L<documentation on grammars|/language/grammars> is available.
 
 Defined as:
 
-    method parse($target, :$rule = 'TOP',  Capture() :$args = \(), Mu :$actions = Mu, *%opt)
+    method parse(Grammar: $target, :$rule = 'TOP',  Capture() :$args = \(), Mu :$actions = Mu, *%opt)
 
 Parses the C<$target>, which will be coerced to L<Str|/type/Str> if it isn't
 one, using C<$rule> as the starting rule. Additional C<$args> will be passed
@@ -80,7 +80,7 @@ failure.
 
 Defined as:
 
-    method subparse($target, :$rule = 'TOP', Capture() :$args = \(),  Mu :$actions = Mu, *%opt)
+    method subparse(Grammar: $target, :$rule = 'TOP', Capture() :$args = \(),  Mu :$actions = Mu, *%opt)
 
 Does exactly the same as L<method parse|/routine/parse>, except that cursor
 doesn't have to reach the end of the string to succeed. That is, it doesn't
@@ -110,7 +110,7 @@ if the grammar failed to match.
 
 Defined as:
 
-    method parsefile(Str(Cool) $filename, :$enc, *%opts)
+    method parsefile(Grammar: Str(Cool) $filename, :$enc, *%opts)
 
 Reads file C<$filename> encoding by C<$enc>, and parses it. All named arguments
 are passed on to L<method parse|/routine/parse>.

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -360,7 +360,7 @@ is:
 
 Defined as:
 
-    method default()
+    method default(Hash: *%_)
 
 Returns the default value of the invocant, i.e. the value which is returned when
 a non existing key is used to access an element in the C<Hash>. Unless the
@@ -380,7 +380,7 @@ C<(Any)>.
 
 Defined as:
 
-    method keyof()
+    method keyof(Hash: *%_)
 
 Returns the type constraint for the keys of the invocant. For
 normal hashes the method returns the coercion type C<(Str(Any))>
@@ -404,7 +404,7 @@ hashes the type used in the declaration of the C<Hash> is returned.
 
 Defined as:
 
-    method of()
+    method of(Hash: *%_)
 
 Returns the type constraint for the values of the invocant. By default,
 i.e., if no type constraint is given during declaration, the method

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -330,7 +330,7 @@ value as is, whereas C<append> will L«C<slip>|/routine/slip» it in:
 
 Defined as:
 
-    method append(+@values, *%_)
+    method append(Hash: +@values, *%_)
 
 Append the provided Pairs or even sized list to the Hash. If a key already
 exists, turn the existing value into an L<Array|/type/Array> and push new value

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -330,7 +330,7 @@ value as is, whereas C<append> will L«C<slip>|/routine/slip» it in:
 
 Defined as:
 
-    method append(+@values)
+    method append(+@values, *%_)
 
 Append the provided Pairs or even sized list to the Hash. If a key already
 exists, turn the existing value into an L<Array|/type/Array> and push new value

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -420,7 +420,7 @@ returns C<(Mu)>.
 
 Defined as:
 
-    method Hash(Hash: *%_ --> Bool:D)
+    method dynamic(Hash: *%_ --> Bool:D)
 
 Returns C<True> if the invocant has been declared with the
 L<is dynamic|/routine/is dynamic> trait.

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -420,7 +420,7 @@ returns C<(Mu)>.
 
 Defined as:
 
-    method dynamic(--> Bool:D)
+    method Hash(Hash: *%_ --> Bool:D)
 
 Returns C<True> if the invocant has been declared with the
 L<is dynamic|/routine/is dynamic> trait.

--- a/doc/Type/HyperSeq.pod6
+++ b/doc/Type/HyperSeq.pod6
@@ -75,7 +75,7 @@ Returns C<False>.
 
 Defined as:
 
-    method sink(--> Nil)
+    method sink(HyperSeq: *%_ --> Nil)
 
 Sinks the underlying data structure, producing any side effects.
 

--- a/doc/Type/HyperSeq.pod6
+++ b/doc/Type/HyperSeq.pod6
@@ -16,7 +16,7 @@ it's not intended for direct consumption by the developer.
 
 =head2 method iterator
 
-    method iterator(HyperSeq:D: --> Iterator:D)
+    method iterator(HyperSeq:D: *%_ --> Iterator:D)
 
 Returns the underlying iterator.
 

--- a/doc/Type/HyperSeq.pod6
+++ b/doc/Type/HyperSeq.pod6
@@ -42,19 +42,19 @@ Uses maps on the C<HyperSeq>, generally created by application of C<hyper> to
 
 =head2 method invert
 
-    method invert(HyperSeq:D:)
+    method invert(HyperSeq:D: *%_)
 
 Inverts the C<HyperSeq> created from a C<Seq> by C<.hyper>.
 
 =head2 method hyper
 
-    method hyper(HyperSeq:D:)
+    method hyper(HyperSeq:D: *%_)
 
 Returns the object.
 
 =head2 method race
 
-    method race(HyperSeq:D:)
+    method race(HyperSeq:D: *%_)
 
 Creates a C<RaceSeq> object out of the current one.
 

--- a/doc/Type/HyperSeq.pod6
+++ b/doc/Type/HyperSeq.pod6
@@ -66,7 +66,7 @@ Converts the object to a C<Seq> and returns it.
 
 =head2 method is-lazy
 
-    method is-lazy(--> False )
+    method HyperSeq(HyperSeq: *%_ --> False )
 
 Returns C<False>.
 

--- a/doc/Type/HyperSeq.pod6
+++ b/doc/Type/HyperSeq.pod6
@@ -66,7 +66,7 @@ Converts the object to a C<Seq> and returns it.
 
 =head2 method is-lazy
 
-    method HyperSeq(HyperSeq: *%_ --> False )
+    method is-lazy(HyperSeq: *%_ --> False )
 
 Returns C<False>.
 

--- a/doc/Type/Instant.pod6
+++ b/doc/Type/Instant.pod6
@@ -54,7 +54,7 @@ Instant:1485726632
 
 =head2 method from-posix
 
-    method from-posix($posix, Bool $prefer-leap-second = False, *%_)
+    method from-posix(Instant: $posix, Bool $prefer-leap-second = False, *%_)
 
 Converts the POSIX timestamp C<$posix> to an Instant.
 If C<$prefer-leap-second> is C<True>, the return value will be

--- a/doc/Type/Instant.pod6
+++ b/doc/Type/Instant.pod6
@@ -80,7 +80,7 @@ second.
 
 Defined as:
 
-    method Date(Instant:D: --> Date:D)
+    method Date(Instant:D: *%_ --> Date:D)
 
 Coerces the invocant to L<Date|/type/Date>.
 
@@ -92,7 +92,7 @@ Coerces the invocant to L<Date|/type/Date>.
 
 Defined as:
 
-    method DateTime(Instant:D: --> DateTime:D)
+    method DateTime(Instant:D: *%_ --> DateTime:D)
 
 Coerces the invocant to L<DateTime|/type/DateTime>.
 

--- a/doc/Type/Instant.pod6
+++ b/doc/Type/Instant.pod6
@@ -54,7 +54,7 @@ Instant:1485726632
 
 =head2 method from-posix
 
-    method from-posix($posix, Bool $prefer-leap-second = False)
+    method from-posix($posix, Bool $prefer-leap-second = False, *%_)
 
 Converts the POSIX timestamp C<$posix> to an Instant.
 If C<$prefer-leap-second> is C<True>, the return value will be

--- a/doc/Type/Instant.pod6
+++ b/doc/Type/Instant.pod6
@@ -65,7 +65,7 @@ the first of the two possible seconds in the case of a leap second.
 
 =head2 method to-posix
 
-    method to-posix()
+    method to-posix(Instant: *%_)
 
 Converts the invocant to a POSIX timestamp and returns a two
 element list containing the POSIX timestamp and a C<Bool>.

--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -240,7 +240,7 @@ Returns a L<Range object|/type/Range> that represents the range of values suppor
 
 Defined as:
 
-    method Bridge(Int:D: --> Num:D)
+    method Bridge(Int:D: *%_ --> Num:D)
 
 Returns the integer converted to C<Num>.
 

--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -103,7 +103,7 @@ equivalent to C<($x ** $y)> mod $mod.
 
 Defined as:
 
-    method polymod(Int:D: +@mods)
+    method polymod(Int:D: +@mods, *%_)
 
 Returns a sequence of mod results corresponding to the divisors in C<@mods> in
 the same order as they appear there. For the best effect,  the divisors should

--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -59,7 +59,7 @@ The first form will throw an exception; the second and third form will create
 
 Defined as:
 
-    method Capture()
+    method Capture(Int: *%_)
 
 Throws C<X::Cannot::Capture>.
 

--- a/doc/Type/IntStr.pod6
+++ b/doc/Type/IntStr.pod6
@@ -26,7 +26,7 @@ object identity with C<Int>- or C<Str>-only variants:
 
 =head2 method new
 
-    method new(Int $i, Str $s)
+    method new(Int $i, Str $s, *%_)
 
 The constructor requires both the C<Int> and the C<Str> value, when constructing one
 directly the values can be whatever is required:

--- a/doc/Type/IntStr.pod6
+++ b/doc/Type/IntStr.pod6
@@ -26,7 +26,7 @@ object identity with C<Int>- or C<Str>-only variants:
 
 =head2 method new
 
-    method new(Int $i, Str $s, *%_)
+    method new(IntStr: Int $i, Str $s, *%_)
 
 The constructor requires both the C<Int> and the C<Str> value, when constructing one
 directly the values can be whatever is required:

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -148,7 +148,7 @@ B«L<blog post on the semantics of hyper and race|https://6guts.wordpress.com/20
 
 Defined as:
 
-    method race(Int(Cool) :$batch = 64, Int(Cool) :$degree = 4 --> Iterable)
+    method race(Int(Cool) :$batch = 64, Int(Cool) :$degree = 4, *%_ --> Iterable)
 
 Returns another Iterable that is potentially iterated in parallel, with a
 given batch size and degree of parallelism (number of parallel workers).

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -97,7 +97,7 @@ Returns a lazy iterable wrapping the invocant.
 
 Defined as:
 
-    method hyper(Int(Cool) :$batch = 64, Int(Cool) :$degree = 4)
+    method hyper(Int(Cool) :$batch = 64, Int(Cool) :$degree = 4, *%_)
 
 Returns another Iterable that is potentially iterated in parallel, with
 a given batch size and degree of parallelism.

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -44,7 +44,7 @@ the C<iterator> role printing the letters in groups of 3.
 
 Defined as:
 
-    method Iterable(Iterable: *%_ --> Iterator:D)
+    method iterator(Iterable: *%_ --> Iterator:D)
 
 Method stub that ensures all classes doing the C<Iterable> role have a
 method C<iterator>.
@@ -86,7 +86,7 @@ and so de-containerize them, so that C<flat> can flatten them:
 
 Defined as:
 
-    method Iterable(Iterable: *%_ --> Iterable)
+    method lazy(Iterable: *%_ --> Iterable)
 
 Returns a lazy iterable wrapping the invocant.
 
@@ -97,7 +97,7 @@ Returns a lazy iterable wrapping the invocant.
 
 Defined as:
 
-    method hyper($?CLASS: Int(Cool) :$batch = 64, Int(Cool) :$degree = 4, *%_)
+    method hyper(Iterable: int(Cool) :$batch = 64, Int(Cool) :$degree = 4, *%_)
 
 Returns another Iterable that is potentially iterated in parallel, with
 a given batch size and degree of parallelism.
@@ -148,7 +148,7 @@ B«L<blog post on the semantics of hyper and race|https://6guts.wordpress.com/20
 
 Defined as:
 
-    method race($?CLASS: Int(Cool) :$batch = 64, Int(Cool) :$degree = 4, *%_ --> Iterable)
+    method race(Iterable: Int(Cool) :$batch = 64, Int(Cool) :$degree = 4, *%_ --> Iterable)
 
 Returns another Iterable that is potentially iterated in parallel, with a
 given batch size and degree of parallelism (number of parallel workers).

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -97,7 +97,7 @@ Returns a lazy iterable wrapping the invocant.
 
 Defined as:
 
-    method hyper(Int(Cool) :$batch = 64, Int(Cool) :$degree = 4, *%_)
+    method hyper($?CLASS: Int(Cool) :$batch = 64, Int(Cool) :$degree = 4, *%_)
 
 Returns another Iterable that is potentially iterated in parallel, with
 a given batch size and degree of parallelism.
@@ -148,7 +148,7 @@ B«L<blog post on the semantics of hyper and race|https://6guts.wordpress.com/20
 
 Defined as:
 
-    method race(Int(Cool) :$batch = 64, Int(Cool) :$degree = 4, *%_ --> Iterable)
+    method race($?CLASS: Int(Cool) :$batch = 64, Int(Cool) :$degree = 4, *%_ --> Iterable)
 
 Returns another Iterable that is potentially iterated in parallel, with a
 given batch size and degree of parallelism (number of parallel workers).

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -23,7 +23,7 @@ class DNA does Iterable {
         self.bless( :$chain );
     }
 
-    method iterator(DNA:D:) {
+    method iterator(DNA:D: *%_) {
         $!chain.comb.rotor(3).iterator;
     }
 }

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -44,7 +44,7 @@ the C<iterator> role printing the letters in groups of 3.
 
 Defined as:
 
-    method iterator(--> Iterator:D)
+    method Iterable(Iterable: *%_ --> Iterator:D)
 
 Method stub that ensures all classes doing the C<Iterable> role have a
 method C<iterator>.
@@ -57,7 +57,7 @@ It is supposed to return an L<Iterator|/type/Iterator>.
 
 Defined as:
 
-    method flat(--> Iterable)
+    method Iterable(Iterable: *%_ --> Iterable)
 
 Returns another L<Iterable|/type/Iterable> that flattens out all iterables that
 the first one returns.
@@ -86,7 +86,7 @@ and so de-containerize them, so that C<flat> can flatten them:
 
 Defined as:
 
-    method lazy(--> Iterable)
+    method Iterable(Iterable: *%_ --> Iterable)
 
 Returns a lazy iterable wrapping the invocant.
 

--- a/doc/Type/Iterator.pod6
+++ b/doc/Type/Iterator.pod6
@@ -269,7 +269,7 @@ for an example implementation.
 
 Defined as:
 
-    method push-all(Iterator:D: $target)
+    method push-all(Iterator:D: $target, *%_)
 
 Should produce all elements from the iterator and push them to C<$target>.
 
@@ -303,7 +303,7 @@ class DNA does Iterable does Iterator {
       }
     }
 
-    method push-all(Iterator:D: $target) {
+    method push-all(Iterator:D: $target, *%_) {
         for $.chain.comb.rotor(3) -> $codon {
             $target.push: $codon;
         }

--- a/doc/Type/Iterator.pod6
+++ b/doc/Type/Iterator.pod6
@@ -170,7 +170,7 @@ until IterationEnd =:= (my \pulled = $iterator.pull-one) {
 
 Defined as:
 
-    method push-exactly(Iterator:D: $target, int $count *%_ --> Mu)
+    method push-exactly(Iterator:D: $target, int $count, *%_ --> Mu)
 
 Should produce C<$count> elements, and for each of them, call
 C<$target.push($value)>.
@@ -211,7 +211,7 @@ class DNA does Iterable does Iterator {
       }
     }
 
-    method push-exactly(Iterator:D: $target, int $count *%_ --> Mu) {
+    method push-exactly($target, int $count --> Mu) {
         return IterationEnd if $.chain.elems / 3 < $count;
         for ^($count) {
             $target.push: $.chain.comb.rotor(3)[ $_ ];
@@ -241,7 +241,7 @@ called with the number of loop variables as the C<$count> variable.
 
 Defined as:
 
-    method push-at-least(Iterator:D: $target, int $count *%_ --> Mu)
+    method push-at-least(Iterator:D: $target, int $count, *%_ --> Mu)
 
 Should produce at least C<$count> elements, and for each of them, call
 C<$target.push($value)>.
@@ -324,7 +324,7 @@ C<$b> to C<@dna-array>.
 
 Defined as:
 
-    method push-until-lazy(Iterator:D: $target *%_ --> Mu)
+    method push-until-lazy(Iterator:D: $target, *%_ --> Mu)
 
 Should produce values until it considers itself to be lazy, and push them onto
 C<$target>.
@@ -373,7 +373,7 @@ until it is exhausted.
 
 Defined as:
 
-    method skip-one(Iterator:D: $target *%_ --> Mu)
+    method skip-one(Iterator:D: $target, *%_ --> Mu)
 
 Should skip producing one value. The return value should be truthy if the skip
 was successful and falsy if there were no values to be skipped:
@@ -389,7 +389,7 @@ whether the value obtained was not C<IterationEnd>.
 
 Defined as:
 
-    method skip-at-least(Iterator:D: $target, int $to-skip *%_ --> Mu)
+    method skip-at-least(Iterator:D: $target, int $to-skip, *%_ --> Mu)
 
 Should skip producing C<$to-skip> values. The return value should be truthy if
 the skip was successful and falsy if there were not enough values to be skipped:
@@ -405,7 +405,7 @@ returning whether it returned a truthy value sufficient number of times.
 
 Defined as:
 
-    method skip-at-least-pull-one(Iterator:D: $target, int $to-skip *%_ --> Mu)
+    method skip-at-least-pull-one(Iterator:D: $target, int $to-skip, *%_ --> Mu)
 
 Should skip producing C<$to-skip> values and if the iterator is still not
 exhausted, produce and return the next value.  Should return C<IterationEnd>

--- a/doc/Type/Iterator.pod6
+++ b/doc/Type/Iterator.pod6
@@ -104,7 +104,7 @@ say $is-it-the-end =:= IterationEnd; # OUTPUT: «True␤»
 
 Defined as:
 
-    method pull-one(Iterator:D: --> Mu)
+    method pull-one(Iterator:D: *%_ --> Mu)
 
 This method stub ensures that classes implementing the C<Iterator> role
 provide a method named C<pull-one>.
@@ -170,7 +170,7 @@ until IterationEnd =:= (my \pulled = $iterator.pull-one) {
 
 Defined as:
 
-    method push-exactly(Iterator:D: $target, int $count --> Mu)
+    method push-exactly(Iterator:D: $target, int $count *%_ --> Mu)
 
 Should produce C<$count> elements, and for each of them, call
 C<$target.push($value)>.
@@ -201,7 +201,7 @@ class DNA does Iterable does Iterator {
 
     method iterator( ){ self }
 
-    method pull-one( --> Mu){
+    method pull-one(, *%_ --> Mu){
       if $!index < $.chain.chars {
          my $codon = $.chain.comb.rotor(3)[$!index div 3];
          $!index += 3;
@@ -211,7 +211,7 @@ class DNA does Iterable does Iterator {
       }
     }
 
-    method push-exactly(Iterator:D: $target, int $count --> Mu) {
+    method push-exactly(Iterator:D: $target, int $count *%_ --> Mu) {
         return IterationEnd if $.chain.elems / 3 < $count;
         for ^($count) {
             $target.push: $.chain.comb.rotor(3)[ $_ ];
@@ -241,7 +241,7 @@ called with the number of loop variables as the C<$count> variable.
 
 Defined as:
 
-    method push-at-least(Iterator:D: $target, int $count --> Mu)
+    method push-at-least(Iterator:D: $target, int $count *%_ --> Mu)
 
 Should produce at least C<$count> elements, and for each of them, call
 C<$target.push($value)>.
@@ -293,7 +293,7 @@ class DNA does Iterable does Iterator {
     }
 
     method iterator( ){ self }
-    method pull-one( --> Mu){
+    method pull-one(, *%_ --> Mu){
       if $!index < $.chain.chars {
          my $codon = $.chain.comb.rotor(3)[$!index div 3];
          $!index += 3;
@@ -324,7 +324,7 @@ C<$b> to C<@dna-array>.
 
 Defined as:
 
-    method push-until-lazy(Iterator:D: $target --> Mu)
+    method push-until-lazy(Iterator:D: $target *%_ --> Mu)
 
 Should produce values until it considers itself to be lazy, and push them onto
 C<$target>.
@@ -339,7 +339,7 @@ which might be lazy, while others aren't.
 
 Defined as:
 
-    method is-lazy(Iterator:D: --> Bool:D)
+    method is-lazy(Iterator:D: *%_ --> Bool:D)
 
 Should return C<True> for iterators that consider themselves lazy, and C<False>
 otherwise.
@@ -357,7 +357,7 @@ non-lazy iterator.
 
 Defined as:
 
-    method sink-all(Iterator:D: --> IterationEnd)
+    method sink-all(Iterator:D: *%_ --> IterationEnd)
 
 Should exhaust the iterator purely for the side-effects of producing the
 values, without actually saving them in any way.  Should always return
@@ -373,7 +373,7 @@ until it is exhausted.
 
 Defined as:
 
-    method skip-one(Iterator:D: $target --> Mu)
+    method skip-one(Iterator:D: $target *%_ --> Mu)
 
 Should skip producing one value. The return value should be truthy if the skip
 was successful and falsy if there were no values to be skipped:
@@ -389,7 +389,7 @@ whether the value obtained was not C<IterationEnd>.
 
 Defined as:
 
-    method skip-at-least(Iterator:D: $target, int $to-skip --> Mu)
+    method skip-at-least(Iterator:D: $target, int $to-skip *%_ --> Mu)
 
 Should skip producing C<$to-skip> values. The return value should be truthy if
 the skip was successful and falsy if there were not enough values to be skipped:
@@ -405,7 +405,7 @@ returning whether it returned a truthy value sufficient number of times.
 
 Defined as:
 
-    method skip-at-least-pull-one(Iterator:D: $target, int $to-skip --> Mu)
+    method skip-at-least-pull-one(Iterator:D: $target, int $to-skip *%_ --> Mu)
 
 Should skip producing C<$to-skip> values and if the iterator is still not
 exhausted, produce and return the next value.  Should return C<IterationEnd>

--- a/doc/Type/Iterator.pod6
+++ b/doc/Type/Iterator.pod6
@@ -201,7 +201,7 @@ class DNA does Iterable does Iterator {
 
     method iterator( ){ self }
 
-    method pull-one(, *%_ --> Mu){
+    method pull-one( --> Mu){
       if $!index < $.chain.chars {
          my $codon = $.chain.comb.rotor(3)[$!index div 3];
          $!index += 3;
@@ -293,7 +293,7 @@ class DNA does Iterable does Iterator {
     }
 
     method iterator( ){ self }
-    method pull-one(, *%_ --> Mu){
+    method pull-one( --> Mu){
       if $!index < $.chain.chars {
          my $codon = $.chain.comb.rotor(3)[$!index div 3];
          $!index += 3;

--- a/doc/Type/Kernel.pod6
+++ b/doc/Type/Kernel.pod6
@@ -35,7 +35,7 @@ processor.  Usually B<32> or B<64>.
 
 =head2 method cpu-cores
 
-    method cpu-cores(--> Int)
+    method cpu-cores(Kernel: *%_ --> Int)
 
 Instance / Class method returning the number of CPU cores that are available.
 
@@ -43,14 +43,14 @@ Instance / Class method returning the number of CPU cores that are available.
 
 =head2 method cpu-usage
 
-    method cpu-usage(--> Int)
+    method cpu-usage(Kernel: *%_ --> Int)
 
 Instance / Class method returning the amount of CPU uses since the start of
 the program (in microseconds).
 
 =head2 method free-memory
 
-    method free-memory(--> Int)
+    method free-memory(Kernel: *%_ --> Int)
 
 Instance / Class method returning the available memory on the system. When
 using the JVM, this returns the available memory to the JVM instead. This
@@ -58,7 +58,7 @@ method is only available in release v2019.06 and later.
 
 =head2 method total-memory
 
-    method total-memory(--> Int)
+    method total-memory(Kernel: *%_ --> Int)
 
 Instance / Class method returning the total memory available to the system.
 When using the JVM, this returns the total memory available to the JVM instead.
@@ -66,7 +66,7 @@ This method is only available in release v2019.06 and later.
 
 =head2 method endian
 
-    method endian(--> Endian:D)
+    method endian(Kernel: *%_ --> Endian:D)
 
 Class method that returns the L<Endian|/type/Endian> object associated with
 the kernel architecture (either C<LittleEndian> or C<BigEndian>).

--- a/doc/Type/Label.pod6
+++ b/doc/Type/Label.pod6
@@ -61,7 +61,7 @@ You can use, however, other alphabets like here:
 
 Defined as:
 
-    method name()
+    method name(Label: *%_)
 
 Not terribly useful, returns the name of the defined label:
 

--- a/doc/Type/Label.pod6
+++ b/doc/Type/Label.pod6
@@ -75,7 +75,7 @@ Not terribly useful, returns the name of the defined label:
 
 Defined as:
 
-    method next(Label:)
+    method next(Label: *%_)
 
 Begin the next iteration of the loop associated with the label.
 
@@ -91,7 +91,7 @@ Begin the next iteration of the loop associated with the label.
 
 Defined as:
 
-    method redo(Label:)
+    method redo(Label: *%_)
 
 Repeat the same iteration of the loop associated with the label.
 
@@ -112,7 +112,7 @@ Repeat the same iteration of the loop associated with the label.
 
 Defined as:
 
-    method last(Label:)
+    method last(Label: *%_)
 
 Terminate the execution of the loop associated with the label.
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -1327,7 +1327,7 @@ post-processing step can then be undertaken.
 Defined as:
 
     sub    sum($list  )
-    method sum(List:D:)
+    method sum(List:D: *%_)
 
 Returns the sum of all elements in the list or 0 if the list is empty.
 Throws an exception if an element can not be coerced into Numeric.

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -180,7 +180,7 @@ object (this behavior powers C<m:g//> smartmatch), or C<False> otherwise.
 Defined as:
 
     sub    elems($list --> Int:D)
-    method elems(List:D: --> Int:D)
+    method elems(List:D: *%_ --> Int:D)
 
 Returns the number of elements in the list.
 
@@ -191,7 +191,7 @@ Returns the number of elements in the list.
 Defined as:
 
     sub    end($list --> Int:D)
-    method end(List:D: --> Int:D)
+    method end(List:D: *%_ --> Int:D)
 
 Returns the index of the last element.
 
@@ -202,7 +202,7 @@ Returns the index of the last element.
 Defined as:
 
     sub    keys($list --> Seq:D)
-    method keys(List:D: --> Seq:D)
+    method keys(List:D: *%_ --> Seq:D)
 
 Returns a sequence of indexes into the list (e.g.,
 C<0..(@list.elems-1)>).
@@ -214,7 +214,7 @@ C<0..(@list.elems-1)>).
 Defined as:
 
     sub    values($list --> Seq:D)
-    method values(List:D: --> Seq:D)
+    method values(List:D: *%_ --> Seq:D)
 
 Returns a sequence of the list elements, in order.
 
@@ -226,7 +226,7 @@ Returns a sequence of the list elements, in order.
 Defined as:
 
     sub    kv($list --> Seq:D)
-    method kv(List:D: --> Seq:D)
+    method kv(List:D: *%_ --> Seq:D)
 
 Returns an interleaved sequence of indexes and values. For example
 
@@ -237,7 +237,7 @@ Returns an interleaved sequence of indexes and values. For example
 Defined as:
 
     sub    pairs($list --> Seq:D)
-    method pairs(List:D: --> Seq:D)
+    method pairs(List:D: *%_ --> Seq:D)
 
 Returns a sequence of pairs, with the indexes as keys and the list values as
 values.
@@ -248,7 +248,7 @@ values.
 
 Defined as:
 
-    method antipairs(List:D: --> Seq:D)
+    method antipairs(List:D: *%_ --> Seq:D)
 
 Returns a L<Seq|/type/Seq> of pairs, with the values as keys and the indexes as
 values, i.e. the direct opposite to L<pairs|/type/List#routine_pairs>.
@@ -259,7 +259,7 @@ values, i.e. the direct opposite to L<pairs|/type/List#routine_pairs>.
 
 Defined as:
 
-    method invert(List:D: --> Seq:D)
+    method invert(List:D: *%_ --> Seq:D)
 
 Assumes every element of the List is a C<Pair>.  Returns all elements as a
 L<Seq|/type/Seq> of C<Pair>s where the keys and values have been exchanged.
@@ -364,7 +364,7 @@ be handled in the context of that C<Routine>.
 
 Defined as:
 
-    method flatmap(List:D: &code --> Seq:D)
+    method flatmap(List:D: &code *%_ --> Seq:D)
 
 Like L«C<map>|/type/Any#method_map» iterates over the elements of the invocant
 list, feeding each element in turn to the code reference, and assembling the
@@ -416,7 +416,7 @@ put (1..200).List.gist;
 Defined as:
 
     sub    grep(Mu $matcher, *@elems, :$k, :$kv, :$p, :$v --> Seq:D)
-    method grep(List:D:  Mu $matcher, :$k, :$kv, :$p, :$v --> Seq:D)
+    method grep(List:D:  Mu $matcher, :$k, :$kv, :$p, :$v *%_ --> Seq:D)
 
 Returns a sequence of elements against which C<$matcher> smartmatches.
 The elements are returned in the order in which they appear in the original
@@ -645,7 +645,7 @@ classification.
 
 Defined as:
 
-    method Bool(List:D: --> Bool:D)
+    method Bool(List:D: *%_ --> Bool:D)
 
 Returns C<True> if the list has at least one element, and C<False>
 for the empty list.
@@ -657,7 +657,7 @@ for the empty list.
 
 Defined as:
 
-    method Str(List:D: --> Str:D)
+    method Str(List:D: *%_ --> Str:D)
 
 Stringifies the elements of the list and joins them with spaces
 (same as C<.join(' ')>).
@@ -668,7 +668,7 @@ Stringifies the elements of the list and joins them with spaces
 
 Defined as:
 
-    method Int(List:D: --> Int:D)
+    method Int(List:D: *%_ --> Int:D)
 
 Returns the number of elements in the list (same as C<.elems>).
 
@@ -678,7 +678,7 @@ Returns the number of elements in the list (same as C<.elems>).
 
 Defined as:
 
-    method Numeric(List:D: --> Int:D)
+    method Numeric(List:D: *%_ --> Int:D)
 
 Returns the number of elements in the list (same as C<.elems>).
 
@@ -1160,7 +1160,7 @@ L<Range|/type/Range> constructed with C<0..^$from>:
 
 Defined as:
 
-    method rotor(*@cycle, Bool() :$partial --> Seq:D)
+    method rotor(*@cycle, Bool() :$partial, *%_ --> Seq:D)
 
 Returns a sequence of lists, where each sublist is made up of elements of the
 invocant.
@@ -1356,7 +1356,7 @@ say @a.sum(:wrap);        # OUTPUT: «499999500000␤»
 
 Defined as:
 
-    method fmt($format = '%s', $separator = ' ' --> Str:D)
+    method fmt($format = '%s', $separator = ' ', *%_ --> Str:D)
 
 Returns a string where each element in the list has been formatted according
 to C<$format> and where each element is separated by C<$separator>.

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -688,7 +688,7 @@ Returns the number of elements in the list (same as C<.elems>).
 
 Defined as:
 
-    method Capture(--> Capture:D)
+    method Capture(List:D: *%_ --> Capture:D)
 
 Returns a L<Capture|/type/Capture> where each L<Pair|/type/Pair>, if any, in the
 C<List> has been converted to a named argument (with the
@@ -1390,7 +1390,7 @@ value of C<.to> called on the last element of the list.
 
 Defined as:
 
-     method sink(--> Nil) { }
+    method sink(--> Nil) { }
 
 It does nothing, and returns C<Nil>, as the definition clearly shows.
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -274,7 +274,7 @@ of that C<Iterable> into separate pairs.
 Defined as:
 
     sub    join($separator, *@list)
-    method join(List:D: $separator = "")
+    method join(List:D: $separator = "", *%_)
 
 Treats the elements of the list as strings by calling
 L<C<.Str>|/type/Any#routine_Str> on each of them, interleaves them with
@@ -480,7 +480,7 @@ Examples:
 Defined as:
 
     sub    first(Mu $matcher, *@elems, :$k, :$kv, :$p, :$end)
-    method first(List:D:  Mu $matcher?, :$k, :$kv, :$p, :$end)
+    method first(List:D:  Mu $matcher?, :$k, :$kv, :$p, :$end, *%_)
 
 Returns the first item of the list which smartmatches against C<$matcher>,
 returns C<Nil> when no values match.  The optional named parameter C<:end>

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -1390,7 +1390,7 @@ value of C<.to> called on the last element of the list.
 
 Defined as:
 
-    method sink(--> Nil) { }
+    method List(List: *%_ --> Nil) { }
 
 It does nothing, and returns C<Nil>, as the definition clearly shows.
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -364,7 +364,7 @@ be handled in the context of that C<Routine>.
 
 Defined as:
 
-    method flatmap(List:D: &code *%_ --> Seq:D)
+    method flatmap(List:D: &code, *%_ --> Seq:D)
 
 Like L«C<map>|/type/Any#method_map» iterates over the elements of the invocant
 list, feeding each element in turn to the code reference, and assembling the
@@ -416,7 +416,7 @@ put (1..200).List.gist;
 Defined as:
 
     sub    grep(Mu $matcher, *@elems, :$k, :$kv, :$p, :$v --> Seq:D)
-    method grep(List:D:  Mu $matcher, :$k, :$kv, :$p, :$v *%_ --> Seq:D)
+    method grep(List:D:  Mu $matcher, :$k, :$kv, :$p, :$v, *%_ --> Seq:D)
 
 Returns a sequence of elements against which C<$matcher> smartmatches.
 The elements are returned in the order in which they appear in the original
@@ -1390,7 +1390,7 @@ value of C<.to> called on the last element of the list.
 
 Defined as:
 
-    method List(List: *%_ --> Nil) { }
+    method sink(List: *%_ --> Nil) { }
 
 It does nothing, and returns C<Nil>, as the definition clearly shows.
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -1160,7 +1160,7 @@ L<Range|/type/Range> constructed with C<0..^$from>:
 
 Defined as:
 
-    method rotor(*@cycle, Bool() :$partial, *%_ --> Seq:D)
+    method rotor(Any:D: *@cycle, Bool() :$partial, *%_ --> Seq:D)
 
 Returns a sequence of lists, where each sublist is made up of elements of the
 invocant.
@@ -1356,7 +1356,7 @@ say @a.sum(:wrap);        # OUTPUT: «499999500000␤»
 
 Defined as:
 
-    method fmt($format = '%s', $separator = ' ', *%_ --> Str:D)
+    method fmt(List:D: $format = '%s', $separator = ' ', *%_ --> Str:D)
 
 Returns a string where each element in the list has been formatted according
 to C<$format> and where each element is separated by C<$separator>.

--- a/doc/Type/Lock.pod6
+++ b/doc/Type/Lock.pod6
@@ -109,7 +109,7 @@ thus they don't actually protect the code we want to protect.
 
 Defined as:
 
-    method lock(Lock:D:)
+    method lock(Lock:D: *%_)
 
 Acquires the lock. If it is currently not available, waits for it.
 
@@ -130,7 +130,7 @@ takes care of making sure the C<lock>/C<unlock> calls always both occur.
 
 Defined as:
 
-    method unlock(Lock:D:)
+    method unlock(Lock:D: *%_)
 
 Releases the lock.
 

--- a/doc/Type/Lock.pod6
+++ b/doc/Type/Lock.pod6
@@ -161,7 +161,7 @@ my class ConditionVariable {
     method signal_all();
 }
 
-method condition(Lock:D: --> ConditionVariable:D)
+    method condition(Lock:D: *%_ --> ConditionVariable:D)
 =end code
 
 Returns a condition variable. Compare

--- a/doc/Type/Lock.pod6
+++ b/doc/Type/Lock.pod6
@@ -68,7 +68,7 @@ L<Promise|/type/Promise>, L<Channel|/type/Channel> and L<Supply|/type/Supply>.
 
 Defined as:
 
-    method protect(Lock:D: &code)
+    method protect(Lock:D: &code, *%_)
 
 Obtains the lock, runs C<&code>, and releases the lock afterwards. Care
 is taken to make sure the lock is released even if the code is left through

--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -50,7 +50,7 @@ a C<Map> has been initialized:
 
 Defined as:
 
-    method new(*@args)
+    method new(Map: *@args, *%_ --> Map:D)
 
 Creates a new Map from a list of alternating keys and values, with
 L<the same semantics|/language/hashmap#Hash_assignment> as described

--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -246,7 +246,7 @@ Returns C<True> if the invocant contains at least one key/value pair.
 
 Defined as:
 
-    method Capture(Map:D:)
+    method Capture(Map:D: *%_)
 
 Returns a L<Capture|/type/Capture> where each key, if any, has been converted
 to a named argument with the same value as it had in the original C<Map>.

--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -70,7 +70,7 @@ extra parentheses around all the arguments.
 
 Defined as:
 
-    method elems(Map:D: --> Int:D)
+    method elems(Map:D: *%_ --> Int:D)
 
 Returns the number of pairs stored in the Map.
 
@@ -105,7 +105,7 @@ behavior is applied.
 
 Defined as:
 
-    method gist(Map:D: --> Str:D)
+    method gist(Map:D: *%_ --> Str:D)
 
 Returns the string containing the "gist" of the L<Map|/type/Map>,
 sorts the pairs and lists B<up to the first 100>,
@@ -115,7 +115,7 @@ appending an ellipsis if the L<Map|/type/Map> has more than 100 pairs.
 
 Defined as:
 
-    method keys(Map:D: --> Seq:D)
+    method keys(Map:D: *%_ --> Seq:D)
 
 Returns a C<Seq> of all keys in the Map.
 
@@ -126,7 +126,7 @@ Returns a C<Seq> of all keys in the Map.
 
 Defined as:
 
-    method values(Map:D: --> Seq:D)
+    method values(Map:D: *%_ --> Seq:D)
 
 Returns a C<Seq> of all values in the Map.
 
@@ -137,7 +137,7 @@ Returns a C<Seq> of all values in the Map.
 
 Defined as:
 
-    method pairs(Map:D: --> Seq:D)
+    method pairs(Map:D: *%_ --> Seq:D)
 
 Returns a C<Seq> of all pairs in the Map.
 
@@ -148,7 +148,7 @@ Returns a C<Seq> of all pairs in the Map.
 
 Defined as:
 
-    method antipairs(Map:D: --> Seq:D)
+    method antipairs(Map:D: *%_ --> Seq:D)
 
 Returns all keys and their respective values as a L<Seq|/type/Seq> of C<Pair>s
 where the keys and values have been exchanged, i.e. the opposite of method
@@ -163,7 +163,7 @@ values into multiple pairs.
 
 Defined as:
 
-    method invert(Map:D: --> Seq:D)
+    method invert(Map:D: *%_ --> Seq:D)
 
 Returns all keys and their respective values as a L<Seq|/type/Seq> of C<Pair>s
 where the keys and values have been exchanged. The difference between C<invert>
@@ -177,7 +177,7 @@ values into multiple pairs.
 
 Defined as:
 
-    method kv(Map:D: --> Seq:D)
+    method kv(Map:D: *%_ --> Seq:D)
 
 Returns a C<Seq> of keys and values interleaved.
 
@@ -187,7 +187,7 @@ Returns a C<Seq> of keys and values interleaved.
 
 Defined as:
 
-    method list(Map:D: --> List:D)
+    method list(Map:D: *%_ --> List:D)
 
 Returns a C<List> of all keys and values in the Map.
 
@@ -213,7 +213,7 @@ See L<Any.sort|/type/Any#method_sort> for additional available candidates.
 
 Defined as:
 
-    method Int(Map:D: --> Int:D)
+    method Int(Map:D: *%_ --> Int:D)
 
 Returns the number of pairs stored in the C<Map> (same as C<.elems>).
 
@@ -224,7 +224,7 @@ Returns the number of pairs stored in the C<Map> (same as C<.elems>).
 
 Defined as:
 
-    method Numeric(Map:D: --> Int:D)
+    method Numeric(Map:D: *%_ --> Int:D)
 
 Returns the number of pairs stored in the C<Map> (same as C<.elems>).
 
@@ -235,7 +235,7 @@ Returns the number of pairs stored in the C<Map> (same as C<.elems>).
 
 Defined as:
 
-    method Bool(Map:D: --> Bool:D)
+    method Bool(Map:D: *%_ --> Bool:D)
 
 Returns C<True> if the invocant contains at least one key/value pair.
 

--- a/doc/Type/Match.pod6
+++ b/doc/Type/Match.pod6
@@ -184,7 +184,7 @@ Alias for L<#method made>.
 
 Defined as:
 
-    method Bool(Capture:D: --> Bool:D)
+    method Bool(Capture:D:, *%_ --> Bool:D)
 
 Returns C<True> on successful and C<False> on unsuccessful matches. Please note
 that any zero-width match can also be successful.
@@ -207,7 +207,7 @@ Returns the matched text.
 
 Defined as:
 
-    method Int(Match:D: --> Int:D)
+    method Int(Match:D: *%_ --> Int:D)
 
 Tries to convert stringified result of the matched text into Int.
 
@@ -243,7 +243,7 @@ Returns a hash of named submatches.
 
 Defined as:
 
-    method prematch(Match:D: --> Str:D)
+    method prematch(Match:D: *%_ --> Str:D)
 
 Returns the part of the original string leading up to the match.
 
@@ -258,7 +258,7 @@ Returns the part of the original string leading up to the match.
 
 Defined as:
 
-    method postmatch(Match:D: --> Str:D)
+    method postmatch(Match:D: *%_ --> Str:D)
 
 Returns the part of the original string following the match.
 

--- a/doc/Type/Match.pod6
+++ b/doc/Type/Match.pod6
@@ -184,7 +184,7 @@ Alias for L<#method made>.
 
 Defined as:
 
-    method Bool(Capture:D:, *%_ --> Bool:D)
+    method Bool(Match:D:, *%_ --> Bool:D)
 
 Returns C<True> on successful and C<False> on unsuccessful matches. Please note
 that any zero-width match can also be successful.

--- a/doc/Type/Match.pod6
+++ b/doc/Type/Match.pod6
@@ -184,7 +184,7 @@ Alias for L<#method made>.
 
 Defined as:
 
-    method Bool(Match:D:, *%_ --> Bool:D)
+    method Bool(Match:D: *%_ --> Bool:D)
 
 Returns C<True> on successful and C<False> on unsuccessful matches. Please note
 that any zero-width match can also be successful.

--- a/doc/Type/Match.pod6
+++ b/doc/Type/Match.pod6
@@ -101,7 +101,7 @@ Returns the same as C<.Str.chars>.
 
 Defined as:
 
-    method clone()
+    method clone(Match: *%_)
 
 Clones the C<Match> object.
 
@@ -136,7 +136,7 @@ Returns the index of the end position of the match.
 
 =head2 method made
 
-    method made()
+    method made(Match: *%_)
 
 Returns the payload that was set with L<C<make>|/routine/make>.
 

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -551,7 +551,7 @@ See L<Exporting and Selective Importing Modules|/language/modules#Exporting_and_
 for more details.
 =head2 method return
 
-    method return()
+    method return(Mu: *%_)
 
 The method C<return> will stop execution of a subroutine or method, run all
 relevant L<phasers|/language/phasers#Block_phasers> and provide invocant as a
@@ -570,7 +570,7 @@ container to the invocant (see more details here: L<C<return-rw>|/language/contr
 
 =head2 method emit
 
-    method emit()
+    method emit(Mu: *%_)
 
 Emits the invocant into the enclosing
 L<supply|/language/concurrency#index-entry-supply_(on-demand)> or
@@ -587,7 +587,7 @@ L<react|/language/concurrency#index-entry-react> block.
 
 =head2 method take
 
-    method take()
+    method take(Mu: *%_)
 
 Returns the invocant in the enclosing L<gather|/language/control#gather/take> block.
 
@@ -628,7 +628,7 @@ Returns the given item to the enclosing C<gather> block, without introducing a n
 
 =head2 method so
 
-    method so()
+    method so(Mu: *%_)
 
 Evaluates the item in Boolean context (and thus, for instance, collapses Junctions),
 and returns the result.
@@ -652,7 +652,7 @@ result will be C<True>. C<so> is performing all those operations under the hood.
 
 =head2 method not
 
-    method not()
+    method not(Mu: *%_)
 
 Evaluates the item in Boolean context (leading to final evaluation of Junctions, for instance),
 and negates the result.

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -197,7 +197,7 @@ that can be used via EVAL to reconstruct the value of the object.
 
 =head2 method item
 
-    method item(Mu \item:) is raw
+    method item(Mu \item: *%_) is raw
 
 Forces the invocant to be evaluated in item context and returns the value of it.
 

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -78,7 +78,7 @@ L<C<does>|/routine/does#(Mu)_routine_does> is similar, but includes roles.
 
 =head2 routine does
 
-    method does(Mu $type --> Bool:D)
+    method does(Mu $type *%_ --> Bool:D)
 
 Returns C<True> if and only if the invocant conforms to type C<$type>.
 
@@ -127,7 +127,7 @@ empty L<string|/type/Str> or numerical zeros
 
 Declared as:
 
-    method Capture(Mu:D: --> Capture:D)
+    method Capture(Mu:D: *%_ --> Capture:D)
 
 Returns a L<Capture|/type/Capture> with named arguments corresponding to
 invocant's public attributes:
@@ -316,7 +316,7 @@ for more information.
 
 =head2 method bless
 
-    method bless(*%attrinit --> Mu:D)
+    method bless(*%attrinit, *%_ --> Mu:D)
 
 Low-level object construction method, usually called from within C<new>,
 implicitly from the default constructor, or explicitly if you create your own

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -21,7 +21,7 @@ L<Any|/type/Any>.
 
 Defined as:
 
-    method Mu(Mu: *%_ --> Iterator)
+    method iterator(Mu: *%_ --> Iterator)
 
 Coerces the invocant to a C<list> by applying its L«C<.list>|/routine/list»
 method and uses L«C<iterator>|/type/Iterable#method_iterator» on it.
@@ -78,7 +78,7 @@ L<C<does>|/routine/does#(Mu)_routine_does> is similar, but includes roles.
 
 =head2 routine does
 
-    method does(Mu \SELF: Mu $type *%_ --> Bool:D)
+    method does(Mu \SELF: Mu $type, *%_ --> Bool:D)
 
 Returns C<True> if and only if the invocant conforms to type C<$type>.
 
@@ -207,7 +207,7 @@ Forces the invocant to be evaluated in item context and returns the value of it.
 
 =head2 method self
 
-    method Mu(Mu: *%_ --> Mu)
+    method self(Mu: *%_ --> Mu)
 
 Returns the object it is called on.
 
@@ -429,7 +429,7 @@ L<the documentation on object construction|/language/objects#Object_construction
 
 =head2 method CREATE
 
-    method Mu(Mu: *%_ --> Mu:D)
+    method CREATE(Mu: *%_ --> Mu:D)
 
 Allocates a new object of the same type as the invocant, without
 initializing any attributes.
@@ -508,7 +508,7 @@ objects return the same return value from C<WHICH>.
 
 =head2 method WHERE
 
-    method Mu(Mu: *%_ --> Int)
+    method WHERE(Mu: *%_ --> Int)
 
 Returns an C<Int> representing the memory address of the object.  Please note
 that in the Rakudo implementation of Raku, and possibly other implementations,

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -78,7 +78,7 @@ L<C<does>|/routine/does#(Mu)_routine_does> is similar, but includes roles.
 
 =head2 routine does
 
-    method does(Mu $type *%_ --> Bool:D)
+    method does(Mu \SELF: Mu $type *%_ --> Bool:D)
 
 Returns C<True> if and only if the invocant conforms to type C<$type>.
 
@@ -316,7 +316,7 @@ for more information.
 
 =head2 method bless
 
-    method bless(*%attrinit, *%_ --> Mu:D)
+    method bless(Mu: *%attrinit, *%_ --> Mu:D)
 
 Low-level object construction method, usually called from within C<new>,
 implicitly from the default constructor, or explicitly if you create your own
@@ -551,7 +551,7 @@ See L<Exporting and Selective Importing Modules|/language/modules#Exporting_and_
 for more details.
 =head2 method return
 
-    method return(Mu: *%_)
+    method return(Mu: |)
 
 The method C<return> will stop execution of a subroutine or method, run all
 relevant L<phasers|/language/phasers#Block_phasers> and provide invocant as a

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -21,7 +21,7 @@ L<Any|/type/Any>.
 
 Defined as:
 
-    method iterator(--> Iterator)
+    method Mu(Mu: *%_ --> Iterator)
 
 Coerces the invocant to a C<list> by applying its L«C<.list>|/routine/list»
 method and uses L«C<iterator>|/type/Iterable#method_iterator» on it.
@@ -207,7 +207,7 @@ Forces the invocant to be evaluated in item context and returns the value of it.
 
 =head2 method self
 
-    method self(--> Mu)
+    method Mu(Mu: *%_ --> Mu)
 
 Returns the object it is called on.
 
@@ -429,7 +429,7 @@ L<the documentation on object construction|/language/objects#Object_construction
 
 =head2 method CREATE
 
-    method CREATE(--> Mu:D)
+    method Mu(Mu: *%_ --> Mu:D)
 
 Allocates a new object of the same type as the invocant, without
 initializing any attributes.
@@ -508,7 +508,7 @@ objects return the same return value from C<WHICH>.
 
 =head2 method WHERE
 
-    method WHERE(--> Int)
+    method Mu(Mu: *%_ --> Int)
 
 Returns an C<Int> representing the memory address of the object.  Please note
 that in the Rakudo implementation of Raku, and possibly other implementations,

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -134,7 +134,7 @@ Warns the user that they tried to append onto a C<Nil> (or derived type object).
 
 =head2 method gist
 
-    method gist(--> Str:D)
+    method Nil(Nil: *%_ --> Str:D)
 
 Returns C<"Nil">.
 

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -140,7 +140,7 @@ Returns C<"Nil">.
 
 =head2 method Str
 
-    method Str()
+    method Str(Nil: *%_)
 
 Warns the user that they tried to stringify a C<Nil>.
 
@@ -187,7 +187,7 @@ takes any arguments and always returns a L<Nil|/type/Nil>.
 
 =head2 method Numeric
 
-    method Numeric()
+    method Numeric(Nil: *%_)
 
 Warns the user that they tried to numify a C<Nil>.
 

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -128,7 +128,7 @@ C<STORE> will produce an L<C<X::Assignment::RO>|https://docs.raku.org/type/X::As
 
 =head2 method append
 
-    method append(*@)
+    method append(Nil: |)
 
 Warns the user that they tried to append onto a C<Nil> (or derived type object).
 
@@ -146,25 +146,25 @@ Warns the user that they tried to stringify a C<Nil>.
 
 =head2 method new
 
-    method new(*@)
+    method new(Nil: |)
 
 Returns C<Nil>
 
 =head2 method prepend
 
-    method prepend(*@)
+    method prepend(Nil: |)
 
 Warns the user that they tried to prepend onto a C<Nil> or derived type object.
 
 =head2 method push
 
-    method push(*@)
+    method push(Nil: |)
 
 Warns the user that they tried to push onto a C<Nil> or derived type object.
 
 =head2 method unshift
 
-    method unshift(*@)
+    method unshift(Nil: |)
 
 Warns the user that they tried to unshift onto a C<Nil> or derived type object.
 
@@ -180,7 +180,7 @@ Will return C<\0>, and also throw a warning.
 
 =head2 method FALLBACK
 
-    method FALLBACK(|, *%_ --> Nil) {}
+    method FALLBACK(Nil: | --> Nil) {}
 
 The L<fallback method|/language/typesystem#index-entry-FALLBACK_(method)>
 takes any arguments and always returns a L<Nil|/type/Nil>.

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -180,7 +180,7 @@ Will return C<\0>, and also throw a warning.
 
 =head2 method FALLBACK
 
-    method FALLBACK(| --> Nil) {}
+    method FALLBACK(|, *%_ --> Nil) {}
 
 The L<fallback method|/language/typesystem#index-entry-FALLBACK_(method)>
 takes any arguments and always returns a L<Nil|/type/Nil>.

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -134,7 +134,7 @@ Warns the user that they tried to append onto a C<Nil> (or derived type object).
 
 =head2 method gist
 
-    method Nil(Nil: *%_ --> Str:D)
+    method gist(Nil: *%_ --> Str:D)
 
 Returns C<"Nil">.
 

--- a/doc/Type/Num.pod6
+++ b/doc/Type/Num.pod6
@@ -87,7 +87,7 @@ argument, it will be coerced to Num and then returned.
 
 =head2 method rand
 
-    method rand(Num:D: --> Num)
+    method rand(Num:D: *%_ --> Num)
 
 Returns a pseudo random number between 0 and the invocant.
 

--- a/doc/Type/Num.pod6
+++ b/doc/Type/Num.pod6
@@ -103,7 +103,7 @@ value when a Raku program is started.
 
 Defined as:
 
-    method Capture()
+    method Capture(Num: *%_)
 
 Throws C<X::Cannot::Capture>.
 

--- a/doc/Type/Num.pod6
+++ b/doc/Type/Num.pod6
@@ -117,7 +117,7 @@ or C<Inf>/C<-Inf>. No L<rounding|/routine/round> is performed.
 
 =head2 Rat
 
-    method Rat(Num:D: Real $epsilon = 1e-6)
+    method Rat(Num:D: Real $epsilon = 1e-6, *%_)
 
 Converts the number to a L<Rat|/type/Rat> with C<$epsilon> precision. If the invocant
 is a C<Inf>, C<-Inf>, or a C<NaN>, converts them to a L<Rat|/type/Rat> with C<0>
@@ -125,7 +125,7 @@ L<denominator|/routine/denominator> and C<1>, C<-1>, or C<0> L<numerator|/routin
 
 =head2 FatRat
 
-    method FatRat(Num:D: Real $epsilon = 1e-6)
+    method FatRat(Num:D: Real $epsilon = 1e-6, *%_)
 
 Converts the number to a L<FatRat|/type/FatRat> with the precision C<$epsilon>. If invocant
 is a C<Inf>, C<-Inf>, or a C<NaN>, converts them to a L<FatRat|/type/FatRat> with C<0>

--- a/doc/Type/Num.pod6
+++ b/doc/Type/Num.pod6
@@ -109,7 +109,7 @@ Throws C<X::Cannot::Capture>.
 
 =head2 Int
 
-    method Int(Num:D:)
+    method Int(Num:D: *%_)
 
 Converts the number to an L<Int|/type/Int>. L<Fails|/routine/fail> with
 C<X::Numeric::CannotConvert> if the invocant L«is a C<NaN>|/routine/isNaN»
@@ -135,7 +135,7 @@ L<denominator|/routine/denominator> and C<1>, C<-1>, or C<0> L<numerator|/routin
 
 Defined as:
 
-    method Bridge(Num:D:)
+    method Bridge(Num:D: *%_)
 
 Returns the number.
 

--- a/doc/Type/NumStr.pod6
+++ b/doc/Type/NumStr.pod6
@@ -26,7 +26,7 @@ object identity with C<Num>- or C<Str>-only variants:
 
 =head2 method new
 
-    method new(Num $i, Str $s)
+    method new(Num $i, Str $s, *%_)
 
 The constructor requires both the C<Num> and the C<Str> value, when constructing one
 directly the values can be whatever is required:

--- a/doc/Type/NumStr.pod6
+++ b/doc/Type/NumStr.pod6
@@ -26,7 +26,7 @@ object identity with C<Num>- or C<Str>-only variants:
 
 =head2 method new
 
-    method new(Num $i, Str $s, *%_)
+    method new(NumStr: Num $n, Str $s, *%_)
 
 The constructor requires both the C<Num> and the C<Str> value, when constructing one
 directly the values can be whatever is required:

--- a/doc/Type/Numeric.pod6
+++ b/doc/Type/Numeric.pod6
@@ -150,13 +150,13 @@ Returns C<False> if the number is equivalent to zero, and C<True> otherwise.
 
 =head2 method succ
 
-    method succ(Numeric:D:)
+    method succ(Numeric:D: *%_)
 
 Returns the number incremented by one (successor).
 
 =head2 method pred
 
-    method pred(Numeric:D:)
+    method pred(Numeric:D: *%_)
 
 Returns the number decremented by one (predecessor).
 

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -275,7 +275,7 @@ of the invocant.
 
 Defined as:
 
-    method invert(Pair:D: --> Seq:D)
+    method invert(Pair:D: *%_ --> Seq:D)
 
 Returns a L<Seq|/type/Seq>. If the C<.value> of the invocant is I<NOT> an
 L<Iterable|/type/Iterable>, the L<Seq|/type/Seq> will contain a single L<Pair|/type/Pair> whose

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -324,7 +324,7 @@ of the invocant.
 
 Defined as:
 
-    method freeze(Pair:D:)
+    method freeze(Pair:D: *%_)
 
 Makes the I<value> of the C<Pair> read-only, by removing it from its L<Scalar container|/language/containers#Scalar_containers>, and returns it.
 

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -172,7 +172,7 @@ L<IO::Path|/type/IO::Path>, by using L<Junctions|/type/Junction>:
 
 Defined as:
 
-    method Pair(Pair: *%_ --> Pair:D)
+    method antipair(Pair: *%_ --> Pair:D)
 
 Returns a new C<Pair> object with key and value exchanged.
 

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -172,7 +172,7 @@ L<IO::Path|/type/IO::Path>, by using L<Junctions|/type/Junction>:
 
 Defined as:
 
-    method antipair(--> Pair:D)
+    method Pair(Pair: *%_ --> Pair:D)
 
 Returns a new C<Pair> object with key and value exchanged.
 

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -359,7 +359,7 @@ as I<key ~ \t ~ value>.
 
 Defined as:
 
-    method Pair()
+    method Pair(Pair: *%_)
 
 Returns the invocant Pair object.
 

--- a/doc/Type/Parameter.pod6
+++ b/doc/Type/Parameter.pod6
@@ -35,7 +35,7 @@ If the parameter is anonymous, C<Nil> will be returned.
 
 Defined as:
 
-    method sigil(Parameter:D: --> Str:D)
+    method sigil(Parameter:D: *%_ --> Str:D)
 
 Returns a string containing the parameter's sigil, for a looser
 definition of "sigil" than what is considered part of
@@ -77,7 +77,7 @@ parameter (usually as an C<all>-Junction).
 
 Defined as:
 
-    method named(Parameter:D: --> Bool:D)
+    method named(Parameter:D: *%_ --> Bool:D)
 
 Returns C<True> if it's a L<named parameter|/type/Signature#Positional_vs._named_arguments>.
 
@@ -89,7 +89,7 @@ Returns C<True> if it's a L<named parameter|/type/Signature#Positional_vs._named
 
 Defined as:
 
-    method named_names(Parameter:D: --> List:D)
+    method named_names(Parameter:D: *%_ --> List:D)
 
 Returns the list of externally usable names/aliases for a
 L<named parameter|/type/Signature#Positional_vs._named_arguments>.
@@ -98,7 +98,7 @@ L<named parameter|/type/Signature#Positional_vs._named_arguments>.
 
 Defined as:
 
-    method positional(Parameter:D: --> Bool:D)
+    method positional(Parameter:D: *%_ --> Bool:D)
 
 Returns C<True> if the parameter is
 L<positional|/type/Signature#Positional_vs._named_arguments>.
@@ -111,7 +111,7 @@ L<positional|/type/Signature#Positional_vs._named_arguments>.
 
 Defined as:
 
-    method slurpy(Parameter:D: --> Bool:D)
+    method slurpy(Parameter:D: *%_ --> Bool:D)
 
 Returns C<True> for
 L<slurpy parameters|/type/Signature#Slurpy_(A.K.A._variadic)_parameters>.
@@ -120,7 +120,7 @@ L<slurpy parameters|/type/Signature#Slurpy_(A.K.A._variadic)_parameters>.
 
 Defined as:
 
-    method twigil(Parameter:D: --> Str:D)
+    method twigil(Parameter:D: *%_ --> Str:D)
 
 Returns a string containing the twigil part of the parameter's name.
 
@@ -128,7 +128,7 @@ Returns a string containing the twigil part of the parameter's name.
 
 Defined as:
 
-    method optional(Parameter:D: --> Bool:D)
+    method optional(Parameter:D: *%_ --> Bool:D)
 
 Returns C<True> for
 L<optional parameters|/type/Signature#Optional_and_Mandatory_Parameters>.
@@ -137,7 +137,7 @@ L<optional parameters|/type/Signature#Optional_and_Mandatory_Parameters>.
 
 Defined as:
 
-    method raw(Parameter:D: --> Bool:D)
+    method raw(Parameter:D: *%_ --> Bool:D)
 
 Returns C<True> for raw parameters.
 
@@ -189,7 +189,7 @@ behavior when using C<+> with a sigilless parameter:
 
 Defined as:
 
-    method capture(Parameter:D: --> Bool:D)
+    method capture(Parameter:D: *%_ --> Bool:D)
 
 Returns C<True> for parameters that capture the rest of the argument list into
 a single L<Capture|/type/Capture> object.
@@ -206,7 +206,7 @@ declarations.
 
 Defined as:
 
-    method rw(Parameter:D: --> Bool:D)
+    method rw(Parameter:D: *%_ --> Bool:D)
 
 Returns C<True> for L<C<is rw>|/type/Signature#Parameter_Traits_and_Modifiers>
 parameters.
@@ -219,7 +219,7 @@ parameters.
 
 Defined as:
 
-    method copy(Parameter:D: --> Bool:D)
+    method copy(Parameter:D: *%_ --> Bool:D)
 
 Returns C<True> for L<C<is copy>|/type/Signature#Parameter_Traits_and_Modifiers>
 parameters.
@@ -232,7 +232,7 @@ parameters.
 
 Defined as:
 
-    method readonly(Parameter:D: --> Bool:D)
+    method readonly(Parameter:D: *%_ --> Bool:D)
 
 Returns C<True> for read-only parameters (the default).
 
@@ -244,7 +244,7 @@ Returns C<True> for read-only parameters (the default).
 
 Defined as:
 
-    method invocant(Parameter:D: --> Bool:D)
+    method invocant(Parameter:D: *%_ --> Bool:D)
 
 Returns C<True> if the parameter is the
 L<invocant parameter|/type/Signature#Parameter_separators>.
@@ -263,7 +263,7 @@ this parameter, or C<Any> if no default was provided.
 
 Defined as:
 
-    method type_captures(Parameter:D: --> List:D)
+    method type_captures(Parameter:D: *%_ --> List:D)
 
 Returns a list of variable names of type captures associated with this
 parameter.  Type captures define a type name within the attached code,
@@ -305,7 +305,7 @@ returns a C<Signature> object for it.  Otherwise returns C<Any>.
 
 Defined as:
 
-    method prefix(Parameter:D: --> Str:D)
+    method prefix(Parameter:D: *%_ --> Str:D)
 
 If the parameter is L«slurpy|/type/Signature#Slurpy_(A.K.A._variadic)_parameters»,
 returns the marker (e.g., C«*», C«**», or C«+») the parameter was declared
@@ -327,7 +327,7 @@ with. Otherwise, returns an empty string.
 
 Defined as:
 
-    method suffix(Parameter:D: --> Str:D)
+    method suffix(Parameter:D: *%_ --> Str:D)
 
 Returns the C«?» or C«!» marker a parameter was declared with, if any. Otherwise,
 returns the empty string.

--- a/doc/Type/Positional.pod6
+++ b/doc/Type/Positional.pod6
@@ -14,7 +14,7 @@ include L<List|/type/List>, L<Array|/type/Array>, L<Range|/type/Range>, and L<Bu
 
 =head2 method of
 
-    method of()
+    method of(Positional: *%_)
 
 Returns the type constraint for elements of the positional container. Defaults
 to L<Mu|/type/Mu>.

--- a/doc/Type/PositionalBindFailover.pod6
+++ b/doc/Type/PositionalBindFailover.pod6
@@ -62,7 +62,7 @@ Returns a L<List|/type/List> based on the C<iterator> method without caching it.
 
 =head2 method iterator
 
-    method iterator(PositionalBindFailover:D:) { ... }
+    method iterator(PositionalBindFailover:D: *%_) { ... }
 
 This method stub ensure that a class implementing role
 C<PositionalBindFailover> provides an C<iterator> method.

--- a/doc/Type/PositionalBindFailover.pod6
+++ b/doc/Type/PositionalBindFailover.pod6
@@ -49,7 +49,7 @@ need to provide an C<iterator> method that produces an L<Iterator|/type/Iterator
 
 =head2 method cache
 
-    method cache(PositionalBindFailover:D: --> List:D)
+    method cache(PositionalBindFailover:D: *%_ --> List:D)
 
 Returns a L<List|/type/List> based on the C<iterator> method, and caches it.
 Subsequent calls to C<cache> always return the same C<List> object.

--- a/doc/Type/PredictiveIterator.pod6
+++ b/doc/Type/PredictiveIterator.pod6
@@ -23,7 +23,7 @@ of the result of the call to the C<count-only> method.
 
 Defined as:
 
-    method PredictiveIterator(PredictiveIterator: *%_ --> Int:D) { ... }
+    method count-only(PredictiveIterator: *%_ --> Int:D) { ... }
 
 It is expected to return the number of values the iterator can still produce
 B<without> actually producing them. The returned number B<must adjust itself>
@@ -47,7 +47,7 @@ iterator is capable of producing any value, it should be implemented.
 
 Defined as:
 
-    method PredictiveIterator(PredictiveIterator: *%_ --> Bool:D) { self.count-only.Bool }
+    method bool-only(PredictiveIterator: *%_ --> Bool:D) { self.count-only.Bool }
 
 =end pod
 

--- a/doc/Type/PredictiveIterator.pod6
+++ b/doc/Type/PredictiveIterator.pod6
@@ -23,7 +23,7 @@ of the result of the call to the C<count-only> method.
 
 Defined as:
 
-    method count-only(--> Int:D) { ... }
+    method PredictiveIterator(PredictiveIterator: *%_ --> Int:D) { ... }
 
 It is expected to return the number of values the iterator can still produce
 B<without> actually producing them. The returned number B<must adjust itself>
@@ -47,7 +47,7 @@ iterator is capable of producing any value, it should be implemented.
 
 Defined as:
 
-    method bool-only(--> Bool:D) { self.count-only.Bool }
+    method PredictiveIterator(PredictiveIterator: *%_ --> Bool:D) { self.count-only.Bool }
 
 =end pod
 

--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -170,7 +170,7 @@ n block <unit> at /tmp/3169qXElwq line 1␤␤»
 
 =head2 method spawn
 
-    method spawn(*@args ($, *@), :$cwd = $*CWD, Hash() :$env = %*ENV, :$win-verbatim-args = False --> Bool:D)
+    method spawn(*@args ($, *@), :$cwd = $*CWD, Hash() :$env = %*ENV, :$win-verbatim-args = False, *%_ --> Bool:D)
 
 Runs the C<Proc> object with the given command, argument list, working directory,
 and environment.
@@ -183,7 +183,7 @@ present in older releases.
 
 =head2 method shell
 
-    method shell($cmd, :$cwd = $*CWD, :$env --> Bool:D)
+    method shell($cmd, :$cwd = $*CWD, :$env, *%_ --> Bool:D)
 
 Runs the C<Proc> object with the given command and environment which are
 passed through to the shell for parsing and execution. See
@@ -192,7 +192,7 @@ are used by default in the most common operating systems.
 
 =head2 method command
 
-    method command(Proc:D: --> List:D)
+    method command(Proc:D: *%_ --> List:D)
 
 The command method is an accessor to a list containing the arguments
 that were passed when the Proc object was executed via C<spawn> or
@@ -213,7 +213,7 @@ Returns the C<PID> value of the process if available, or C<Nil>.
 
 =head2 method exitcode
 
-    method exitcode(Proc:D: --> Int:D)
+    method exitcode(Proc:D: *%_ --> Int:D)
 
 Returns the exit code of the external process, or -1 if it has not exited yet.
 

--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -207,7 +207,7 @@ of the process were 0, indicating a successful process termination. Returns C<Fa
 
 =head2 method pid
 
-    method pid()
+    method pid(Proc: *%_)
 
 Returns the C<PID> value of the process if available, or C<Nil>.
 

--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -62,7 +62,7 @@ Use L<Proc::Async|/type/Proc::Async> for non-blocking operations.
 =head2 routine new
 
 =begin code :skip-test<compile time error>
-method new(Proc:U:
+    method new(Proc:U:
         :$in = '-',
         :$out = '-',
         :$err = '-',

--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -170,7 +170,7 @@ n block <unit> at /tmp/3169qXElwq line 1␤␤»
 
 =head2 method spawn
 
-    method spawn(*@args ($, *@), :$cwd = $*CWD, Hash() :$env = %*ENV, :$win-verbatim-args = False, *%_ --> Bool:D)
+    method spawn(Proc: *@args ($, *@), :$cwd = $*CWD, Hash() :$env = %*ENV, :$win-verbatim-args = False, *%_ --> Bool:D)
 
 Runs the C<Proc> object with the given command, argument list, working directory,
 and environment.
@@ -183,7 +183,7 @@ present in older releases.
 
 =head2 method shell
 
-    method shell($cmd, :$cwd = $*CWD, :$env, *%_ --> Bool:D)
+    method shell(Proc: $cmd, :$cwd = $*CWD, :$env, *%_ --> Bool:D)
 
 Runs the C<Proc> object with the given command and environment which are
 passed through to the shell for parsing and execution. See

--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -158,7 +158,7 @@ merged in C<$proc.out>.
 
 Defined as:
 
-    method sink(--> Nil)
+    method sink(Proc: *%_ --> Nil)
 
 When sunk, the C<Proc> object will throw L<X::Proc::Unsuccessful|/type/X::Proc::Unsuccessful>
 if the process it ran exited unsuccessfully.

--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -219,7 +219,7 @@ Returns the exit code of the external process, or -1 if it has not exited yet.
 
 =head2 method signal
 
-    method signal(Proc:D:)
+    method signal(Proc:D: *%_)
 
 Returns the signal number with which the external process was killed, or
 C<0> or an undefined value otherwise.

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -290,7 +290,7 @@ say "promise got Kept" if $promise.status ~~ Kept;
 
 =head2 method scheduler
 
-    method scheduler(Promise:D:)
+    method scheduler(Promise:D: *%_)
 
 Returns the scheduler that manages the promise.
 
@@ -315,7 +315,7 @@ exception of type C<X::Promise::Vowed>.
 
 =head2 method Supply
 
-    method Supply(Promise:D:)
+    method Supply(Promise:D: *%_)
 
 Returns a L<Supply|/type/Supply> that will emit the C<result> of the L<Promise|/type/Promise> being Kept
 or C<quit> with the C<cause> if the L<Promise|/type/Promise> is Broken.

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -212,7 +212,7 @@ You can use this to wait at most a number of seconds for a promise:
 
 =head2 method then
 
-    method then(Promise:D: &code)
+    method then(Promise:D: &code, *%_)
 
 Schedules a piece of code to be run after the invocant has been kept or
 broken, and returns a new promise for this computation. In other words,
@@ -260,14 +260,14 @@ taken. See method C<vow> for more information.
 
 =head2 method result
 
-    method result(Promise:D)
+    method result(Promise:D, *%_)
 
 Waits for the promise to be kept or broken. If it is kept, returns the result;
 otherwise throws the result as an exception.
 
 =head2 method cause
 
-    method cause(Promise:D)
+    method cause(Promise:D, *%_)
 
 If the promise was broken, returns the result (or exception). Otherwise, throws
 an exception of type C<X::Promise::CauseOnlyValidOnBroken>.

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -167,7 +167,7 @@ or with the default value C«X::AdHoc.new(payload => "Died")»
 
 =head2 method allof
 
-    method allof(Promise:U: *@promises *%_ --> Promise:D)
+    method allof(Promise:U: *@promises, *%_ --> Promise:D)
 
 Returns a new promise that will be kept when all the promises passed as
 arguments are kept or broken. The result of the individual Promises is
@@ -193,7 +193,7 @@ see the exception.)
 
 =head2 method anyof
 
-    method anyof(Promise:U: *@promises *%_ --> Promise:D)
+    method anyof(Promise:U: *@promises, *%_ --> Promise:D)
 
 Returns a new promise that will be kept as soon as any of the promises
 passed as arguments is kept or broken. The result of the completed

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -53,7 +53,7 @@ Further examples can be found in the L<concurrency page|/language/concurrency#Pr
 
 =head2 method start
 
-    method start(Promise:U: &code, :$scheduler = $*SCHEDULER --> Promise:D)
+    method start(Promise:U: &code, :$scheduler = $*SCHEDULER *%_ --> Promise:D)
 
 Creates a new Promise that runs the given code object. The promise will be
 kept when the code terminates normally, or broken if it throws an exception.
@@ -109,7 +109,7 @@ behavior.
 
 =head2 method in
 
-    method in(Promise:U: $seconds, :$scheduler = $*SCHEDULER --> Promise:D)
+    method in(Promise:U: $seconds, :$scheduler = $*SCHEDULER *%_ --> Promise:D)
 
 Creates a new Promise that will be kept in C<$seconds> seconds, or later.
 
@@ -134,7 +134,7 @@ a L<react and whenever block|/language/concurrency#index-entry-react-react>.
 
 =head2 method at
 
-    method at(Promise:U: $at, :$scheduler = $*SCHEDULER --> Promise:D)
+    method at(Promise:U: $at, :$scheduler = $*SCHEDULER *%_ --> Promise:D)
 
 Creates a new C<Promise> that will be kept C<$at> the given time—which is
 given as an L<Instant|/type/Instant> or equivalent L<Numeric|/type/Numeric>—or as soon as possible after it.
@@ -167,7 +167,7 @@ or with the default value C«X::AdHoc.new(payload => "Died")»
 
 =head2 method allof
 
-    method allof(Promise:U: *@promises --> Promise:D)
+    method allof(Promise:U: *@promises *%_ --> Promise:D)
 
 Returns a new promise that will be kept when all the promises passed as
 arguments are kept or broken. The result of the individual Promises is
@@ -193,7 +193,7 @@ see the exception.)
 
 =head2 method anyof
 
-    method anyof(Promise:U: *@promises --> Promise:D)
+    method anyof(Promise:U: *@promises *%_ --> Promise:D)
 
 Returns a new promise that will be kept as soon as any of the promises
 passed as arguments is kept or broken. The result of the completed
@@ -281,7 +281,7 @@ C<Planned>.
 
 =head2 method status
 
-    method status(Promise:D --> PromiseStatus)
+    method status(Promise:D *%_ --> PromiseStatus)
 
 Returns the current state of the promise: C<Kept>, C<Broken> or C<Planned>:
 
@@ -302,7 +302,7 @@ my class Vow {
     method keep() { ... }
     method break() { ... }
 }
-method vow(Promise:D: --> Vow:D)
+    method vow(Promise:D: *%_ --> Vow:D)
 
 Returns an object that holds the sole authority over keeping or breaking a
 promise. Calling C<keep> or C<break> on a promise that has vow taken throws an

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -299,8 +299,8 @@ Returns the scheduler that manages the promise.
 =for code
 my class Vow {
     has Promise $.promise;
-    method keep() { ... }
-    method break() { ... }
+    method keep(Promise: *%_) { ... }
+    method break(Promise: *%_) { ... }
 }
     method vow(Promise:D: *%_ --> Vow:D)
 

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -260,14 +260,14 @@ taken. See method C<vow> for more information.
 
 =head2 method result
 
-    method result(Promise:D, *%_)
+    method result(Promise:D: *%_)
 
 Waits for the promise to be kept or broken. If it is kept, returns the result;
 otherwise throws the result as an exception.
 
 =head2 method cause
 
-    method cause(Promise:D, *%_)
+    method cause(Promise:D: *%_)
 
 If the promise was broken, returns the result (or exception). Otherwise, throws
 an exception of type C<X::Promise::CauseOnlyValidOnBroken>.
@@ -281,7 +281,7 @@ C<Planned>.
 
 =head2 method status
 
-    method status(Promise:D *%_ --> PromiseStatus)
+    method status(Promise:D: *%_ --> PromiseStatus)
 
 Returns the current state of the promise: C<Kept>, C<Broken> or C<Planned>:
 

--- a/doc/Type/QuantHash.pod6
+++ b/doc/Type/QuantHash.pod6
@@ -16,7 +16,7 @@ C<QuantHashes> are what L<set operators|/language/setbagmix> use internally.
 
 =head2 method hash
 
-    method hash()
+    method hash(QuantHash: *%_)
 
 Coerces the C<QuantHash> object to a L<Hash|/type/Hash> (by stringifying the objects
 for the keys) with the values of the hash limited to the same limitation as
@@ -24,7 +24,7 @@ C<QuantHash>, and returns that.
 
 =head2 method Hash
 
-    method Hash()
+    method Hash(QuantHash: *%_)
 
 Coerces the C<QuantHash> object to a L<Hash|/type/Hash> (by stringifying the objects
 for the keys) without any limitations on the values, and returns that.
@@ -39,7 +39,7 @@ L<Baggy|/type/Baggy> or L<Real|/type/Real> for L<Mixy|/type/Mixy> roles.
 
 =head2 method keyof
 
-    method keyof()
+    method keyof(QuantHash: *%_)
 
 Returns the type of value a key of this subclass of C<QuantHash> may have. This
 is typically L<Mu|/type/Mu>, which is also the default for punned QuantHashes.

--- a/doc/Type/QuantHash.pod6
+++ b/doc/Type/QuantHash.pod6
@@ -46,7 +46,7 @@ is typically L<Mu|/type/Mu>, which is also the default for punned QuantHashes.
 
 =head2 method Setty
 
-    method QuantHash(QuantHash: *%_ --> Setty:D)
+    method Setty(QuantHash: *%_ --> Setty:D)
 
 Coerce the C<QuantHash> object to the equivalent object that uses the L<Setty|/type/Setty>
 role. Note that for L<Mixy|/type/Mixy> type coercion items with negative values will be skipped.
@@ -58,7 +58,7 @@ role. Note that for L<Mixy|/type/Mixy> type coercion items with negative values 
 
 =head2 method Baggy
 
-    method QuantHash(QuantHash: *%_ --> Baggy:D)
+    method Baggy(QuantHash: *%_ --> Baggy:D)
 
 Coerce the C<QuantHash> object to the equivalent object that uses the L<Baggy|/type/Baggy>
 role. Note that for L<Mixy|/type/Mixy> type coercion items with negative values will be skipped.
@@ -70,7 +70,7 @@ role. Note that for L<Mixy|/type/Mixy> type coercion items with negative values 
 
 =head2 method Mixy
 
-    method QuantHash(QuantHash: *%_ --> Mixy:D)
+    method Mixy(QuantHash: *%_ --> Mixy:D)
 
 Coerce the C<QuantHash> object to the equivalent object that uses the L<Mixy|/type/Mixy>
 role.

--- a/doc/Type/QuantHash.pod6
+++ b/doc/Type/QuantHash.pod6
@@ -46,7 +46,7 @@ is typically L<Mu|/type/Mu>, which is also the default for punned QuantHashes.
 
 =head2 method Setty
 
-    method Setty(--> Setty:D)
+    method QuantHash(QuantHash: *%_ --> Setty:D)
 
 Coerce the C<QuantHash> object to the equivalent object that uses the L<Setty|/type/Setty>
 role. Note that for L<Mixy|/type/Mixy> type coercion items with negative values will be skipped.
@@ -58,7 +58,7 @@ role. Note that for L<Mixy|/type/Mixy> type coercion items with negative values 
 
 =head2 method Baggy
 
-    method Baggy(--> Baggy:D)
+    method QuantHash(QuantHash: *%_ --> Baggy:D)
 
 Coerce the C<QuantHash> object to the equivalent object that uses the L<Baggy|/type/Baggy>
 role. Note that for L<Mixy|/type/Mixy> type coercion items with negative values will be skipped.
@@ -70,7 +70,7 @@ role. Note that for L<Mixy|/type/Mixy> type coercion items with negative values 
 
 =head2 method Mixy
 
-    method Mixy(--> Mixy:D)
+    method QuantHash(QuantHash: *%_ --> Mixy:D)
 
 Coerce the C<QuantHash> object to the equivalent object that uses the L<Mixy|/type/Mixy>
 role.

--- a/doc/Type/RaceSeq.pod6
+++ b/doc/Type/RaceSeq.pod6
@@ -66,7 +66,7 @@ Converts the object to a C<Seq> and returns it.
 
 =head2 method is-lazy
 
-    method is-lazy(--> False )
+    method RaceSeq(RaceSeq: *%_ --> False )
 
 Returns C<False>.
 

--- a/doc/Type/RaceSeq.pod6
+++ b/doc/Type/RaceSeq.pod6
@@ -66,7 +66,7 @@ Converts the object to a C<Seq> and returns it.
 
 =head2 method is-lazy
 
-    method RaceSeq(RaceSeq: *%_ --> False )
+    method is-lazy(RaceSeq: *%_ --> False )
 
 Returns C<False>.
 

--- a/doc/Type/RaceSeq.pod6
+++ b/doc/Type/RaceSeq.pod6
@@ -16,7 +16,7 @@ it's not intended for direct consumption by the developer.
 
 =head2 method iterator
 
-    method iterator(RaceSeq:D: --> Iterator:D)
+    method iterator(RaceSeq:D: *%_ --> Iterator:D)
 
 Returns the underlying iterator.
 

--- a/doc/Type/RaceSeq.pod6
+++ b/doc/Type/RaceSeq.pod6
@@ -42,19 +42,19 @@ Uses maps on the C<RaceSeq>, generally created by application of C<.race> to
 
 =head2 method invert
 
-    method invert(RaceSeq:D:)
+    method invert(RaceSeq:D: *%_)
 
 Inverts the C<RaceSeq> created from a C<Seq> by C<.race>.
 
 =head2 method race
 
-    method race(RaceSeq:D:)
+    method race(RaceSeq:D: *%_)
 
 Returns the object.
 
 =head2 method hyper
 
-    method hyper(RaceSeq:D:)
+    method hyper(RaceSeq:D: *%_)
 
 Creates a C<HyperSeq> object out of the current one.
 

--- a/doc/Type/RaceSeq.pod6
+++ b/doc/Type/RaceSeq.pod6
@@ -75,7 +75,7 @@ Returns C<False>.
 
 Defined as:
 
-    method sink(--> Nil)
+    method sink(RaceSeq: *%_ --> Nil)
 
 Sinks the underlying data structure, producing any side effects.
 

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -423,7 +423,7 @@ L<equivalent|/routine/eqv> object when given to L<EVAL|/routine/EVAL>.
 
 Defined as
 
-    method fmt(|c)
+    method fmt(Range: |c)
 
 Returns a string where C<min> and C<max> in the L<Range|/type/Range> have been
 formatted according to C<|c>.

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -362,7 +362,7 @@ say (1..∞).reverse;                             # OUTPUT: «(Inf Inf Inf ...)�
 
 Defined as:
 
-    method Capture(Range *%_ --> Capture:D)
+    method Capture(Range: *%_ --> Capture:D)
 
 Returns a L<Capture|/type/Capture> with values of L«C<.min>|/type/Range#method_min»
 L«C<.max>|/type/Range#method_max»,
@@ -375,7 +375,7 @@ L«C<.is-int>|/type/Range#method_is-int» as named arguments.
 
 Defined as:
 
-    method rand(Range:D *%_ --> Num:D)
+    method rand(Range:D: *%_ --> Num:D)
 
 Returns a pseudo-random value belonging to the range.
 

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -186,7 +186,7 @@ Returns the start point of the range.
 
 =head2 method excludes-min
 
-    method excludes-min(Range:D: --> Bool:D)
+    method excludes-min(Range:D: *%_ --> Bool:D)
 
 Returns C<True> if the start point is excluded from the range, and C<False>
 otherwise.
@@ -205,7 +205,7 @@ Returns the end point of the range.
 
 =head2 method excludes-max
 
-    method excludes-max(Range:D: --> Bool:D)
+    method excludes-max(Range:D: *%_ --> Bool:D)
 
 Returns C<True> if the end point is excluded from the range, and C<False>
 otherwise.
@@ -224,7 +224,7 @@ Returns a list consisting of the start and end point.
 
 =head2 method infinite
 
-    method infinite(Range:D: --> Bool:D)
+    method infinite(Range:D: *%_ --> Bool:D)
 
 Returns C<True> if either end point was declared with C<∞> or C<*>.
 
@@ -233,7 +233,7 @@ Returns C<True> if either end point was declared with C<∞> or C<*>.
 
 =head2 method is-int
 
-    method is-int(Range:D: --> Bool:D)
+    method is-int(Range:D: *%_ --> Bool:D)
 
 Returns C<True> if both end points are C<Int> values.
 
@@ -294,7 +294,7 @@ L<excludes-max|/routine/excludes-max> are C<True> in which case a L<Failure|/typ
 
 =head2 method elems
 
-    method elems(Range:D: --> Numeric:D)
+    method elems(Range:D: *%_ --> Numeric:D)
 
 Returns the number of elements in the range, e.g. when being iterated over,
 or when used as a C<List>.  Returns 0 if the start point is larger than the
@@ -307,7 +307,7 @@ either end point was specified as C<*>.
 
 =head2 method list
 
-    method list(Range:D: --> List:D)
+    method list(Range:D: *%_ --> List:D)
 
 Generates the list of elements that the range represents.
 
@@ -316,7 +316,7 @@ Generates the list of elements that the range represents.
 
 =head2 method flat
 
-    method flat(Range:D: --> List:D)
+    method flat(Range:D: *%_ --> List:D)
 
 Generates the list of elements that the range represents.
 
@@ -347,7 +347,7 @@ element can not be coerced into Numeric.
 
 =head2 method reverse
 
-    method reverse(Range:D: --> Seq:D)
+    method reverse(Range:D: *%_ --> Seq:D)
 
 Returns a L<Seq|/type/Seq> where all elements that the C<Range> represents have
 been reversed. Note that reversing an infinite C<Range> won't produce any
@@ -362,7 +362,7 @@ say (1..∞).reverse;                             # OUTPUT: «(Inf Inf Inf ...)�
 
 Defined as:
 
-    method Capture(Range --> Capture:D)
+    method Capture(Range *%_ --> Capture:D)
 
 Returns a L<Capture|/type/Capture> with values of L«C<.min>|/type/Range#method_min»
 L«C<.max>|/type/Range#method_max»,
@@ -375,7 +375,7 @@ L«C<.is-int>|/type/Range#method_is-int» as named arguments.
 
 Defined as:
 
-    method rand(Range:D --> Num:D)
+    method rand(Range:D *%_ --> Num:D)
 
 Returns a pseudo-random value belonging to the range.
 

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -177,7 +177,7 @@ the L<cmp|/routine/cmp> operator is used.
 
 =head2 method min
 
-    method min(Range:D:)
+    method min(Range:D: *%_)
 
 Returns the start point of the range.
 
@@ -196,7 +196,7 @@ otherwise.
 
 =head2 method max
 
-    method max(Range:D:)
+    method max(Range:D: *%_)
 
 Returns the end point of the range.
 

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -215,7 +215,7 @@ otherwise.
 
 =head2 method bounds
 
-    method bounds()
+    method bounds(Range: *%_)
 
 Returns a list consisting of the start and end point.
 

--- a/doc/Type/RatStr.pod6
+++ b/doc/Type/RatStr.pod6
@@ -51,7 +51,7 @@ C<True>. String portion is not considered.
 
 Defined as:
 
-    method Capture(RatStr:D --> Capture:D)
+    method Capture(RatStr:D *%_ --> Capture:D)
 
 Equivalent to L«C<Mu.Capture>|/type/Mu#method_Capture».
 

--- a/doc/Type/RatStr.pod6
+++ b/doc/Type/RatStr.pod6
@@ -26,7 +26,7 @@ object identity with C<Rat>- or C<Str>-only variants:
 
 =head2 method new
 
-    method new(Rat $i, Str $s)
+    method new(Rat $i, Str $s, *%_)
 
 The constructor requires both the C<Rat> and the C<Str> value, when constructing one
 directly the values can be whatever is required:

--- a/doc/Type/RatStr.pod6
+++ b/doc/Type/RatStr.pod6
@@ -26,7 +26,7 @@ object identity with C<Rat>- or C<Str>-only variants:
 
 =head2 method new
 
-    method new(Rat $i, Str $s, *%_)
+    method new(RatStr: Rat $r, Str $s, *%_)
 
 The constructor requires both the C<Rat> and the C<Str> value, when constructing one
 directly the values can be whatever is required:
@@ -51,7 +51,7 @@ C<True>. String portion is not considered.
 
 Defined as:
 
-    method Capture(RatStr:D *%_ --> Capture:D)
+    method Capture(RatStr:D: *%_ --> Capture:D)
 
 Equivalent to L«C<Mu.Capture>|/type/Mu#method_Capture».
 

--- a/doc/Type/Rational.pod6
+++ b/doc/Type/Rational.pod6
@@ -27,7 +27,7 @@ both do the C<Rational> role.
 =head2 method new
 
     =for code :preamble<subset NuT of Int; subset DeT of Int>
-    method new(NuT:D $numerator, DeT:D $denominator --> Rational:D)
+    method new(NuT:D $numerator, DeT:D $denominator, *%_ --> Rational:D)
 
 Creates a new rational object from numerator and denominator, which it
 normalizes to the lowest terms. The C<$denominator> can be zero, in which
@@ -56,7 +56,7 @@ Returns the number, converted to C<Num>.
 
 Defined as:
 
-    method Int(Rational:D: --> Int:D)
+    method Int(Rational:D: *%_ --> Int:D)
 
 Coerces the invocant to L<Int|/type/Int> by truncating non-whole portion of the represented
 number, if any. If the L<denominator|/routine/denominator> is zero, will L<fail|/routine/fail> with
@@ -66,7 +66,7 @@ C<X::Numeric::DivideByZero>.
 
 Defined as:
 
-    method Num(Rational:D: --> Num:D)
+    method Num(Rational:D: *%_ --> Num:D)
 
 Coerces the invocant to L<Num|/type/Num> by dividing L<numerator|/routine/numerator> by L<denominator|/routine/denominator>.
 If L<denominator|/routine/denominator> is C<0>, returns C<Inf>, C<-Inf>, or C<NaN>, based on
@@ -77,7 +77,7 @@ respectively.
 
 Defined as:
 
-    method ceiling(Rational:D: --> Int:D)
+    method ceiling(Rational:D: *%_ --> Int:D)
 
 Return the smallest integer not less than the invocant. If L<denominator|/routine/denominator>
 is zero, L<fails|/routine/fail> with C<X::Numeric::DivideByZero>.
@@ -86,14 +86,14 @@ is zero, L<fails|/routine/fail> with C<X::Numeric::DivideByZero>.
 
 Defined as:
 
-    method floor(Rational:D: --> Int:D)
+    method floor(Rational:D: *%_ --> Int:D)
 
 Return the largest integer not greater than the invocant. If L<denominator|/routine/denominator>
 is zero, L<fails|/routine/fail> with C<X::Numeric::DivideByZero>.
 
 =head2 method isNaN
 
-    method isNaN(Rational:D: --> Bool:D)
+    method isNaN(Rational:D: *%_ --> Bool:D)
 
 Tests whether the invocant's Num value is a NaN, an acronym for I<Not available
 Number>. That is both its numerator and denominator are zero.
@@ -114,13 +114,13 @@ Returns the denominator.
 
 =head2 method nude
 
-    method nude(Rational:D: --> Positional)
+    method nude(Rational:D: *%_ --> Positional)
 
 Returns a list of the numerator and denominator.
 
 =head2 method norm
 
-    method norm(Rational:D: --> Rational:D)
+    method norm(Rational:D: *%_ --> Rational:D)
 
 B<DEPRECATED as of 6.d>. The method is no longer needed, because as of 6.d
 language version, it's required for C<Rational> type to be normalized on

--- a/doc/Type/Rational.pod6
+++ b/doc/Type/Rational.pod6
@@ -140,7 +140,7 @@ say $by-zero; # OUTPUT: «Attempt to divide by zero when coercing Rational to St
 
 =head2 method base-repeating
 
-    method base-repeating(Rational:D: Int:D() $base = 10)
+    method base-repeating(Rational:D: Int:D() $base = 10, *%_)
 
 Returns a list of two strings that, when concatenated, represent the number in
 base C<$base>. The second element is the one that repeats. For example:

--- a/doc/Type/Rational.pod6
+++ b/doc/Type/Rational.pod6
@@ -48,7 +48,7 @@ being C<True>.
 
 Defined as:
 
-    method Bridge()
+    method Bridge(Rational: *%_)
 
 Returns the number, converted to C<Num>.
 

--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -14,7 +14,7 @@ Common role for non-L<Complex|/type/Complex> numbers.
 
 Defined as:
 
-    method Bridge(Real:D:)
+    method Bridge(Real:D: *%_)
 
 Default implementation coerces the invocant to L<Num|/type/Num> and that's the behavior
 of this method in core L<Real|/type/Real> types. This method primarily exist to make it
@@ -99,7 +99,7 @@ The term form returns a pseudo-random C<Num> between 0e0 (inclusive) and 1e0
 
 =head2 method sign
 
-    method sign(Real:D:)
+    method sign(Real:D: *%_)
 
 Returns C<-1> if the number is negative, C<0> if it is zero and C<1>
 otherwise.

--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -63,7 +63,7 @@ it is an L<Int|/type/Int> when we instantiated C<Temperature> with an L<Int|/typ
 
 =head2 method Complex
 
-    method Complex(Real:D: --> Complex:D)
+    method Complex(Real:D: *%_ --> Complex:D)
 
 Converts the number to a C<Complex> with the number converted to a C<Num> as
 its real part and 0e0 as the imaginary part.
@@ -88,7 +88,7 @@ C<self.new>.
 =head2 routine rand
 
     sub term:<rand> (--> Num:D)
-    method rand(Real:D: --> Real:D)
+    method rand(Real:D: *%_ --> Real:D)
 
 Returns a pseudo-random number between zero (inclusive) and the number
 (non-inclusive). The L«C<Bridge> method|/routine/Bridge» is used to coerce the
@@ -113,19 +113,19 @@ integer. If scale is C<0.1>, rounds to one digit after the radix point (period o
 
 =head2 method floor
 
-    method floor(Real:D --> Int:D)
+    method floor(Real:D *%_ --> Int:D)
 
 Return the largest integer not greater than the number.
 
 =head2 method ceiling
 
-    method ceiling(Real:D --> Int:D)
+    method ceiling(Real:D *%_ --> Int:D)
 
 Returns the smallest integer not less than the number.
 
 =head2 method truncate
 
-    method truncate(Real:D --> Int:D)
+    method truncate(Real:D *%_ --> Int:D)
 
 Rounds the number towards zero.
 
@@ -145,7 +145,7 @@ for the last remainder.
 
 =head2 method base
 
-    method base(Real:D: Int:D $base where 2..36, $digits? --> Str:D)
+    method base(Real:D: Int:D $base where 2..36, $digits? *%_ --> Str:D)
 
 Converts the number to a string, using C<$base> as base. For C<$base> larger
 than ten, capital Latin letters are used.

--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -113,19 +113,19 @@ integer. If scale is C<0.1>, rounds to one digit after the radix point (period o
 
 =head2 method floor
 
-    method floor(Real:D *%_ --> Int:D)
+    method floor(Real:D: *%_ --> Int:D)
 
 Return the largest integer not greater than the number.
 
 =head2 method ceiling
 
-    method ceiling(Real:D *%_ --> Int:D)
+    method ceiling(Real:D: *%_ --> Int:D)
 
 Returns the smallest integer not less than the number.
 
 =head2 method truncate
 
-    method truncate(Real:D *%_ --> Int:D)
+    method truncate(Real:D: *%_ --> Int:D)
 
 Rounds the number towards zero.
 

--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -145,7 +145,7 @@ for the last remainder.
 
 =head2 method base
 
-    method base(Real:D: Int:D $base where 2..36, $digits? *%_ --> Str:D)
+    method base(Real:D: Int:D $base where 2..36, $digits?, *%_ --> Str:D)
 
 Converts the number to a string, using C<$base> as base. For C<$base> larger
 than ten, capital Latin letters are used.

--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -70,7 +70,7 @@ its real part and 0e0 as the imaginary part.
 
 =head2 method Rat
 
-    method Rat(Real:D: Real $epsilon = 1e-6)
+    method Rat(Real:D: Real $epsilon = 1e-6, *%_)
 
 Converts the number to a C<Rat> with the precision C<$epsilon>.
 
@@ -106,7 +106,7 @@ otherwise.
 
 =head2 method round
 
-    method round(Real:D: $scale = 1)
+    method round(Real:D: $scale = 1, *%_)
 
 Rounds the number to scale C<$scale>. If C<$scale> is 1, rounds to an
 integer. If scale is C<0.1>, rounds to one digit after the radix point (period or comma), etc.
@@ -131,7 +131,7 @@ Rounds the number towards zero.
 
 =head2 method polymod
 
-    method polymod(Real:D: +@mods)
+    method polymod(Real:D: +@mods, *%_)
 
 Returns the remainders after applying sequentially all divisors in the C<@mods>
 argument; the last element of the array will be the last remainder.

--- a/doc/Type/Routine.pod6
+++ b/doc/Type/Routine.pod6
@@ -57,7 +57,7 @@ if it's not a multi
 
 =head2 method cando
 
-    method cando(Capture $c, *%_)
+    method cando(Routine: Capture $c, *%_)
 
 Returns a possibly-empty list of candidates that can be called with the
 given L<Capture|/type/Capture>, ordered by narrowest candidate first. For
@@ -82,7 +82,7 @@ which you can pass to L<unwrap|/routine/unwrap> to restore the original routine.
 
 =head2 method unwrap
 
-    method unwrap($wraphandle, *%_)
+    method unwrap(Routine:D: $wraphandle, *%_)
 
 Restores the original routine after it has been wrapped with
 L<wrap|/routine/wrap>. While the signature allows any type to be passed, only

--- a/doc/Type/Routine.pod6
+++ b/doc/Type/Routine.pod6
@@ -37,7 +37,7 @@ Returns the package in which the routine is defined.
 
 =head2 method multi
 
-    method multi(Routine:D: --> Bool:D)
+    method multi(Routine:D: *%_ --> Bool:D)
 
 Returns C<True> if the routine is a multi sub or method. Note that
 the name of a multi sub refers to its L<C<proto>|/syntax/proto> and this method would
@@ -50,7 +50,7 @@ candidates themselves:
 
 =head2 method candidates
 
-    method candidates(Routine:D: --> Positional:D)
+    method candidates(Routine:D: *%_ --> Positional:D)
 
 Returns a list of multi candidates, or a one-element list with itself
 if it's not a multi

--- a/doc/Type/Routine.pod6
+++ b/doc/Type/Routine.pod6
@@ -31,7 +31,7 @@ Returns the name of the sub or method.
 
 =head2 method package
 
-    method package(Routine:D:)
+    method package(Routine:D: *%_)
 
 Returns the package in which the routine is defined.
 

--- a/doc/Type/Routine.pod6
+++ b/doc/Type/Routine.pod6
@@ -57,7 +57,7 @@ if it's not a multi
 
 =head2 method cando
 
-    method cando(Capture $c)
+    method cando(Capture $c, *%_)
 
 Returns a possibly-empty list of candidates that can be called with the
 given L<Capture|/type/Capture>, ordered by narrowest candidate first. For
@@ -68,7 +68,7 @@ methods, the first element of the Capture needs to be the invocant:
 
 =head2 method wrap
 
-    method wrap(Routine:D: &wrapper)
+    method wrap(Routine:D: &wrapper, *%_)
 
 Wraps (i.e. in-place modifies) the routine. That means a call to this routine
 first calls C<&wrapper>, which then can (but doesn't have to) call the
@@ -82,7 +82,7 @@ which you can pass to L<unwrap|/routine/unwrap> to restore the original routine.
 
 =head2 method unwrap
 
-    method unwrap($wraphandle)
+    method unwrap($wraphandle, *%_)
 
 Restores the original routine after it has been wrapped with
 L<wrap|/routine/wrap>. While the signature allows any type to be passed, only

--- a/doc/Type/Scalar.pod6
+++ b/doc/Type/Scalar.pod6
@@ -113,7 +113,7 @@ make such bugs much more evident (rather than only observed under stress).
 
 =head2 method of
 
-    method of(Scalar:D: --> Mu)
+    method of(Scalar:D: *%_ --> Mu)
 
 Returns the type constraint of the container.
 
@@ -124,7 +124,7 @@ Example:
 
 =head2 method default
 
-    method default(Scalar:D: --> Str)
+    method default(Scalar:D: *%_ --> Str)
 
 Returns the default value associated with the container.
 
@@ -135,7 +135,7 @@ Example:
 
 =head2 method name
 
-    method name(Scalar:D: --> Str)
+    method name(Scalar:D: *%_ --> Str)
 
 Returns the name associated with the container.
 
@@ -146,7 +146,7 @@ Example:
 
 =head2 method dynamic
 
-    method dynamic(Scalar:D: --> Bool)
+    method dynamic(Scalar:D: *%_ --> Bool)
 
 It will return C<False> for scalars.
 

--- a/doc/Type/Scheduler.pod6
+++ b/doc/Type/Scheduler.pod6
@@ -27,7 +27,7 @@ code that is being scheduled and run.
 
 =head2 method cue
 
-    method cue(&code, Instant :$at, :$in, :$every, :$times = 1; :&catch --> Cancellation)
+    method cue(&code, Instant :$at, :$in, :$every, :$times = 1; :&catch, *%_ --> Cancellation)
 
 Schedules a callable (C<&code>) for execution and returns an instantiated
 C<Cancellation> object to cancel the scheduling of the code for execution

--- a/doc/Type/Semaphore.pod6
+++ b/doc/Type/Semaphore.pod6
@@ -63,7 +63,7 @@ releases the semaphore.
 
 =head2 method try_acquire
 
-  method try_acquire(--> Bool)
+    method try_acquire(Semaphore: *%_ --> Bool)
 
 Same as acquire but will not block. Instead it returns C<True> if access is
 permitted or C<False> otherwise.

--- a/doc/Type/Semaphore.pod6
+++ b/doc/Type/Semaphore.pod6
@@ -55,7 +55,7 @@ third time acquire is called.
 
 =head2 method acquire
 
-  method acquire()
+    method acquire(Semaphore: *%_)
 
 Acquire access. When other threads have called the method before and the
 number of permits are used up, the process blocks until threads passed before
@@ -70,7 +70,7 @@ permitted or C<False> otherwise.
 
 =head2 method release
 
-  method release()
+    method release(Semaphore: *%_)
 
 Release the semaphore raising the number of permissions. Any blocked thread will
 get access after that.

--- a/doc/Type/Semaphore.pod6
+++ b/doc/Type/Semaphore.pod6
@@ -25,7 +25,7 @@ printer becomes available.
 
     method find-available-printer-and-print-it($job) { say "Is printed!"; }
 
-    method print( $print-job ) {
+    method print( $print-job , *%_) {
       $!print-control.acquire;
 
       self.find-available-printer-and-print-it($print-job);
@@ -47,7 +47,7 @@ indefinitely.
 
 =head2 method new
 
-  method new( int $permits )
+    method new( int $permits , *%_)
 
 Initialize the semaphore with the number of permitted accesses. E.g. when set to
 2, program threads can pass the acquire method twice until it blocks on the

--- a/doc/Type/Semaphore.pod6
+++ b/doc/Type/Semaphore.pod6
@@ -47,7 +47,7 @@ indefinitely.
 
 =head2 method new
 
-    method new( int $permits , *%_)
+    method new(Semaphore: int $permits , *%_)
 
 Initialize the semaphore with the number of permitted accesses. E.g. when set to
 2, program threads can pass the acquire method twice until it blocks on the

--- a/doc/Type/Seq.pod6
+++ b/doc/Type/Seq.pod6
@@ -135,7 +135,7 @@ C<&afterward>, after each call to C<&body>.
 
 Defined as:
 
-    method sink(--> Nil)
+    method sink(Seq: *%_ --> Nil)
 
 Calls L<C<sink-all>|/routine/sink-all> if it is an C<Iterator>, C<sink> if the Sequence is a list.
 

--- a/doc/Type/Seq.pod6
+++ b/doc/Type/Seq.pod6
@@ -77,13 +77,13 @@ leading to possibly infinite loops, so be sure to limit search somehow.
 
 =head2 method new
 
-    method new(Iterator:D $iter --> Seq:D)
+    method new(Iterator:D $iter, *%_ --> Seq:D)
 
 Creates a new C<Seq> object from the iterator passed as the single argument.
 
 =head2 method iterator
 
-    method iterator(Seq:D: --> Iterator:D)
+    method iterator(Seq:D: *%_ --> Iterator:D)
 
 If the C<Seq> is not cached, returns the underlying iterator and marks
 the invocant as consumed. If called on an already consumed sequence,
@@ -93,7 +93,7 @@ Otherwise returns an iterator over the cached list.
 
 =head2 method is-lazy
 
-    method is-lazy(Seq:D: --> Bool:D)
+    method is-lazy(Seq:D: *%_ --> Bool:D)
 
 Returns C<True> if and only if the underlying iterator or cached list
 considers itself lazy. If called on an already consumed sequence, throws

--- a/doc/Type/Seq.pod6
+++ b/doc/Type/Seq.pod6
@@ -101,7 +101,7 @@ an error of type L<X::Seq::Consumed|/type/X::Seq::Consumed>.
 
 =head2 method elems
 
-    method elems(Seq:D:)
+    method elems(Seq:D: *%_)
 
 Returns the number of values in the sequence. If this number cannot be
 predicted, the C<Seq> is cached and evaluated till the end.

--- a/doc/Type/Seq.pod6
+++ b/doc/Type/Seq.pod6
@@ -77,7 +77,7 @@ leading to possibly infinite loops, so be sure to limit search somehow.
 
 =head2 method new
 
-    method new(Iterator:D $iter, *%_ --> Seq:D)
+    method new(Seq: Iterator:D $iter, *%_ --> Seq:D)
 
 Creates a new C<Seq> object from the iterator passed as the single argument.
 

--- a/doc/Type/Sequence.pod6
+++ b/doc/Type/Sequence.pod6
@@ -81,7 +81,7 @@ L<X::Seq::Consumed|/type/X::Seq::Consumed>.
 
 =head2 method fmt
 
-    method fmt($format = '%s', $separator = ' ', *%_ --> Str:D)
+    method fmt($?CLASS: $format = '%s', $separator = ' ', *%_ --> Str:D)
 
 L<Formats|/type/List#method_fmt> the
 L<cached|/type/PositionalBindFailover#method_cache> sequence.

--- a/doc/Type/Sequence.pod6
+++ b/doc/Type/Sequence.pod6
@@ -81,7 +81,7 @@ L<X::Seq::Consumed|/type/X::Seq::Consumed>.
 
 =head2 method fmt
 
-    method fmt($?CLASS: $format = '%s', $separator = ' ', *%_ --> Str:D)
+    method fmt(Sequence: $format = '%s', $separator = ' ', *%_ --> Str:D)
 
 L<Formats|/type/List#method_fmt> the
 L<cached|/type/PositionalBindFailover#method_cache> sequence.

--- a/doc/Type/Sequence.pod6
+++ b/doc/Type/Sequence.pod6
@@ -35,7 +35,7 @@ L<cached|/type/PositionalBindFailover#method_cache> sequence.
 
 =head2 method Numeric
 
-    method Numeric(::?CLASS:D:)
+    method Numeric(::?CLASS:D: *%_)
 
 Returns the number of elements in the
 L<cached|/type/PositionalBindFailover#method_cache> sequence.

--- a/doc/Type/Sequence.pod6
+++ b/doc/Type/Sequence.pod6
@@ -81,7 +81,7 @@ L<X::Seq::Consumed|/type/X::Seq::Consumed>.
 
 =head2 method fmt
 
-    method fmt($format = '%s', $separator = ' ' --> Str:D)
+    method fmt($format = '%s', $separator = ' ', *%_ --> Str:D)
 
 L<Formats|/type/List#method_fmt> the
 L<cached|/type/PositionalBindFailover#method_cache> sequence.

--- a/doc/Type/SetHash.pod6
+++ b/doc/Type/SetHash.pod6
@@ -170,7 +170,7 @@ say $a ∪ $b;  # OUTPUT: «SetHash(1 2 3 4)␤»
 
 Defined as:
 
-    method set(SetHash:D: \to-set *%_ --> Nil)
+    method set(SetHash:D: \to-set, *%_ --> Nil)
 
 When given single key, C<set> adds it to the C<SetHash>.  When given a
 C<List>, C<Array>, C<Seq>, or any other type that C<does> the
@@ -183,7 +183,7 @@ I<Note:> since version 2020.02.
 
 Defined as:
 
-    method unset(SetHash:D: \to-unset *%_ --> Nil)
+    method unset(SetHash:D: \to-unset, *%_ --> Nil)
 
 When given single key, C<unset> removes it from the C<SetHash>.  When
 given a C<List>, C<Array>, C<Seq>, or any other type that C<does> the

--- a/doc/Type/SetHash.pod6
+++ b/doc/Type/SetHash.pod6
@@ -170,7 +170,7 @@ say $a ∪ $b;  # OUTPUT: «SetHash(1 2 3 4)␤»
 
 Defined as:
 
-    method set(SetHash:D: \to-set --> Nil)
+    method set(SetHash:D: \to-set *%_ --> Nil)
 
 When given single key, C<set> adds it to the C<SetHash>.  When given a
 C<List>, C<Array>, C<Seq>, or any other type that C<does> the
@@ -183,7 +183,7 @@ I<Note:> since version 2020.02.
 
 Defined as:
 
-    method unset(SetHash:D: \to-unset --> Nil)
+    method unset(SetHash:D: \to-unset *%_ --> Nil)
 
 When given single key, C<unset> removes it from the C<SetHash>.  When
 given a C<List>, C<Array>, C<Seq>, or any other type that C<does> the

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -15,7 +15,7 @@ See L<Set|/type/Set> and L<SetHash|/type/SetHash>.
 
 Defined as:
 
-    method new-from-pairs(*@pairs --> Setty:D)
+    method new-from-pairs(*@pairs, *%_ --> Setty:D)
 
 Constructs a Setty object from a list of L«C<Pair> objects|/type/Pair»
 given as positional arguments:

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -15,7 +15,7 @@ See L<Set|/type/Set> and L<SetHash|/type/SetHash>.
 
 Defined as:
 
-    method new-from-pairs(*@pairs, *%_ --> Setty:D)
+    method new-from-pairs(Setty: *@pairs, *%_ --> Setty:D)
 
 Constructs a Setty object from a list of L«C<Pair> objects|/type/Pair»
 given as positional arguments:
@@ -28,7 +28,7 @@ the quotes around the keys in the above example are significant.
 
 =head2 method grab
 
-    method grab($count = 1, *%_)
+    method grab(Setty: $count = 1, *%_)
 
 Removes and returns C<$count> elements chosen at random (without repetition)
 from the set.
@@ -41,7 +41,7 @@ exception.
 
 =head2 method grabpairs
 
-    method grabpairs($count = 1, *%_)
+    method grabpairs(Setty: $count = 1, *%_)
 
 Removes C<$count> elements chosen at random (without repetition) from the set,
 and returns a list of C<Pair> objects whose keys are the grabbed elements and

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -144,13 +144,13 @@ Returns a L<Seq|/type/Seq> of the set's elements and C<True> values interleaved.
 
 =head2 method elems
 
-    method elems(--> Int)
+    method Setty(Setty: *%_ --> Int)
 
 The number of elements of the set.
 
 =head2 method total
 
-    method total(--> Int)
+    method Setty(Setty: *%_ --> Int)
 
 The total of all the values of the C<QuantHash> object. For a C<Setty>
 object, this is just the number of elements.
@@ -179,7 +179,7 @@ L«C<Any.maxpairs>|/routine/maxpairs»
 
 Defined as:
 
-    method default(--> False)
+    method Setty(Setty: *%_ --> False)
 
 Returns the default value of the invocant, i.e. the value which is returned
 when trying to access an element in the C<Setty> object which has not been

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -28,7 +28,7 @@ the quotes around the keys in the above example are significant.
 
 =head2 method grab
 
-    method grab($count = 1)
+    method grab($count = 1, *%_)
 
 Removes and returns C<$count> elements chosen at random (without repetition)
 from the set.
@@ -41,7 +41,7 @@ exception.
 
 =head2 method grabpairs
 
-    method grabpairs($count = 1)
+    method grabpairs($count = 1, *%_)
 
 Removes C<$count> elements chosen at random (without repetition) from the set,
 and returns a list of C<Pair> objects whose keys are the grabbed elements and

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -144,7 +144,7 @@ Returns a L<Seq|/type/Seq> of the set's elements and C<True> values interleaved.
 
 =head2 method elems
 
-    method Setty(Setty: *%_ --> Int)
+    method elems(Setty: *%_ --> Int)
 
 The number of elements of the set.
 
@@ -179,7 +179,7 @@ L«C<Any.maxpairs>|/routine/maxpairs»
 
 Defined as:
 
-    method Setty(Setty: *%_ --> False)
+    method default(Setty: *%_ --> False)
 
 Returns the default value of the invocant, i.e. the value which is returned
 when trying to access an element in the C<Setty> object which has not been

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -1098,20 +1098,20 @@ Traits can be followed by the where clause:
 
 =head2 method params
 
-    method params(Signature:D: --> Positional)
+    method params(Signature:D: *%_ --> Positional)
 
 Returns the list of L<C<Parameter>|/type/Parameter> objects that make up the signature.
 
 =head2 method arity
 
-    method arity(Signature:D: --> Int:D)
+    method arity(Signature:D: *%_ --> Int:D)
 
 Returns the I<minimal> number of positional arguments required to satisfy
 the signature.
 
 =head2 method count
 
-    method count(Signature:D: --> Real:D)
+    method count(Signature:D: *%_ --> Real:D)
 
 Returns the I<maximal> number of positional arguments which can be bound
 to the signature. Returns C<Inf> if there is a slurpy positional parameter.

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -1162,7 +1162,7 @@ literals, which are just sugar for the C<where>-constraints:
 
 Defined as:
 
-    method Capture()
+    method Capture(Signature: *%_)
 
 Throws C<X::Cannot::Capture>.
 

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -337,7 +337,7 @@ characters, and ignores additional marks such as combining accents.
 
 =head2 method match
 
-    method match($pat, :continue(:$c), :pos(:$p), :global(:$g), :overlap(:$ov), :exhaustive(:$ex), :st(:$nd), :rd(:$th), :$nth, :$x --> Match)
+    method match($pat, :continue(:$c), :pos(:$p), :global(:$g), :overlap(:$ov), :exhaustive(:$ex), :st(:$nd), :rd(:$th), :$nth, :$x, *%_ --> Match)
 
 Performs a match of the string against C<$pat> and returns a
 L<Match|/type/Match> object if there is a successful match; it returns C<(Any)>
@@ -413,7 +413,7 @@ say "foo[bar][baz]bada".match('ba', :x(2));       # OUTPUT: «(｢ba｣ ｢ba｣
 
 Defined as:
 
-    method Numeric(Str:D: --> Numeric:D)
+    method Numeric(Str:D: *%_ --> Numeric:D)
 
 Coerces the string to L<Numeric|/type/Numeric> using semantics equivalent to L<val|/routine/val> routine.
 L<Fails|/routine/fail> with C<X::Str::Numeric> if the coercion to a number cannot be done.
@@ -435,7 +435,7 @@ C<Numeric>. +, - and the Unicode MINUS SIGN − are all allowed.
 
 Defined as:
 
-    method Int(Str:D: --> Int:D)
+    method Int(Str:D: *%_ --> Int:D)
 
 Coerces the string to L<Int|/type/Int>, using the same rules as
 L«C<Str.Numeric>|/type/Str#method_Numeric».
@@ -444,7 +444,7 @@ L«C<Str.Numeric>|/type/Str#method_Numeric».
 
 Defined as:
 
-    method Rat(Str:D: --> Rational:D)
+    method Rat(Str:D: *%_ --> Rational:D)
 
 Coerces the string to a L<Rat|/type/Rat> object, using the same rules as
 L«C<Str.Numeric>|/type/Str#method_Numeric». If the denominator is larger
@@ -454,7 +454,7 @@ than 64-bits is it still kept and no degradation to L<Num|/type/Num> occurs.
 
 Defined as:
 
-    method Bool(Str:D: --> Bool:D)
+    method Bool(Str:D: *%_ --> Bool:D)
 
 Returns C<False> if the string is empty, C<True> otherwise.
 
@@ -478,7 +478,7 @@ See also: L«:16<FF> syntax for number literals|/syntax/Number%20literals»
 =head2 routine parse-names
 
     sub    parse-names(Str:D $names  --> Str:D)
-    method parse-names(Str:D $names: --> Str:D)
+    method parse-names(Str:D $names: *%_ --> Str:D)
 
 B<DEPRECATED>. Use L<uniparse|/routine/uniparse> instead. Existed in Rakudo implementation as a proof of viability
 implementation before being renamed and will be removed when 6.e language is released.
@@ -486,7 +486,7 @@ implementation before being renamed and will be removed when 6.e language is rel
 =head2 routine uniparse
 
     sub    uniparse(Str:D $names  --> Str:D)
-    method uniparse(Str:D $names: --> Str:D)
+    method uniparse(Str:D $names: *%_ --> Str:D)
 
 Takes string with comma-separated Unicode names of characters and
 returns a string composed of those characters. Will L«C<fail>|/routine/fail»
@@ -1013,7 +1013,7 @@ for repeated operations:
 =head2 routine samemark
 
     multi sub samemark(Str:D $string, Str:D $pattern --> Str:D)
-    method    samemark(Str:D: Str:D $pattern --> Str:D)
+    method samemark(Str:D: Str:D $pattern *%_ --> Str:D)
 
 Returns a copy of C<$string> with the mark/accent information for each
 character changed such that it matches the mark/accent of the corresponding
@@ -1031,7 +1031,7 @@ Examples:
 
 =head2 method succ
 
-    method succ(Str:D --> Str:D)
+    method succ(Str:D *%_ --> Str:D)
 
 Returns the string incremented by one.
 
@@ -1056,7 +1056,7 @@ character can be uniquely classified as belonging to one range of characters.
 
 =head2 method pred
 
-    method pred(Str:D: --> Str:D)
+    method pred(Str:D: *%_ --> Str:D)
 
 Returns the string decremented by one.
 
@@ -1184,7 +1184,7 @@ outdented to the margin:
 
 =head2 method trim
 
-    method trim(Str:D: --> Str)
+    method trim(Str:D: *%_ --> Str)
 
 Remove leading and trailing whitespace. It can be used both as a method
 on strings and as a function. When used as a method it will return
@@ -1204,40 +1204,40 @@ See also L<trim-trailing|/routine/trim-trailing> and L<trim-leading|/routine/tri
 
 =head2 method trim-trailing
 
-    method trim-trailing(Str:D: --> Str)
+    method trim-trailing(Str:D: *%_ --> Str)
 
 Removes the whitespace characters from the end of a string. See also L<trim|/routine/trim>.
 
 =head2 method trim-leading
 
-    method trim-leading(Str:D: --> Str)
+    method trim-leading(Str:D: *%_ --> Str)
 
 Removes the whitespace characters from the beginning of a string. See also L<trim|/routine/trim>.
 
 =head2 method NFC
 
-    method NFC(Str:D: --> NFC:D)
+    method NFC(Str:D: *%_ --> NFC:D)
 
 Returns a codepoint string in L<NFC|/type/NFC> format (Unicode
 Normalization Form C / Composed).
 
 =head2 method NFD
 
-    method NFD(Str:D: --> NFD:D)
+    method NFD(Str:D: *%_ --> NFD:D)
 
 Returns a codepoint string in L<NFD|/type/NFD> format (Unicode
 Normalization Form D / Decomposed).
 
 =head2 method NFKC
 
-    method NFKC(Str:D: --> NFKC:D)
+    method NFKC(Str:D: *%_ --> NFKC:D)
 
 Returns a codepoint string in L<NFKC|/type/NFKC> format (Unicode Normalization
 Form KC / Compatibility Composed).
 
 =head2 method NFKD
 
-    method NFKD(Str:D: --> NFKD:D)
+    method NFKD(Str:D: *%_ --> NFKD:D)
 
 Returns a codepoint string in L<NFKD|/type/NFKD> format (Unicode Normalization
 Form KD / Compatibility Decomposed).
@@ -1291,7 +1291,7 @@ C<Numeric>.
 
 =head2 method Version
 
-    method Version(Str:D: --> Version:D)
+    method Version(Str:D: *%_ --> Version:D)
 
 Coerces the string to L<Version|/type/Version>.
 

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -1307,7 +1307,7 @@ B<Note>: Available since version 6.e (2020.01 and later).
 
 Defined as:
 
-    method Date(Str:D:)
+    method Date(Str:D: *%_)
 
 Coerces a C<Str> to a L«C«Date»|/type/Date» object, provided the string is
 properly formatted. C«Date(Str)» also works.
@@ -1321,7 +1321,7 @@ Examples:
 
 Defined as:
 
-    method DateTime(Str:D:)
+    method DateTime(Str:D: *%_)
 
 Coerces a C<Str> to a L«C«DateTime»|/type/DateTime» object, provided the
 string is properly formatted. C«DateTime(Str)» also works.

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -337,7 +337,7 @@ characters, and ignores additional marks such as combining accents.
 
 =head2 method match
 
-    method match($pat, :continue(:$c), :pos(:$p), :global(:$g), :overlap(:$ov), :exhaustive(:$ex), :st(:$nd), :rd(:$th), :$nth, :$x, *%_ --> Match)
+    method match(Str: $pat, :continue(:$c), :pos(:$p), :global(:$g), :overlap(:$ov), :exhaustive(:$ex), :st(:$nd), :rd(:$th), :$nth, :$x, *%_ --> Match)
 
 Performs a match of the string against C<$pat> and returns a
 L<Match|/type/Match> object if there is a successful match; it returns C<(Any)>
@@ -964,7 +964,7 @@ Also using a different value or an incorrect starting index won't match:
 
 =head2 method substr-rw
 
-    method substr-rw($from, $length = *)
+    method substr-rw(Str:D \SELF: $from, $length = *)
 
 A version of C<substr> that returns a L<Proxy|/type/Proxy> functioning as a
 writable reference to a part of a string variable. Its first argument, C<$from>
@@ -1013,7 +1013,7 @@ for repeated operations:
 =head2 routine samemark
 
     multi sub samemark(Str:D $string, Str:D $pattern --> Str:D)
-    method samemark(Str:D: Str:D $pattern *%_ --> Str:D)
+    method samemark(Str:D: Str:D $pattern, *%_ --> Str:D)
 
 Returns a copy of C<$string> with the mark/accent information for each
 character changed such that it matches the mark/accent of the corresponding
@@ -1031,7 +1031,7 @@ Examples:
 
 =head2 method succ
 
-    method succ(Str:D *%_ --> Str:D)
+    method succ(Str:D: *%_ --> Str:D)
 
 Returns the string incremented by one.
 

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -1252,7 +1252,7 @@ Returns C<True> if the string is L<the same as|/routine/eq> C<$other>.
 
 Defined as:
 
-    method Capture()
+    method Capture(Str: *%_)
 
 Throws C<X::Cannot::Capture>.
 

--- a/doc/Type/Supplier.pod6
+++ b/doc/Type/Supplier.pod6
@@ -30,7 +30,7 @@ be created with a L<Supplier::Preserving|/type/Supplier::Preserving>.
 
 =head2 method new
 
-    method new()
+    method new(Supplier: *%_)
 
 The C<Supplier> constructor.
 

--- a/doc/Type/Supplier.pod6
+++ b/doc/Type/Supplier.pod6
@@ -43,7 +43,7 @@ on this supplier are passed. This is the factory for all C<live> supplies.
 
 =head2 method emit
 
-    method emit(Supplier:D: Mu \value)
+    method emit(Supplier:D: Mu \value, *%_)
 
 Sends the given value to all of the taps on all of the supplies created by
 C<Supply> on this C<Supplier>.

--- a/doc/Type/Supplier.pod6
+++ b/doc/Type/Supplier.pod6
@@ -36,7 +36,7 @@ The C<Supplier> constructor.
 
 =head2 method Supply
 
-    method Supply(Supplier:D: --> Supply)
+    method Supply(Supplier:D: *%_ --> Supply)
 
 This creates a new C<Supply> object to which any values which are emitted
 on this supplier are passed. This is the factory for all C<live> supplies.

--- a/doc/Type/Supplier.pod6
+++ b/doc/Type/Supplier.pod6
@@ -50,7 +50,7 @@ C<Supply> on this C<Supplier>.
 
 =head2 method done
 
-    method done(Supplier:D:)
+    method done(Supplier:D: *%_)
 
 Calls the C<done> callback on all the taps that have one.
 

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -110,14 +110,14 @@ a time.
 
 Defined as:
 
-    method Capture(Supply:D: --> Capture:D)
+    method Capture(Supply:D: *%_ --> Capture:D)
 
 Equivalent to calling L«C<.List.Capture>|/type/List#method_Capture»
 on the invocant.
 
 =head2 method Channel
 
-    method Channel(Supply:D: --> Channel:D)
+    method Channel(Supply:D: *%_ --> Channel:D)
 
 Returns a L<Channel|/type/Channel> object that will receive all future values
 from the supply, and will be C<close>d when the Supply is done, and quit (shut
@@ -125,7 +125,7 @@ down with error) when the supply is quit.
 
 =head2 method Promise
 
-    method Promise(Supply:D: --> Promise:D)
+    method Promise(Supply:D: *%_ --> Promise:D)
 
 Returns a L<Promise|/type/Promise> that will be kept when the C<Supply> is
 C<done>. If the C<Supply> also emits any values, then the C<Promise> will be
@@ -146,7 +146,7 @@ only completion (successful or not) is relevant.
 
 =head2 method live
 
-    method live(Supply:D: --> Bool:D)
+    method live(Supply:D: *%_ --> Bool:D)
 
 Returns C<True> if the supply is "live", that is, values are emitted to taps
 as soon as they arrive. Always returns C<True> in the default C<Supply> (but
@@ -187,7 +187,7 @@ the exception that was passed to C<quit>).
 
 =head2 method list
 
-    method list(Supply:D: --> List:D)
+    method list(Supply:D: *%_ --> List:D)
 
 Taps the C<Supply> it is called on, and returns a lazy list that will be reified
 as the C<Supply> emits values. The list will be terminated once the C<Supply> is
@@ -203,7 +203,7 @@ contains.
 
 =head2 method grab
 
-    method grab(Supply:D: &when-done --> Supply:D)
+    method grab(Supply:D: &when-done *%_ --> Supply:D)
 
 Taps the C<Supply> it is called on. When it is C<done>, calls C<&when-done> and
 then emits the list of values that it returns on the result C<Supply>. If the
@@ -216,7 +216,7 @@ return C<Supply>.
 
 =head2 method reverse
 
-    method reverse(Supply:D: --> Supply:D)
+    method reverse(Supply:D: *%_ --> Supply:D)
 
 Taps the C<Supply> it is called on. Once that C<Supply> emits C<done>, all of the
 values it emitted will be emitted on the returned C<Supply> in reverse order. If
@@ -229,7 +229,7 @@ return C<Supply>.
 
 =head2 method sort
 
-    method sort(Supply:D: &custom-routine-to-use? --> Supply:D)
+    method sort(Supply:D: &custom-routine-to-use? *%_ --> Supply:D)
 
 Taps the C<Supply> it is called on. Once that C<Supply> emits C<done>, all of the
 values that it emitted will be sorted, and the results emitted on the returned
@@ -259,7 +259,7 @@ for more details on the collated sort.
 
 Defined as:
 
-    method reduce(Supply:D: &with --> Supply:D)
+    method reduce(Supply:D: &with *%_ --> Supply:D)
 
 Creates a "reducing" supply, which will emit a single value with the same
 semantics as L<List.reduce|/type/List#routine_reduce>.
@@ -271,7 +271,7 @@ semantics as L<List.reduce|/type/List#routine_reduce>.
 
 =head2 method from-list
 
-    method from-list(Supply:U: +@values --> Supply:D)
+    method from-list(Supply:U: +@values *%_ --> Supply:D)
 
 Creates an on-demand supply from the values passed to this method.
 
@@ -280,7 +280,7 @@ Creates an on-demand supply from the values passed to this method.
 
 =head2 method share
 
-    method share(Supply:D: --> Supply:D)
+    method share(Supply:D: *%_ --> Supply:D)
 
 Creates a live supply from an on-demand supply, thus making it possible to
 share the values of the on-demand supply on multiple taps, instead of each
@@ -295,14 +295,14 @@ tap seeing its own copy of all values from the on-demand supply.
 
 =head2 method flat
 
-    method flat(Supply:D: --> Supply:D)
+    method flat(Supply:D: *%_ --> Supply:D)
 
 Creates a supply on which all of the values seen in the given supply are
 flattened before being emitted again.
 
 =head2 method do
 
-    method do(Supply:D: &do --> Supply:D)
+    method do(Supply:D: &do *%_ --> Supply:D)
 
 Creates a supply to which all values seen in the given supply, are emitted
 again.  The given code, executed for its side-effects only, is guaranteed
@@ -310,7 +310,7 @@ to be only executed by one thread at a time.
 
 =head2 method on-close
 
-    method on-close(Supply:D: &on-close --> Supply:D)
+    method on-close(Supply:D: &on-close *%_ --> Supply:D)
 
 Returns a new C<Supply> which will run C<&on-close> whenever a L<Tap|/type/Tap>
 of that C<Supply> is closed. This includes if further operations are chained
@@ -330,7 +330,7 @@ phaser is usually a better choice.
 
 =head2 method interval
 
-    method interval(Supply:U: $interval, $delay = 0, :$scheduler = $*SCHEDULER --> Supply:D)
+    method interval(Supply:U: $interval, $delay = 0, :$scheduler = $*SCHEDULER *%_ --> Supply:D)
 
 Creates a supply that emits a value every C<$interval> seconds, starting
 C<$delay> seconds from the call. The emitted value is an integer, starting from
@@ -342,7 +342,7 @@ For 6.d language version, the minimal value specified is C<0.001>.
 
 =head2 method grep
 
-    method grep(Supply:D: Mu $test --> Supply:D)
+    method grep(Supply:D: Mu $test *%_ --> Supply:D)
 
 Creates a new supply that only emits those values from the original supply
 that smartmatch against C<$test>.
@@ -355,7 +355,7 @@ that smartmatch against C<$test>.
 
 =head2 method map
 
-    method map(Supply:D: &mapper --> Supply:D)
+    method map(Supply:D: &mapper *%_ --> Supply:D)
 
 Returns a new supply that maps each value of the given supply through
 C<&mapper> and emits it to the new supply.
@@ -368,7 +368,7 @@ C<&mapper> and emits it to the new supply.
 
 =head2 method batch
 
-    method batch(Supply:D: :$elems, :$seconds --> Supply:D)
+    method batch(Supply:D: :$elems, :$seconds *%_ --> Supply:D)
 
 Creates a new supply that batches the values of the given supply by either
 the number of elements in the batch (using C<:elems>) or the maximum number of
@@ -377,7 +377,7 @@ a final batch when the supply is done.
 
 =head2 method elems
 
-    method elems(Supply:D: $seconds? --> Supply:D)
+    method elems(Supply:D: $seconds? *%_ --> Supply:D)
 
 Creates a new supply in which changes to the number of values seen are
 emitted.  It optionally also takes an interval (in seconds) if you only want
@@ -462,13 +462,13 @@ L«C<.head>|#method head».
 
 =head2 method rotor
 
-    method rotor(Supply:D: @cycle --> Supply:D)
+    method rotor(Supply:D: @cycle *%_ --> Supply:D)
 
 Creates a "rotoring" supply with the same semantics as L<List.rotor|/type/List#method_rotor>.
 
 =head2 method delayed
 
-    method delayed(Supply:D: $seconds, :$scheduler = $*SCHEDULER --> Supply:D)
+    method delayed(Supply:D: $seconds, :$scheduler = $*SCHEDULER *%_ --> Supply:D)
 
 Creates a new supply in which all values flowing through the given supply
 are emitted, but with the given delay in seconds.
@@ -653,7 +653,7 @@ done 5
 
 =head2 method stable
 
-    method stable(Supply:D: $time, :$scheduler = $*SCHEDULER --> Supply:D)
+    method stable(Supply:D: $time, :$scheduler = $*SCHEDULER *%_ --> Supply:D)
 
 Creates a new supply that only passes on a value flowing through the given
 supply if it wasn't superseded by another value in the given C<$time> (in
@@ -692,7 +692,7 @@ reset after three seconds.
 
 =head2 method produce
 
-    method produce(Supply:D: &with --> Supply:D)
+    method produce(Supply:D: &with *%_ --> Supply:D)
 
 Creates a "producing" supply with the same semantics as L<List.produce|/type/List#routine_produce>.
 
@@ -701,7 +701,7 @@ Creates a "producing" supply with the same semantics as L<List.produce|/type/Lis
 
 =head2 method lines
 
-    method lines(Supply:D: :$chomp = True --> Supply:D)
+    method lines(Supply:D: :$chomp = True *%_ --> Supply:D)
 
 Creates a supply that will emit the characters coming in line by line from a
 supply that's usually created by some asynchronous I/O operation. The optional
@@ -710,7 +710,7 @@ C<True>.
 
 =head2 method words
 
-    method words(Supply:D: --> Supply:D)
+    method words(Supply:D: *%_ --> Supply:D)
 
 Creates a supply that will emit the characters coming in word for word from a
 supply that's usually created by some asynchronous I/O operation.
@@ -721,7 +721,7 @@ supply that's usually created by some asynchronous I/O operation.
 
 =head2 method unique
 
-    method unique(Supply:D: :$as, :$with, :$expires --> Supply:D)
+    method unique(Supply:D: :$as, :$with, :$expires *%_ --> Supply:D)
 
 Creates a supply that only provides unique values, as defined
 by the optional C<:as> and C<:with> parameters (same as with
@@ -748,7 +748,7 @@ B<Note>: Available since version 6.e (L<Rakudo|/language/glossary#Rakudo> 2020.0
 
 =head2 method squish
 
-    method squish(Supply:D: :$as, :$with --> Supply:D)
+    method squish(Supply:D: :$as, :$with *%_ --> Supply:D)
 
 Creates a supply that only provides unique values, as defined
 by the optional C<:as> and C<:with> parameters (same as with
@@ -756,7 +756,7 @@ L<C<squish>|/language/independent-routines#routine_squish>).
 
 =head2 method max
 
-    method max(Supply:D: &custom-routine-to-use = &infix:<cmp> --> Supply:D)
+    method max(Supply:D: &custom-routine-to-use = &infix:<cmp> *%_ --> Supply:D)
 
 Creates a supply that only emits values from the given supply if they are
 larger than any value seen before. In other words, from a continuously
@@ -766,7 +766,7 @@ the comparator, just as with L<Any.max|/type/Any#method_max>.
 
 =head2 method min
 
-    method min(Supply:D: &custom-routine-to-use = &infix:<cmp> --> Supply:D)
+    method min(Supply:D: &custom-routine-to-use = &infix:<cmp> *%_ --> Supply:D)
 
 Creates a supply that only emits values from the given supply if they are
 smaller than any value seen before.  In other words, from a continuously
@@ -776,7 +776,7 @@ the comparator, just as with L<Any.min|/type/Any#method_min>.
 
 =head2 method minmax
 
-    method minmax(Supply:D: &custom-routine-to-use = &infix:<cmp> --> Supply:D)
+    method minmax(Supply:D: &custom-routine-to-use = &infix:<cmp> *%_ --> Supply:D)
 
 Creates a supply that emits a Range every time a new minimum or maximum
 values is seen from the given supply.  The optional parameter specifies
@@ -784,7 +784,7 @@ the comparator, just as with L<Any.minmax|/type/Any#method_minmax>.
 
 =head2 method skip
 
-    method skip(Supply:D: Int(Cool) $number = 1 --> Supply:D)
+    method skip(Supply:D: Int(Cool) $number = 1 *%_ --> Supply:D)
 
 Returns a new C<Supply> which will emit all values from the given C<Supply>
 except for the first C<$number> values, which will be thrown away.
@@ -798,7 +798,7 @@ $supplier.emit($_) for 1..10; # OUTPUT: «4␤5␤6␤7␤8␤9␤10␤»
 
 =head2 method start
 
-    method start(Supply:D: &startee --> Supply:D)
+    method start(Supply:D: &startee *%_ --> Supply:D)
 
 Creates a supply of supplies. For each value in the original supply, the code
 object is scheduled on another thread, and returns a supply either of a single
@@ -811,7 +811,7 @@ Use C<migrate> to join the values into a single supply again.
 
 =head2 method migrate
 
-    method migrate(Supply:D: --> Supply:D)
+    method migrate(Supply:D: *%_ --> Supply:D)
 
 Takes a C<Supply> which itself has values that are of type C<Supply> as input. Each
 time the outer C<Supply> emits a new C<Supply>, this will be tapped and its values
@@ -867,7 +867,7 @@ AAPL: 111.6
 
 =head2 method merge
 
-    method merge(Supply @*supplies --> Supply:D)
+    method merge(Supply @*supplies *%_ --> Supply:D)
 
 Creates a supply to which any value seen from the given supplies, is emitted.
 The resulting supply is done Only when all given supplies are done.  Can also

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -51,7 +51,7 @@ Further examples can be found in the L<concurrency page|/language/concurrency#Su
 =head2 method tap
 
 =for code :skip-test<compile time error>
-method tap(Supply:D: &emit = -> $ { },
+    method tap(Supply:D: &emit = -> $ { },
         :&done = -> {},
         :&quit = -> $ex { $ex.throw },
         :&tap = -> $ {} )
@@ -156,7 +156,7 @@ for example on the supply returned from C<Supply.from-list> it's C<False>).
 
 =head2 method schedule-on
 
-    method schedule-on(Supply:D: Scheduler $scheduler)
+    method schedule-on(Supply:D: Scheduler $scheduler, *%_)
 
 Runs the emit, done and quit callbacks on the specified scheduler.
 
@@ -732,7 +732,7 @@ an old value.
 
 =head2 method repeated
 
-    method repeated(Supply:D: :&as, :&with)
+    method repeated(Supply:D: :&as, :&with, *%_)
 
 Creates a supply that only provides repeated values, as defined
 by the optional C<:as> and C<:with> parameters (same as with

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -203,7 +203,7 @@ contains.
 
 =head2 method grab
 
-    method grab(Supply:D: &when-done *%_ --> Supply:D)
+    method grab(Supply:D: &when-done, *%_ --> Supply:D)
 
 Taps the C<Supply> it is called on. When it is C<done>, calls C<&when-done> and
 then emits the list of values that it returns on the result C<Supply>. If the
@@ -229,7 +229,7 @@ return C<Supply>.
 
 =head2 method sort
 
-    method sort(Supply:D: &custom-routine-to-use? *%_ --> Supply:D)
+    method sort(Supply:D: &custom-routine-to-use?, *%_ --> Supply:D)
 
 Taps the C<Supply> it is called on. Once that C<Supply> emits C<done>, all of the
 values that it emitted will be sorted, and the results emitted on the returned
@@ -259,7 +259,7 @@ for more details on the collated sort.
 
 Defined as:
 
-    method reduce(Supply:D: &with *%_ --> Supply:D)
+    method reduce(Supply:D: &with, *%_ --> Supply:D)
 
 Creates a "reducing" supply, which will emit a single value with the same
 semantics as L<List.reduce|/type/List#routine_reduce>.
@@ -271,7 +271,7 @@ semantics as L<List.reduce|/type/List#routine_reduce>.
 
 =head2 method from-list
 
-    method from-list(Supply:U: +@values *%_ --> Supply:D)
+    method from-list(Supply:U: +@values, *%_ --> Supply:D)
 
 Creates an on-demand supply from the values passed to this method.
 
@@ -310,7 +310,7 @@ to be only executed by one thread at a time.
 
 =head2 method on-close
 
-    method on-close(Supply:D: &on-close *%_ --> Supply:D)
+    method on-close(Supply:D: &on-close, *%_ --> Supply:D)
 
 Returns a new C<Supply> which will run C<&on-close> whenever a L<Tap|/type/Tap>
 of that C<Supply> is closed. This includes if further operations are chained
@@ -330,7 +330,7 @@ phaser is usually a better choice.
 
 =head2 method interval
 
-    method interval(Supply:U: $interval, $delay = 0, :$scheduler = $*SCHEDULER *%_ --> Supply:D)
+    method interval(Supply:U: $interval, $delay = 0, :$scheduler = $*SCHEDULER, *%_ --> Supply:D)
 
 Creates a supply that emits a value every C<$interval> seconds, starting
 C<$delay> seconds from the call. The emitted value is an integer, starting from
@@ -342,7 +342,7 @@ For 6.d language version, the minimal value specified is C<0.001>.
 
 =head2 method grep
 
-    method grep(Supply:D: Mu $test *%_ --> Supply:D)
+    method grep(Supply:D: Mu $test, *%_ --> Supply:D)
 
 Creates a new supply that only emits those values from the original supply
 that smartmatch against C<$test>.
@@ -355,7 +355,7 @@ that smartmatch against C<$test>.
 
 =head2 method map
 
-    method map(Supply:D: &mapper *%_ --> Supply:D)
+    method map(Supply:D: &mapper, *%_ --> Supply:D)
 
 Returns a new supply that maps each value of the given supply through
 C<&mapper> and emits it to the new supply.
@@ -368,7 +368,7 @@ C<&mapper> and emits it to the new supply.
 
 =head2 method batch
 
-    method batch(Supply:D: :$elems, :$seconds *%_ --> Supply:D)
+    method batch(Supply:D: :$elems, :$seconds, *%_ --> Supply:D)
 
 Creates a new supply that batches the values of the given supply by either
 the number of elements in the batch (using C<:elems>) or the maximum number of
@@ -377,7 +377,7 @@ a final batch when the supply is done.
 
 =head2 method elems
 
-    method elems(Supply:D: $seconds? *%_ --> Supply:D)
+    method elems(Supply:D: $seconds?, *%_ --> Supply:D)
 
 Creates a new supply in which changes to the number of values seen are
 emitted.  It optionally also takes an interval (in seconds) if you only want
@@ -462,13 +462,13 @@ L«C<.head>|#method head».
 
 =head2 method rotor
 
-    method rotor(Supply:D: @cycle *%_ --> Supply:D)
+    method rotor(Supply:D: @cycle, *%_ --> Supply:D)
 
 Creates a "rotoring" supply with the same semantics as L<List.rotor|/type/List#method_rotor>.
 
 =head2 method delayed
 
-    method delayed(Supply:D: $seconds, :$scheduler = $*SCHEDULER *%_ --> Supply:D)
+    method delayed(Supply:D: $seconds, :$scheduler = $*SCHEDULER, *%_ --> Supply:D)
 
 Creates a new supply in which all values flowing through the given supply
 are emitted, but with the given delay in seconds.
@@ -653,7 +653,7 @@ done 5
 
 =head2 method stable
 
-    method stable(Supply:D: $time, :$scheduler = $*SCHEDULER *%_ --> Supply:D)
+    method stable(Supply:D: $time, :$scheduler, = $*SCHEDULER *%_ --> Supply:D)
 
 Creates a new supply that only passes on a value flowing through the given
 supply if it wasn't superseded by another value in the given C<$time> (in
@@ -692,7 +692,7 @@ reset after three seconds.
 
 =head2 method produce
 
-    method produce(Supply:D: &with *%_ --> Supply:D)
+    method produce(Supply:D: &with, *%_ --> Supply:D)
 
 Creates a "producing" supply with the same semantics as L<List.produce|/type/List#routine_produce>.
 
@@ -701,7 +701,7 @@ Creates a "producing" supply with the same semantics as L<List.produce|/type/Lis
 
 =head2 method lines
 
-    method lines(Supply:D: :$chomp = True *%_ --> Supply:D)
+    method lines(Supply:D: :$chomp = True, *%_ --> Supply:D)
 
 Creates a supply that will emit the characters coming in line by line from a
 supply that's usually created by some asynchronous I/O operation. The optional
@@ -721,7 +721,7 @@ supply that's usually created by some asynchronous I/O operation.
 
 =head2 method unique
 
-    method unique(Supply:D: :$as, :$with, :$expires *%_ --> Supply:D)
+    method unique(Supply:D: :$as, :$with, :$expires, *%_ --> Supply:D)
 
 Creates a supply that only provides unique values, as defined
 by the optional C<:as> and C<:with> parameters (same as with
@@ -748,7 +748,7 @@ B<Note>: Available since version 6.e (L<Rakudo|/language/glossary#Rakudo> 2020.0
 
 =head2 method squish
 
-    method squish(Supply:D: :$as, :$with *%_ --> Supply:D)
+    method squish(Supply:D: :$as, :$with, *%_ --> Supply:D)
 
 Creates a supply that only provides unique values, as defined
 by the optional C<:as> and C<:with> parameters (same as with
@@ -756,7 +756,7 @@ L<C<squish>|/language/independent-routines#routine_squish>).
 
 =head2 method max
 
-    method max(Supply:D: &custom-routine-to-use = &infix:<cmp> *%_ --> Supply:D)
+    method max(Supply:D: &custom-routine-to-use = &infix:<cmp>, *%_ --> Supply:D)
 
 Creates a supply that only emits values from the given supply if they are
 larger than any value seen before. In other words, from a continuously
@@ -766,7 +766,7 @@ the comparator, just as with L<Any.max|/type/Any#method_max>.
 
 =head2 method min
 
-    method min(Supply:D: &custom-routine-to-use = &infix:<cmp> *%_ --> Supply:D)
+    method min(Supply:D: &custom-routine-to-use = &infix:<cmp>, *%_ --> Supply:D)
 
 Creates a supply that only emits values from the given supply if they are
 smaller than any value seen before.  In other words, from a continuously
@@ -776,7 +776,7 @@ the comparator, just as with L<Any.min|/type/Any#method_min>.
 
 =head2 method minmax
 
-    method minmax(Supply:D: &custom-routine-to-use = &infix:<cmp> *%_ --> Supply:D)
+    method minmax(Supply:D: &custom-routine-to-use = &infix:<cmp>, *%_ --> Supply:D)
 
 Creates a supply that emits a Range every time a new minimum or maximum
 values is seen from the given supply.  The optional parameter specifies
@@ -784,7 +784,7 @@ the comparator, just as with L<Any.minmax|/type/Any#method_minmax>.
 
 =head2 method skip
 
-    method skip(Supply:D: Int(Cool) $number = 1 *%_ --> Supply:D)
+    method skip(Supply:D: Int(Cool) $number = 1, *%_ --> Supply:D)
 
 Returns a new C<Supply> which will emit all values from the given C<Supply>
 except for the first C<$number> values, which will be thrown away.
@@ -798,7 +798,7 @@ $supplier.emit($_) for 1..10; # OUTPUT: «4␤5␤6␤7␤8␤9␤10␤»
 
 =head2 method start
 
-    method start(Supply:D: &startee *%_ --> Supply:D)
+    method start(Supply:D: &startee, *%_ --> Supply:D)
 
 Creates a supply of supplies. For each value in the original supply, the code
 object is scheduled on another thread, and returns a supply either of a single
@@ -867,7 +867,7 @@ AAPL: 111.6
 
 =head2 method merge
 
-    method merge(Supply @*supplies *%_ --> Supply:D)
+    method merge(Supply: *@supplies, *%_ --> Supply:D)
 
 Creates a supply to which any value seen from the given supplies, is emitted.
 The resulting supply is done Only when all given supplies are done.  Can also
@@ -877,7 +877,7 @@ be called as a class method.
 
 Defined as:
 
-    method zip(**@s, :&with)
+    method zip(Supply: **@s, :&with, *%_)
 
 Creates a supply that emits combined values as soon as there is a new value
 seen on B<all> of the supplies.  By default, L<C<Lists>|/type/List> are
@@ -893,7 +893,7 @@ special treatment).
 
 Defined as:
 
-    method zip-latest(**@s, :&with, :$initial )
+    method zip-latest(Supply: **@s, :&with, :$initial, *%_)
 
 Creates a supply that emits combined values as soon as there is a new value
 seen on B<any> of the supplies.  By default, L<Lists|/type/List> are

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -167,7 +167,7 @@ the GUI thread.
 
 =head2 method wait
 
-    method wait(Supply:D:)
+    method wait(Supply:D: *%_)
 
 Taps the C<Supply> it is called on, and blocks execution until the either the supply
 is C<done> (in which case it evaluates to the final value that was emitted on the
@@ -196,7 +196,7 @@ point in the lazy list is reached.
 
 =head2 method Seq
 
-    method Seq(Supply:D:)
+    method Seq(Supply:D: *%_)
 
 Returns a C<Seq> with an iterator containing the values that the C<Supply>
 contains.
@@ -243,7 +243,7 @@ return C<Supply>.
 
 =head2 method collate
 
-    method collate(Supply:D:)
+    method collate(Supply:D: *%_)
 
 Taps the C<Supply> it is called on. Once that C<Supply> emits C<done>,
 all of the values that it emitted will be sorted taking into account

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -302,7 +302,7 @@ flattened before being emitted again.
 
 =head2 method do
 
-    method do(Supply:D: &do *%_ --> Supply:D)
+    method do(Supply:D: &do, *%_ --> Supply:D)
 
 Creates a supply to which all values seen in the given supply, are emitted
 again.  The given code, executed for its side-effects only, is guaranteed
@@ -653,7 +653,7 @@ done 5
 
 =head2 method stable
 
-    method stable(Supply:D: $time, :$scheduler, = $*SCHEDULER *%_ --> Supply:D)
+    method stable(Supply:D: $time, :$scheduler = $*SCHEDULER, *%_ --> Supply:D)
 
 Creates a new supply that only passes on a value flowing through the given
 supply if it wasn't superseded by another value in the given C<$time> (in

--- a/doc/Type/Tap.pod6
+++ b/doc/Type/Tap.pod6
@@ -22,7 +22,7 @@ A Tap is a subscription to a L<Supply|/type/Supply>.
 
 =head2 method close
 
-    method close(Tap:D:)
+    method close(Tap:D: *%_)
 
 Closes the tap.
 

--- a/doc/Type/Thread.pod6
+++ b/doc/Type/Thread.pod6
@@ -37,7 +37,7 @@ The current thread is available in the dynamic variable C<$*THREAD>.
 
 =head2 method new
 
-    method new(:&code!, Bool :$app_lifetime = False, Str :$name = '<anon>' --> Thread:D)
+    method new(:&code!, Bool :$app_lifetime = False, Str :$name = '<anon>', *%_ --> Thread:D)
 
 Creates and returns a new C<Thread>, without starting it yet. C<&code> is the
 code that will be run in a separate thread.
@@ -50,7 +50,7 @@ terminate when the thread has finished.
 
 =head2 method start
 
-    method start(Thread:U: &code, Bool :$app_lifetime = False, Str :$name = '<anon>' --> Thread:D)
+    method start(Thread:U: &code, Bool :$app_lifetime = False, Str :$name = '<anon>' *%_ --> Thread:D)
 
 Creates, runs and returns a new C<Thread>. Note that it can (and often does)
 return before the thread's code has finished running.
@@ -64,7 +64,7 @@ has already been started.
 
 =head2 method id
 
-    method id(Thread:D: --> Int:D)
+    method id(Thread:D: *%_ --> Int:D)
 
 Returns a numeric, unique thread identifier.
 
@@ -91,7 +91,7 @@ Tells the scheduler to prefer another thread for now.
 
 =head2 method app_lifetime
 
-    method app_lifetime(Thread:D: --> Bool:D)
+    method app_lifetime(Thread:D: *%_ --> Bool:D)
 
 Returns C<False> unless the named parameter C<:app_lifetime> is specifically set
 to C<True> during object creation. If the method returns C<False> it means that
@@ -106,7 +106,7 @@ the thread will be killed when the main thread of the process terminates.
 
 =head2 method name
 
-    method name(Thread:D: --> Str:D)
+    method name(Thread:D: *%_ --> Str:D)
 
 Returns the user defined string, which can optionally be set during object
 creation in order to identify the C<Thread>, or '<anon>' if no such string
@@ -120,13 +120,13 @@ was specified.
 
 =head2 method Numeric
 
-    method Numeric(Thread:D: --> Int:D)
+    method Numeric(Thread:D: *%_ --> Int:D)
 
 Returns a numeric, unique thread identifier, i.e. the same as L<id|#method_id>.
 
 =head2 method Str
 
-    method Str(Thread:D: --> Str:D)
+    method Str(Thread:D: *%_ --> Str:D)
 
 Returns a string which contains the invocants L<thread id|#method_id> and
 L<name|#method_name>.

--- a/doc/Type/Thread.pod6
+++ b/doc/Type/Thread.pod6
@@ -70,20 +70,20 @@ Returns a numeric, unique thread identifier.
 
 =head2 method finish
 
-    method finish(Thread:D)
+    method finish(Thread:D, *%_)
 
 Waits for the thread to finish. This is called L<join|#method_join> in other programming
 systems.
 
 =head2 method join
 
-    method join(Thread:D)
+    method join(Thread:D, *%_)
 
 Waits for the thread to finish.
 
 =head2 method yield
 
-    method yield(Thread:U)
+    method yield(Thread:U, *%_)
 
 Tells the scheduler to prefer another thread for now.
 

--- a/doc/Type/Thread.pod6
+++ b/doc/Type/Thread.pod6
@@ -136,7 +136,7 @@ L<name|#method_name>.
 
 =head2 method is-initial-thread
 
-    method is-initial-thread(--> Bool)
+    method is-initial-thread(Thread: *%_ --> Bool)
 
 Returns a Bool indicating whether the current thread (if called as a class
 method) or the Thread object on which it is called, is the initial thread

--- a/doc/Type/Thread.pod6
+++ b/doc/Type/Thread.pod6
@@ -70,20 +70,20 @@ Returns a numeric, unique thread identifier.
 
 =head2 method finish
 
-    method finish(Thread:D, *%_)
+    method finish(Thread:D: *%_)
 
 Waits for the thread to finish. This is called L<join|#method_join> in other programming
 systems.
 
 =head2 method join
 
-    method join(Thread:D, *%_)
+    method join(Thread:D: *%_)
 
 Waits for the thread to finish.
 
 =head2 method yield
 
-    method yield(Thread:U, *%_)
+    method yield(Thread:U: *%_)
 
 Tells the scheduler to prefer another thread for now.
 

--- a/doc/Type/Thread.pod6
+++ b/doc/Type/Thread.pod6
@@ -57,7 +57,7 @@ return before the thread's code has finished running.
 
 =head2 method run
 
-    method run(Thread:D:)
+    method run(Thread:D: *%_)
 
 Runs the thread, and returns the invocant. It is an error to run a thread that
 has already been started.

--- a/doc/Type/ThreadPoolScheduler.pod6
+++ b/doc/Type/ThreadPoolScheduler.pod6
@@ -17,7 +17,7 @@ the work.
 
 =head2 new
 
-    method new(Int :$initial_threads = 0, Int :$max_threads=16)
+    method new(Int :$initial_threads = 0, Int :$max_threads=16, *%_)
 
 Creates a new C<ThreadPoolScheduler> object with the given range of threads to
 maintain.

--- a/doc/Type/Uni.pod6
+++ b/doc/Type/Uni.pod6
@@ -19,43 +19,43 @@ C<NFKD> and C<NFKC>, which represent strings in one of the L<Unicode Normalizati
 
 =head2 method new
 
-    method new(*@codes --> Uni:D)
+    method new(*@codes, *%_ --> Uni:D)
 
 Creates a new C<Uni> instance from the given codepoint numbers.
 
 =head2 method NFC
 
-    method NFC(Uni:D: --> NFC:D)
+    method NFC(Uni:D: *%_ --> NFC:D)
 
 Returns a NFC (Normal Form Composed)-converted version of the invocant.
 
 =head2 method NFD
 
-    method NFD(Uni:D: --> NFD:D)
+    method NFD(Uni:D: *%_ --> NFD:D)
 
 Returns a NFD (Normal Form Decomposed)-converted version of the invocant.
 
 =head2 method NFKC
 
-    method NFKC(Uni:D: --> NFKC:D)
+    method NFKC(Uni:D: *%_ --> NFKC:D)
 
 Returns a NFKC (Normal Form Compatibility Composed)-converted version of the invocant.
 
 =head2 method NFKD
 
-    method NFKD(Uni:D: --> NFKD:D)
+    method NFKD(Uni:D: *%_ --> NFKD:D)
 
 Returns a NFKD (Normal Form Compatibility Decomposed)-converted version of the invocant.
 
 =head2 method codes
 
-    method codes(Uni:D: --> Int:D)
+    method codes(Uni:D: *%_ --> Int:D)
 
 Returns the number of codepoints in the invocant.
 
 =head2 method elems
 
-    method elems(Uni:D: --> Int:D)
+    method elems(Uni:D: *%_ --> Int:D)
 
 Returns the number of codepoints in the invocant.
 

--- a/doc/Type/Uni.pod6
+++ b/doc/Type/Uni.pod6
@@ -19,7 +19,7 @@ C<NFKD> and C<NFKC>, which represent strings in one of the L<Unicode Normalizati
 
 =head2 method new
 
-    method new(*@codes, *%_ --> Uni:D)
+    method new(Uni: *@codes, *%_ --> Uni:D)
 
 Creates a new C<Uni> instance from the given codepoint numbers.
 

--- a/doc/Type/ValueObjAt.pod6
+++ b/doc/Type/ValueObjAt.pod6
@@ -24,7 +24,7 @@ instance:
         has $.foo;  # note these are not mutable
         has $.bar;
 
-    method WHICH(ValueObjAt: *%_) {
+        method WHICH() {
             ValueObjAt.new("YourClass|$!foo|$!bar");
         }
     }

--- a/doc/Type/ValueObjAt.pod6
+++ b/doc/Type/ValueObjAt.pod6
@@ -24,7 +24,7 @@ instance:
         has $.foo;  # note these are not mutable
         has $.bar;
 
-        method WHICH() {
+    method WHICH(ValueObjAt: *%_) {
             ValueObjAt.new("YourClass|$!foo|$!bar");
         }
     }

--- a/doc/Type/Variable.pod6
+++ b/doc/Type/Variable.pod6
@@ -108,7 +108,7 @@ which would be equivalent to the previous definition.
 
 =head2 method name
 
-    method name(Variable:D: str)
+    method name(Variable:D: str, *%_)
 
 Returns the name of the variable, including the sigil.
 

--- a/doc/Type/Version.pod6
+++ b/doc/Type/Version.pod6
@@ -55,7 +55,7 @@ examples:
 
 =head2 method new
 
-    method new(Str:D $s, *%_)
+    method new(Version: Str:D $s, *%_)
 
 Creates a C<Version> from a string C<$s>.  The string is combed
 for the numeric, alphabetic, and wildcard components of the version object.

--- a/doc/Type/Version.pod6
+++ b/doc/Type/Version.pod6
@@ -115,7 +115,7 @@ L<Str|#method_Str>, prepended with a lower-case C<v>.
 
 Defined as:
 
-    method Capture()
+    method Capture(Version: *%_)
 
 Throws C<X::Cannot::Capture>.
 

--- a/doc/Type/Version.pod6
+++ b/doc/Type/Version.pod6
@@ -55,7 +55,7 @@ examples:
 
 =head2 method new
 
-    method new(Str:D $s)
+    method new(Str:D $s, *%_)
 
 Creates a C<Version> from a string C<$s>.  The string is combed
 for the numeric, alphabetic, and wildcard components of the version object.

--- a/doc/Type/Version.pod6
+++ b/doc/Type/Version.pod6
@@ -65,7 +65,7 @@ numeric and alphabetic characters.
 
 =head2 method parts
 
-    method parts(Version:D: --> List:D)
+    method parts(Version:D: *%_ --> List:D)
 
 Returns the list of parts that make up this C<Version> object
 
@@ -79,7 +79,7 @@ not returned by this method, as shown above in the C<$v2> variable.
 
 =head2 method plus
 
-    method plus(Version:D: --> Bool:D)
+    method plus(Version:D: *%_ --> Bool:D)
 
 Returns C<True> if comparisons against this version allow larger versions too.
 
@@ -90,7 +90,7 @@ Returns C<True> if comparisons against this version allow larger versions too.
 
 =head2 method Str
 
-    method Str(Version:D: --> Str:D)
+    method Str(Version:D: *%_ --> Str:D)
 
 Returns a string representation of the invocant.
 
@@ -101,7 +101,7 @@ Returns a string representation of the invocant.
 
 =head2 method gist
 
-    method gist(Version:D: --> Str:D)
+    method gist(Version:D: *%_ --> Str:D)
 
 Returns a string representation of the invocant, just like
 L<Str|#method_Str>, prepended with a lower-case C<v>.

--- a/doc/Type/Whatever.pod6
+++ b/doc/Type/Whatever.pod6
@@ -127,7 +127,7 @@ always returns C<True>. If the invocant is a type object, performs a typecheck.
 
 Defined as:
 
-    method Capture()
+    method Capture(Whatever: *%_)
 
 Throws C<X::Cannot::Capture>.
 


### PR DESCRIPTION
This PR partially implements #3578 by updating method signatures to include the `*%_` (indicating that they can optionally take named parameters) and, where necessary, updating the signatures to include the invocant.

Despite the large apparent size of this PR, it does not substantively alter the content of any documentation, but should make the documentation as a whole significantly more consistent – both with itself and with the output of the `.signature` introspection method.

This PR only partly implements #3578 because it does not yet include multi methods; I plan to submit a follow-up PR with those changes.