### PR TITLE
Promote `%d is Map` syntax more

### DIFF
--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -24,9 +24,9 @@ return them always in the same order when called on the same object.
 To retrieve a value from the Map by key, use the C<{ }> postcircumfix
 operator:
 
-    my $map = Map.new('a', 1, 'b', 2);
-    say $map{'a'};      # OUTPUT: «1␤»
-    say $map{ 'a', 'b' }; # OUTPUT: «(1 2)␤»
+    my %map is Map = 'a', 1, 'b', 2;
+    say %map{'a'};      # OUTPUT: «1␤»
+    say %map{ 'a', 'b' }; # OUTPUT: «(1 2)␤»
 
 To check whether a given key is stored in a Map, modify the access
 with the C<:exists> adverb:
@@ -67,6 +67,10 @@ extra parentheses around all the arguments.
 
     # RIGHT: :b(2) interpreted as part of Map's contents
     say Map.new( ('a', 1, :b(2)) ).keys; # OUTPUT: «(a b)␤»
+
+A short-hand syntax for creating Maps is provided:
+
+    my %h is Map = 'a', 1, 'b', 2;
 
 =head2 method elems
 


### PR DESCRIPTION
The `%m is Map` syntax is not easily discovered as it is only shown on the `Syntax` page.
Give it some more visibility by also showcasing it on the `Map` page itself.
