### PR TITLE
Expand Code.line documentation

### DIFF
--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -184,15 +184,32 @@ Defined as
     method line(Code:D: --> Int:D)
 
 Returns the line number in the source code at which the code object's
-declaration begins.  If the code object was generated automatically
-(and thus I<not> declared in the source code), then C<line> returns
-the line on which the enclosing scope's declaration begins.  For
-example, when called on an L<automatically generated accessor
-method|/language/objects#Attributes> produced by
-the C<has $.name> syntax, C<line> returns the line on which the
-method's class's declaration begins.
+declaration begins.
 
     say &infix:<+>.line;
+
+If the code object was generated automatically (and thus I<not>
+declared in the source code), then C<line> returns the line on which
+the enclosing scope's declaration begins.  For example, when called on
+an L<automatically generated accessor method|
+/language/objects#Attributes> produced by the C<has $.name>
+syntax, C<line> returns the line on which the method's class's
+declaration begins.
+
+For example, if you have the following source file:
+
+    class Food {                # Line 1
+        has $.ingredients;      # Line 2
+                                # Line 3
+        method eat {};          # Line 4
+    }                           # Line 5
+
+Then the C<line> method would give you the following output:
+
+=begin code :preamble<class Food { has $.ingredients; method eat {};}>
+    say Food.^lookup('eat').line;          # OUTPUT: «4␤»
+    say Food.^lookup('ingredients').line;  # OUTPUT: «1␤»
+=end code
 
 =head2 method is-implementation-detail
 

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -183,7 +183,14 @@ Defined as
 
     method line(Code:D: --> Int:D)
 
-Returns the line number in which the code object was declared.
+Returns the line number in the source code at which the code object's
+declaration begins.  If the code object was generated automatically
+(and thus I<not> declared in the source code), then C<line> returns
+the line on which the enclosing scope's declaration begins.  For
+example, when called on an L<automatically generated accessor
+method|/language/objects#Attributes> produced by
+the C<has $.name> syntax, C<line> returns the line on which the
+method's class's declaration begins.
 
     say &infix:<+>.line;
 


### PR DESCRIPTION
Code.line's documentation previously just stated that it returns the line of the code object's declaration.  This is *usually* true, but
isn't true for auto-generated code objects, which don't have a declaration.  This commit explains how the method works in that case.  Closes #3606 