### PR TITLE
- Document the use of a Whatever to delegate all methods from a class.

### DIFF
--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -382,6 +382,13 @@ searched, use a L<C<HyperWhatever>|/type/HyperWhatever>.
     }
     say E.new.em1; # OUTPUT: «A::m1 has been called.␤»
 
+    class F {
+      # Delegates all methods from A
+      has A $.delegate handles *;
+    }
+    say F.new.m1; # OUTPUT: «A::m1 has been called.␤»
+    say F.new.m2; # OUTPUT: «A::m2 has been called.␤»
+
 =head3  X<trait C<is>|classes,is>
 
 Defined as:


### PR DESCRIPTION
See this discussion: https://colabti.org/irclogger/irclogger_log/raku?date=2020-09-07#l201

The use of a Whatever was mentioned, but not documented in the examples. This PR adds such an example.

An example of the use of a HyperWhateverable would also be nice, but I don't understand the concept well enough to add one. Maybe in a future PR.