### PR TITLE
Pair.keys/kv/values/pairs/antipairs produce a Seq

### DIFF
--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -234,11 +234,11 @@ For more about format strings, see L<sprintf|/routine/sprintf>.
 
 Defined as:
 
-    multi method kv(Pair:D: --> List:D)
+    multi method kv(Pair:D:)
 
-Returns a two-element C<List> with the I<key> and I<value> parts of
+Returns a two-element L<Seq|/type/Seq> with the I<key> and I<value> parts of
 C<Pair>, in that order. This method is a special case of the same-named
-method on C<Hash>, which returns all its entries as a list of keys and
+method on C<Hash>, which returns all its entries as a sequence of keys and
 values.
 
     my $p = (Perl => 6);
@@ -251,10 +251,10 @@ Defined as:
 
     multi method pairs(Pair:D:)
 
-Returns a list of one C<Pair>, namely this one.
+Returns a L<Seq|/type/Seq> of one C<Pair>, namely this one.
 
     my $p = (Perl => 6);
-    say $p.pairs.^name; # OUTPUT: «List␤»
+    say $p.pairs.^name; # OUTPUT: «Seq␤»
     say $p.pairs[0];    # OUTPUT: «Perl => 6␤»
 
 =head2 method antipairs
@@ -263,11 +263,11 @@ Defined as:
 
     multi method antipairs(Pair:D:)
 
-Returns a L<List|/type/List> containing the L<antipair|/type/Pair#method_antipair>
+Returns a L<Seq|/type/Seq> containing the L<antipair|/type/Pair#method_antipair>
 of the invocant.
 
     my $p = (6 => 'Perl').antipairs;
-    say $p.^name;                                     # OUTPUT: «List␤»
+    say $p.^name;                                     # OUTPUT: «Seq␤»
     say $p.first;                                     # OUTPUT: «Perl => 6␤»
     say $p.first.^name;                               # OUTPUT: «Pair␤»
 
@@ -302,9 +302,9 @@ L«C<.antipair> method|/type/Pair#method_antipair».
 
 Defined as:
 
-    multi method keys(Pair:D: --> List:D)
+    multi method keys(Pair:D:)
 
-Returns a L<List|/type/List> containing the L<key|/type/Pair#method_key>
+Returns a L<Seq|/type/Seq> containing the L<key|/type/Pair#method_key>
 of the invocant.
 
     say ('Perl' => 6).keys;                           # OUTPUT: «(Perl)␤»
@@ -313,9 +313,9 @@ of the invocant.
 
 Defined as:
 
-    multi method values(Pair:D: --> List:D)
+    multi method values(Pair:D:)
 
-Returns a L<List|/type/List> containing the L<value|/type/Pair#method_value>
+Returns a L<Seq|/type/Seq> containing the L<value|/type/Pair#method_value>
 of the invocant.
 
     say ('Perl' => 6).values;                         # OUTPUT: «(6)␤»


### PR DESCRIPTION
This was changed in rakudo/rakudo@30584dac2fe231038c5bea557946a41310e9fd0f hence since rakudo 2017.08. Should the previous behavior be mentioned ?