### PR TITLE
Fix typos detected by xt/check-signatures.t

### DIFF
--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -773,8 +773,8 @@ one.
 
 Defined as:
 
-    multi method prepend(--> Array)
-    multi method prepend(@values --> Array)
+    multi method prepend(Any:U: --> Array)
+    multi method prepend(Any:U: @values --> Array)
 
 Called with no arguments on an empty variable, it initializes it as an
 empty L<Array|/type/Array>; if called with arguments, it creates an array and then
@@ -790,8 +790,8 @@ applies L«C<Array.prepend>|/type/Array#method_prepend» on it.
 
 Defined as:
 
-    multi method unshift(--> Array)
-    multi method unshift(@values --> Array)
+    multi method unshift(Any:U: --> Array)
+    multi method unshift(Any:U: @values --> Array)
 
 Initializes L<Any|/type/Any> variable as empty L<Array|/type/Array> and calls
 L«C<Array.unshift>|/type/Array#routine_unshift» on it.

--- a/doc/Type/Backtrace/Frame.pod6
+++ b/doc/Type/Backtrace/Frame.pod6
@@ -62,7 +62,7 @@ Returns the name of the enclosing subroutine.
 
 Defined as:
 
-    method is-hidden(Backtrace::Frame:D --> Bool:D)
+    method is-hidden(Backtrace::Frame:D: --> Bool:D)
 
 Returns C<True> if the frame is marked as hidden with the
 C<is hidden-from-backtrace> trait.
@@ -75,7 +75,7 @@ C<is hidden-from-backtrace> trait.
 
 Defined as:
 
-    method is-routine(Backtrace::Frame:D --> Bool:D)
+    method is-routine(Backtrace::Frame:D: --> Bool:D)
 
 Return C<True> if the frame points into a routine (and not
 into a mere L<Block|/type/Block>).
@@ -88,7 +88,7 @@ into a mere L<Block|/type/Block>).
 
 Defined as:
 
-    method is-setting(Backtrace::Frame:D --> Bool:D)
+    method is-setting(Backtrace::Frame:D: --> Bool:D)
 
 Returns C<True> if the frame is part of a setting.
 

--- a/doc/Type/Baggy.pod6
+++ b/doc/Type/Baggy.pod6
@@ -15,7 +15,7 @@ L<Mixy|/type/Mixy>.
 
 Defined as:
 
-    method new-from-pairs(*@pairs --> Baggy:D)
+    method new-from-pairs(Baggy: *@pairs --> Baggy:D)
 
 Constructs a Baggy objects from a list of L«C<Pair> objects|/type/Pair»
 given as positional arguments:

--- a/doc/Type/Blob.pod6
+++ b/doc/Type/Blob.pod6
@@ -69,7 +69,7 @@ Returns C<False> if and only if the buffer is empty.
 
 Defined as:
 
-    method Capture(Blob:D)
+    method Capture(Blob:D:)
 
 Equivalent to calling L«C<.List.Capture>|/type/List#method_Capture»
 on the invocant.

--- a/doc/Type/Buf.pod6
+++ b/doc/Type/Buf.pod6
@@ -90,7 +90,7 @@ Invokes the C<subbuf-rw> method on the specified C<Buf>:
 
 =head2 method reallocate
 
-    method reallocate($elems)
+    method reallocate(Buf:D: Int:D $elems)
 
 Change the number of elements of the C<Buf>, returning the changed
 C<Buf>. The size of C<Buf> will be adapted depending on the number of

--- a/doc/Type/Channel.pod6
+++ b/doc/Type/Channel.pod6
@@ -165,7 +165,7 @@ been closed or C<.fail> has already been called on it.
 
 Defined as:
 
-    method Capture(Channel:D --> Capture:D)
+    method Capture(Channel:D: --> Capture:D)
 
 Equivalent to calling L«C<.List.Capture>|/type/List#method_Capture»
 on the invocant.

--- a/doc/Type/ComplexStr.pod6
+++ b/doc/Type/ComplexStr.pod6
@@ -51,7 +51,7 @@ is not considered.
 
 Defined as:
 
-    method Capture(ComplexStr:D --> Capture:D)
+    method Capture(ComplexStr:D: --> Capture:D)
 
 Equivalent to L«C<Mu.Capture>|/type/Mu#method_Capture».
 

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -1400,9 +1400,9 @@ See L<the documentation in type Str|/type/Str#routine_rindex> for examples.
 
 Defined as:
 
-    multi method match(Cool:D: $target, *%adverbs)
+    method match(Cool:D: $target, *%adverbs)
 
-Coerces the invocant to L<Str|/type/Str> and calls the method
+Coerces the invocant to L<Stringy|/type/Stringy> and calls the method
 L<match|/type/Str#method_match> on it.
 
 =head2 routine roots
@@ -1435,15 +1435,6 @@ for @roots -> $r {
 # OUTPUT:«8.03651692704705e-15␤»
 # OUTPUT:«1.04441561648202e-14␤»
 =end code
-
-=head2 method match
-
-Defined as:
-
-    method match(|)
-
-Coerces the invocant to L<Stringy|/type/Stringy> and calls
-L<Str.match|/type/Str#method_match>.
 
 =head2 method subst
 

--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -100,7 +100,7 @@ the invocant if the day value is already the first day of the month.
 
 Defined as:
 
-    method clone(:$year, :$month, :$day, :&formatter)
+    method clone(Date:D: :$year, :$month, :$day, :&formatter)
 
 Creates a new C<Date> object based on the invocant, but with the given
 arguments overriding the values from the invocant.

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -119,7 +119,7 @@ values, e.g.,
 
 Defined as:
 
-    method clone(:$year, :$month, :$day, :$hour, :$minute, :$second, :$timezone, :&formatter)
+    method clone(DateTime:D: :$year, :$month, :$day, :$hour, :$minute, :$second, :$timezone, :&formatter)
 
 Creates a new C<DateTime> object based on the invocant, but with the given
 arguments overriding the values from the invocant.

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -71,7 +71,7 @@ invocant as its only argument.
 
 Defined as:
 
-    method is-leap-year(--> Bool:D)
+    method is-leap-year(Dateish:D: --> Bool:D)
 
 Returns C<True> if the year of the Dateish object is a leap year.
 

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -360,7 +360,7 @@ is:
 
 Defined as:
 
-    method default()
+    method default(Hash:D:)
 
 Returns the default value of the invocant, i.e. the value which is returned when
 a non existing key is used to access an element in the C<Hash>. Unless the
@@ -404,7 +404,7 @@ hashes the type used in the declaration of the C<Hash> is returned.
 
 Defined as:
 
-    method of()
+    method of(Hash:D:)
 
 Returns the type constraint for the values of the invocant. By default,
 i.e., if no type constraint is given during declaration, the method

--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -892,7 +892,7 @@ given "foo".IO.open: :w {
 
 Defined as:
 
-    method native-descriptor()
+    method native-descriptor(IO::Handle:D:)
 
 This returns a value that the operating system would understand as a "file
 descriptor" and is suitable for passing to a native function that requires a

--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -624,7 +624,7 @@ $fh.path.r;       # method form
 
 Defined as:
 
-    method e(--> Bool:D)
+    method e(IO::Path:D: --> Bool:D)
 
 Returns C<True> if the invocant is a path that exists.
 
@@ -632,7 +632,7 @@ Returns C<True> if the invocant is a path that exists.
 
 Defined as:
 
-    method d(--> Bool:D)
+    method d(IO::Path:D: --> Bool:D)
 
 Returns C<True> if the invocant is a path that exists and is a directory.
 The method will L«C<fail>|/routine/fail» with C<X::IO::DoesNotExist> if the
@@ -642,7 +642,7 @@ path points to a non-existent filesystem entity.
 
 Defined as:
 
-    method f(--> Bool:D)
+    method f(IO::Path:D: --> Bool:D)
 
 Returns C<True> if the invocant is a path that exists and is a file. The method
 will L«C<fail>|/routine/fail» with C<X::IO::DoesNotExist> if the path points to
@@ -652,7 +652,7 @@ a non-existent filesystem entity.
 
 Defined as:
 
-    method s(--> Int:D)
+    method s(IO::Path:D: --> Int:D)
 
 Returns the file size in bytes. May be called on paths that are directories, in
 which case the reported size is dependent on the operating system. The method
@@ -665,7 +665,7 @@ a non-existent filesystem entity.
 
 Defined as:
 
-    method l(--> Bool:D)
+    method l(IO::Path:D: --> Bool:D)
 
 Returns C<True> if the invocant is a path that exists and is a symlink.
 The method will L«C<fail>|/routine/fail» with C<X::IO::DoesNotExist> if the
@@ -675,7 +675,7 @@ path points to a non-existent filesystem entity.
 
 Defined as:
 
-    method r(--> Bool:D)
+    method r(IO::Path:D: --> Bool:D)
 
 Returns C<True> if the invocant is a path that exists and is accessible.
 The method will L«C<fail>|/routine/fail» with C<X::IO::DoesNotExist> if the
@@ -685,7 +685,7 @@ path points to a non-existent filesystem entity.
 
 Defined as:
 
-    method w(--> Bool:D)
+    method w(IO::Path:D: --> Bool:D)
 
 Returns C<True> if the invocant is a path that exists and is writable.
 The method will L«C<fail>|/routine/fail» with C<X::IO::DoesNotExist> if the
@@ -695,7 +695,7 @@ path points to a non-existent filesystem entity.
 
 Defined as:
 
-    method rw(--> Bool:D)
+    method rw(IO::Path:D: --> Bool:D)
 
 Returns C<True> if the invocant is a path that exists and is readable and
 writable. The method will L«C<fail>|/routine/fail» with C<X::IO::DoesNotExist>
@@ -705,7 +705,7 @@ if the path points to a non-existent filesystem entity.
 
 Defined as:
 
-    method x(--> Bool:D)
+    method x(IO::Path:D: --> Bool:D)
 
 Returns C<True> if the invocant is a path that exists and is executable.
 The method will L«C<fail>|/routine/fail» with C<X::IO::DoesNotExist> if the
@@ -715,7 +715,7 @@ path points to a non-existent filesystem entity.
 
 Defined as:
 
-    method rwx(--> Bool:D)
+    method rwx(IO::Path:D: --> Bool:D)
 
 Returns C<True> if the invocant is a path that exists and is executable,
 readable, and writable. The method will L«C<fail>|/routine/fail» with
@@ -725,7 +725,7 @@ C<X::IO::DoesNotExist> if the path points to a non-existent filesystem entity.
 
 Defined as:
 
-    method z(--> Bool:D)
+    method z(IO::Path:D: --> Bool:D)
 
 Returns C<True> if the invocant is a path that exists and has size of C<0>. May
 be called on paths that are directories, in which case the reported file size

--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -175,7 +175,7 @@ sent to the broadcast address.
 
 =head2 method print
 
-    method print(Str $str --> Promise)
+    method print(IO::Socket::Async:D: Str $str --> Promise)
 
 Attempt to send C<$str> on the L<IO::Socket::Async|/type/IO::Socket::Async> that will have been
 obtained indirectly via C<connect> or C<listen>, returning a L<Promise|/type/Promise>
@@ -196,7 +196,7 @@ the socket was created.
 
 =head2 method write
 
-    method write(Blob $b --> Promise)
+    method write(IO::Socket::Async:D: Blob $b --> Promise)
 
 This method will attempt to send the bytes in C<$b> on the
 L<IO::Socket::Async|/type/IO::Socket::Async> that will have been obtained indirectly via
@@ -244,7 +244,7 @@ upon a decoding error.
 
 =head2 method close
 
-    method close()
+    method close(IO::Socket::Async:D: )
 
 Close the connected client L<IO::Socket::Async|/type/IO::Socket::Async> which will have been
 obtained from the C<listen> L<Supply|/type/Supply> or the C<connect>

--- a/doc/Type/IO/Spec/Cygwin.pod6
+++ b/doc/Type/IO/Spec/Cygwin.pod6
@@ -119,7 +119,7 @@ except replaces backslashes with slashes in the final result.
 
 Defined as:
 
-    method split(|c --> List:D)
+    method split(IO::Spec::Cygwin: |c --> List:D)
 
 Same as L«C<IO::Spec::Win32.split>|/type/IO::Spec::Win32#method_split», except
 replaces backslashes with slashes in all the values of the final result.

--- a/doc/Type/IO/Spec/Unix.pod6
+++ b/doc/Type/IO/Spec/Unix.pod6
@@ -249,7 +249,7 @@ Returns string C<'/'>, representing root directory.
 
 Defined as:
 
-    method split(Cool:D $path --> List:D)
+    method split(IO::Spec::Unix: Cool:D $path --> List:D)
 
 Splits the given C<$path> into "volume", "dirname", and "basename" and
 returns the result as a L<List|/type/List> of three L<Pairs|/type/Pair>, in that order.

--- a/doc/Type/IO/Spec/Win32.pod6
+++ b/doc/Type/IO/Spec/Win32.pod6
@@ -214,7 +214,7 @@ Returns string C<｢\｣>, representing root directory.
 
 Defined as:
 
-    method split(Cool:D $path --> List:D)
+    method split(IO::Spec::Win32: Cool:D $path --> List:D)
 
 Splits the given C<$path> into "volume", "dirname", and "basename" and
 returns the result as a L<List|/type/List> of three L<Pairs|/type/Pair>, in that order.

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -57,7 +57,7 @@ It is supposed to return an L<Iterator|/type/Iterator>.
 
 Defined as:
 
-    method flat(--> Iterable)
+    method flat(Iterable:D: --> Iterable)
 
 Returns another L<Iterable|/type/Iterable> that flattens out all iterables that
 the first one returns.

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -688,7 +688,7 @@ Returns the number of elements in the list (same as C<.elems>).
 
 Defined as:
 
-    method Capture(--> Capture:D)
+    method Capture(List:D: --> Capture:D)
 
 Returns a L<Capture|/type/Capture> where each L<Pair|/type/Pair>, if any, in the
 C<List> has been converted to a named argument (with the

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -171,7 +171,7 @@ $something> and C<say $something.gist> generally produce the same output.
 
 =head2 method perl
 
-    multi method perl(--> Str)
+    multi method perl(Mu: --> Str)
 
 Returns a Raku-ish representation of the object (i.e., can usually be
 re-evaluated with L<EVAL|/routine/EVAL> to regenerate the object). The exact
@@ -518,7 +518,7 @@ tool only.
 
 =head2 method WHY
 
-    multi method WHY(--> Pod::Block::Declarator)
+    multi method WHY(Mu: --> Pod::Block::Declarator)
 
 Returns the attached Pod::Block::Declarator.
 

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -172,7 +172,7 @@ L<IO::Path|/type/IO::Path>, by using L<Junctions|/type/Junction>:
 
 Defined as:
 
-    method antipair(--> Pair:D)
+    method antipair(Pair:D: --> Pair:D)
 
 Returns a new C<Pair> object with key and value exchanged.
 

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -260,14 +260,14 @@ taken. See method C<vow> for more information.
 
 =head2 method result
 
-    method result(Promise:D)
+    method result(Promise:D:)
 
 Waits for the promise to be kept or broken. If it is kept, returns the result;
 otherwise throws the result as an exception.
 
 =head2 method cause
 
-    method cause(Promise:D)
+    method cause(Promise:D:)
 
 If the promise was broken, returns the result (or exception). Otherwise, throws
 an exception of type C<X::Promise::CauseOnlyValidOnBroken>.

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -362,7 +362,7 @@ say (1..∞).reverse;                             # OUTPUT: «(Inf Inf Inf ...)�
 
 Defined as:
 
-    method Capture(Range --> Capture:D)
+    method Capture(Range:D: --> Capture:D)
 
 Returns a L<Capture|/type/Capture> with values of L«C<.min>|/type/Range#method_min»
 L«C<.max>|/type/Range#method_max»,

--- a/doc/Type/RatStr.pod6
+++ b/doc/Type/RatStr.pod6
@@ -51,7 +51,7 @@ C<True>. String portion is not considered.
 
 Defined as:
 
-    method Capture(RatStr:D --> Capture:D)
+    method Capture(RatStr:D: --> Capture:D)
 
 Equivalent to L«C<Mu.Capture>|/type/Mu#method_Capture».
 

--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -113,19 +113,19 @@ integer. If scale is C<0.1>, rounds to one digit after the radix point (period o
 
 =head2 method floor
 
-    method floor(Real:D --> Int:D)
+    method floor(Real:D: --> Int:D)
 
 Return the largest integer not greater than the number.
 
 =head2 method ceiling
 
-    method ceiling(Real:D --> Int:D)
+    method ceiling(Real:D: --> Int:D)
 
 Returns the smallest integer not less than the number.
 
 =head2 method truncate
 
-    method truncate(Real:D --> Int:D)
+    method truncate(Real:D: --> Int:D)
 
 Rounds the number towards zero.
 

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -144,13 +144,13 @@ Returns a L<Seq|/type/Seq> of the set's elements and C<True> values interleaved.
 
 =head2 method elems
 
-    method elems(--> Int)
+    method elems(Setty:D: --> Int)
 
 The number of elements of the set.
 
 =head2 method total
 
-    method total(--> Int)
+    method total(Setty:D: --> Int)
 
 The total of all the values of the C<QuantHash> object. For a C<Setty>
 object, this is just the number of elements.

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -166,7 +166,7 @@ every word is capitalized, and all the other letters lowercased.
 
 =head2 method unival
 
-    multi method unival(Str:D --> Numeric)
+    multi method unival(Str:D: --> Numeric)
 
 Returns the numeric value that the first codepoint in the invocant represents,
 or C<NaN> if it's not numeric.
@@ -177,7 +177,7 @@ or C<NaN> if it's not numeric.
 
 =head2 method univals
 
-    multi method univals(Str:D --> List)
+    multi method univals(Str:D: --> List)
 
 Returns a list of numeric values represented by each codepoint in the invocant
 string, and C<NaN> for non-numeric characters.
@@ -1031,7 +1031,7 @@ Examples:
 
 =head2 method succ
 
-    method succ(Str:D --> Str:D)
+    method succ(Str:D: --> Str:D)
 
 Returns the string incremented by one.
 

--- a/doc/Type/Thread.pod6
+++ b/doc/Type/Thread.pod6
@@ -70,20 +70,20 @@ Returns a numeric, unique thread identifier.
 
 =head2 method finish
 
-    method finish(Thread:D)
+    method finish(Thread:D:)
 
 Waits for the thread to finish. This is called L<join|#method_join> in other programming
 systems.
 
 =head2 method join
 
-    method join(Thread:D)
+    method join(Thread:D:)
 
 Waits for the thread to finish.
 
 =head2 method yield
 
-    method yield(Thread:U)
+    method yield(Thread:U:)
 
 Tells the scheduler to prefer another thread for now.
 


### PR DESCRIPTION
This PR fixes the errors detected by xt/check-signatures.t.  Most of these were simple typos (typically forgetting `:`).  Nearly all others were places where Rakudo constrains the invocant but we did not.

One change was slightly more substantive: we had inadvertently documented the `match` method twice in `Cool`, so I merged the two definitions.
