### PR TITLE
Revisite (is-)implementation-detail

### DIFF
--- a/doc/Language/traits.pod6
+++ b/doc/Language/traits.pod6
@@ -123,6 +123,10 @@ directly, they will not appear in results of introspection:
 Such routines are not meant for use by users and their behavior and availability can be changed
 anytime.
 
+=head3 method is-implementation-detail
+
+    method is-implementation-detail(--> True)
+
 Applying this trait makes the C<is-implementation-detail> method called on
 L<Code|/type/Code> to return C<True>, thus giving a hint to the user not to use it
 if they are not willing to maintain this code in case of changes for years to come:

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -215,9 +215,10 @@ say Food.^lookup('ingredients').line;  # OUTPUT: «1␤»
 
     method is-implementation-detail(--> False)
 
-Note: this trait has been available in Rakudo compiler starting from 2020.05 release.
+Note: this method has been available in Rakudo compiler starting from 2020.05 release.
 
-Returns C<True> if the code object was marked with C<is implementation-detail> trait,
+Returns C<True> if the code object was marked with
+L«C<is implementation-detail> trait|/language/traits#is_implementation-detail_trait»,
 C<False> otherwise.
 
 =end pod


### PR DESCRIPTION
- xref implementation-detail trait
- fix pasto (trait -> method)
- give is-implementation-detail its own section in implementation-detail
trait's description, hence nicely grouped in search results and routine
page
