### PR TITLE
Update 02-reading-docs.pod6 - s/p6doc/rakudoc/g

### DIFF
--- a/doc/Programs/02-reading-docs.pod6
+++ b/doc/Programs/02-reading-docs.pod6
@@ -2,59 +2,59 @@
 
 =TITLE Reading the docs
 
-=SUBTITLE p6doc - the Raku pod reader
+=SUBTITLE rakudoc - the Raku pod reader
 
-=head1 X<INTRODUCTION|p6doc>
+=head1 X<INTRODUCTION|rakudoc>
 
-Program C<p6doc> is a command-line-interface (CLI) program that reads
+Program C<rakudoc> is a command-line-interface (CLI) program that reads
 Raku pod from B<installed> modules' source code, in contrast to
-running C<perl6 --doc=MODULE programfile> which reads Raku pod from
+running C<raku --doc=MODULE programfile> which reads Raku pod from
 the named source file.
 
-Note that C<p6doc> may not be installed automatically depending upon
+Note that C<rakudoc> may not be installed automatically depending upon
 how you installed Rakudo Raku.  To install it use C<zef>:
 
 =for code :lang<usage>
-zef install p6doc
+zef install rakudoc
 
 =head1 SYNOPSIS
 
 =for code :lang<usage>
-p6doc [switches] [arguments]
+rakudoc [switches] [arguments]
 
 =head1 DESCRIPTION
 
-With no switches or arguments, C<p6doc> lists its help to C<$*OUT> (C<stdout>):
+With no switches or arguments, C<rakudoc> lists its help to C<$*OUT> (C<stdout>):
 
 =begin code :lang<output>
 You want to maintain the index?
-To build an index for 'p6doc -f'
-          p6doc build
+To build an index for 'rakudoc -f'
+          rakudoc build
 
 To list the index keys
-          p6doc list
+          rakudoc list
 
 To display module name(s) containing key
-          p6doc lookup
+          rakudoc lookup
 
 To show where the index file lives
-          p6doc path-to-index
+          rakudoc path-to-index
 
 What documentation do you want to read?
-Examples: p6doc Str
-          p6doc Str.split
-          p6doc faq
-          p6doc path/to/file
+Examples: rakudoc Str
+          rakudoc Str.split
+          rakudoc faq
+          rakudoc path/to/file
 
 You can list some top level documents:
-          p6doc -l
+          rakudoc -l
 
 You can also look up specific method/routine/sub definitions:
-          p6doc -f hyper
-          p6doc -f Array.push
+          rakudoc -f hyper
+          rakudoc -f Array.push
 
 You can bypass the pager and print straight to stdout:
-          p6doc -n Str
+          rakudoc -n Str
 =end code
 
 The text output can be captured and converted to other forms if desired.
@@ -69,9 +69,9 @@ export POD_TO_TEXT_ANSI=1
 
 =head1 LIMITATIONS
 
-Currently C<p6doc> can only extract embedded Raku pod from installed
+Currently C<rakudoc> can only extract embedded Raku pod from installed
 module source files (as listed in a distribution's C<META6.json>
-file).  It is planned to add a feature for C<p6doc> (in conjunction
+file).  It is planned to add a feature for C<rakudoc> (in conjunction
 with C<META6.json> changes) to extract B<all> Raku pod in files
 included with the installed distribution.
 

--- a/doc/Programs/02-reading-docs.pod6
+++ b/doc/Programs/02-reading-docs.pod6
@@ -28,17 +28,8 @@ With no switches or arguments, C<rakudoc> lists its help to C<$*OUT> (C<stdout>)
 
 =begin code :lang<output>
 You want to maintain the index?
-To build an index for 'rakudoc -f'
-          rakudoc build
-
-To list the index keys
-          rakudoc list
-
-To display module name(s) containing key
-          rakudoc lookup
-
-To show where the index file lives
-          rakudoc path-to-index
+To build the index for `rakudoc -r ...`:
+          rakudoc -b
 
 What documentation do you want to read?
 Examples: rakudoc Str
@@ -46,12 +37,9 @@ Examples: rakudoc Str
           rakudoc faq
           rakudoc path/to/file
 
-You can list some top level documents:
-          rakudoc -l
-
 You can also look up specific method/routine/sub definitions:
-          rakudoc -f hyper
-          rakudoc -f Array.push
+          rakudoc -r hyper
+          rakudoc -r push
 
 You can bypass the pager and print straight to stdout:
           rakudoc -n Str


### PR DESCRIPTION
## The problem

https://github.com/Raku/doc/blob/master/doc/Programs/02-reading-docs.pod6 still recommends using `p6doc` to read POD from the command-line. Unfortunately the latest version of the `p6doc` distro (as installed by `zef install p6doc`) does contain neither the `p6doc` nor the `rakudoc` executable (I tried to `zef install p6doc`, but I found neither `p6doc` nor `rakudoc` executable after successfully installing it).

It looks to me that the command-line POD reader tool, which used to live in the https://github.com/Raku/doc repo and called `p6doc` now lives in a separate repo, https://github.com/Raku/rakudoc, and it's called `rakudoc` now; and now the `p6doc` distro (from the https://github.com/Raku/doc repo) only contains the POD, but not the command-line reader tool. To make things even worse, the `rakudoc` tool (https://github.com/Raku/rakudoc) is currently broken, tests fail: https://github.com/Raku/rakudoc/issues/7

## Solution provided

In this PR I just updated the name of the command-line POD reader tool (and the name of the distro to be installed with zef) to `rakudoc` - but that does not fix the problem on its own.

If all my above assumptions and facts are correct, it looks to me that these steps would be needed to fix the original problem:
* merging https://github.com/Raku/rakudoc/pull/8
* possibly adding a symlink (or copy) of the `rakudoc` executable to also keep the `p6doc` command work for the time being
* uploading a new release of https://github.com/Raku/rakudoc
* merging this PR