### PR TITLE
Updating working on the TWEAK documentation based on confusion here :…

### DIFF
--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -773,9 +773,9 @@ default; these are available only during C<TWEAK> (see below), which can
 class.
 
 X<|TWEAK>
-After the C<BUILD> methods have been called, methods named C<TWEAK> are
-called, if they exist, again with all the named arguments that were passed
-to C<new>. See an example of its use below.
+After the C<BUILD> methods have been called for a class, methods named
+C<TWEAK> are called for that class, if they exist, again with all the
+named arguments that were passed to C<new>. See an example of its use below.
 
 Due to the default behavior of C<BUILD> and C<TWEAK> submethods, named
 arguments to the constructor C<new> derived from C<Mu> can


### PR DESCRIPTION
## The problem

There was a stack overflow question that raised some issues with the wording of the order of calling for BUILD and TWEAK methods. 

https://stackoverflow.com/questions/64103610/does-anyone-know-why-the-tweak-routine-gets-hit-before-the-build-routine

## Solution provided

Small change to the wording to make it's meaning more explicit based on my understanding of what the object build process is doing. 