### PR TITLE
Fix output for proto example

### DIFF
--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -486,7 +486,7 @@ class NewClass {
     }
     multi method handle( $a, $b ) {
         $.value = "$a is looking askance at $b";
-        say 'in string'
+        say 'with more than one value'
     }
 }
 my NewClass $x .= new;
@@ -497,15 +497,17 @@ $x.handle('hello world');
 $x.handle(<hello world>);
 $x.handle('Claire', 'John');
 # OUTPUT:
-#in string
-#after value is ｢hello world｣
-#before value is ｢hello world｣
-#in positional
-#after value is ｢hello｣
-#before value is ｢hello｣
-#in string
-#after value is ｢Claire is looking askance at John｣
-
+# in string
+# in positional
+# before value is ｢hello｣
+# in string
+# after value is ｢hello world｣
+# before value is ｢hello world｣
+# in positional
+# after value is ｢hello｣
+# before value is ｢hello｣
+# with more than one value
+# after value is ｢Claire is looking askance at John｣
 
 =head2 X<only|declarator>
 


### PR DESCRIPTION
## The problem

The listed output for the extended proto example did not match the code, and two of the functions had the same message, making following the code more difficult.

## Solution provided

The messages printed by the methods have been modified so they are all different, and the output listing has been updated after executing the code.