### PR TITLE
Documenting the special syntax for initialising the single public attribute of a role in runtime mixin

### DIFF
--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -1259,6 +1259,16 @@ say $a.^name;
 my $all-roles = 1 but (R1,R2);
 say $all-roles.^name; # OUTPUT: «Int+{R1,R2}␤»
 
+If the role supplies exactly one attribute, an initializer can be passed in
+parentheses:
+
+=begin code
+role Named {
+    has $.name;
+}
+my $hero = 1.Rat but Named('Remy');
+say $hero.name;     # OUTPUT: «Remy␤»
+=end code
 
 Mixins can be used at any point in your object's life.
 

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1886,7 +1886,7 @@ precedence.
     multi sub infix:<but>(Mu $obj1, Mu:D $obj2) is assoc<non>
 
 Creates a copy of C<$obj> with C<$role> mixed in. Since C<$obj> is not
-modified, C<but> can be used to created immutable values with mixins.
+modified, C<but> can be used to create immutable values with mixins.
 
 Instead of a role, you can provide an instantiated object. In this case,
 the operator will create a role for you automatically. The role will contain

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1867,6 +1867,9 @@ keep that.
 
 Mixes C<$role> into C<$obj> at runtime. Requires C<$obj> to be mutable.
 
+Similar to L<but|/routine/but> operator, if C<$role> supplies exactly one
+attribute, an initializer can be passed in parentheses.
+
 Similar to L<but|/routine/but> operator, the C<$role> can instead be an instantiated object,
 in which case, the operator will create a role for you automatically.
 The role will contain a single method named the same as C<$obj.^name>
@@ -1887,6 +1890,19 @@ precedence.
 
 Creates a copy of C<$obj> with C<$role> mixed in. Since C<$obj> is not
 modified, C<but> can be used to create immutable values with mixins.
+
+If C<$role> supplies exactly one attribute, an initializer can be passed in
+parentheses:
+
+    =begin code
+    role Answerable {
+        has $.answer;
+    }
+    my $ultimate-question = 'Life, the Universe and Everything' but Answerable(42);
+    say $ultimate-question;         # OUTPUT: «Life, the Universe and Everything␤»
+    say $ultimate-question.^name;   # OUTPUT: «Str+{Answerable}␤»
+    say $ultimate-question.answer;  # OUTPUT: «42␤»
+    =end code
 
 Instead of a role, you can provide an instantiated object. In this case,
 the operator will create a role for you automatically. The role will contain

--- a/xt/pws/code.pws
+++ b/xt/pws/code.pws
@@ -376,6 +376,7 @@ rbar
 rdm
 rectanglewithcachedarea
 rememberit
+remy
 renderbarchart
 repeatchar
 req


### PR DESCRIPTION
The special syntax for initialising the single public attribute provided by a role in a runtime mixin (using the `but` or `does` operator) is not documented.

This should fix #3658.