### PR TITLE
Tweak Array.splice description

### DIFF
--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -237,16 +237,17 @@ returned.
 
 Each of C<$start> and C<$elems> can be specified as a
 L<Whatever|/type/Whatever> or as a L<Callable|/type/Callable> that returns an
-C<Int>-compatible value.
+C<Int>-compatible value: this returned value is then used as the
+corresponding argument to the C<splice> routine.
 
 A C<Whatever> C<$start> uses the number of elements of C<@list> (or invocant). A
 C<Callable> C<$start> is called with one argument—the number of elements in
-C<@list> (or C<self>) —-and its return value is used as C<$start>.
+C<@list> (or C<self>).
 
 A C<Whatever> C<$elems> deletes from C<$start> to end of C<@list> (or C<self>)
-(same as no C<$elems>). A C<Callable> C<$elems> is called with just one
-argument—the number of elements in C<@list> minus the value of C<$start>—and its
-return value is used the value of C<$elems>.
+(same as no C<$elems>). A C<Callable> C<$elems> is called with one
+argument—the number of elements in C<@list> (or C<self>) minus the value
+of C<$start>.
 
 Example:
 


### PR DESCRIPTION
- reduce repetition
- add a missing self mention
- remove an extraneous 'just'
