### PR TITLE
Update modules.pod6

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -520,9 +520,9 @@ export RAKULIB=/path/to/my-modules,/path/to/more/modules
 
 Note that the comma (',') is used as the directory separator.
 
-The include path will be searched recursively for any modules when Rakudo is
-started. Directories that start with a dot are ignored and symlinks are
-followed.
+The directories in the C<RAKULIB> path will be searched for modules when
+Raku C<need>s,C<use>s or C<require>s them. Directories that start with a
+dot are ignored and symlinks are followed.
 
 =head1 Distributing modules
 


### PR DESCRIPTION
Three small text tunings: 

1)  _include_ _path_ appears to not be a Raku term.   This is the only usage I find on [docs.Raku.org](url)
2) "searched ... when Rakudo is started" seems misleading at best.  I think it is just wrong  as a command is needed to place an order for a module.  I don't know what Raku does with core modules but that seems off-topic or arcana here--doubtfully worth a mention or link.
3) 'recursively' seems wrong and just an implementation detail.  Isn't the list linearly searched and then mangling or mapping grabs a module.

If someone knows offhand where this RAKULIB search code is,  please give me a pointer.
