### PR TITLE
Simplify use of pick in is-pure documentation

### DIFF
--- a/doc/Type/Routine.pod6
+++ b/doc/Type/Routine.pod6
@@ -187,7 +187,7 @@ To see it an action with a particular compiler you can try this example:
     =begin code :preamble<sub syllables {}>
     BEGIN { say ‘Begin’ }
     say ‘Start’;
-    say (^100).map: { syllables().pick(2..5).join("") };
+    say (^100).map: { syllables().pick(4).join("") };
 
 
     # Example output:


### PR DESCRIPTION
## The problem

As stated in #3579:

> But pick(2..5) is the same as pick(4). Seeing this in the docs had me running to the "pick" documentation, and trying things out in the REPL.

## Solution provided

As suggested on that ticket, the use of `pick` has been simplified.