### PR TITLE
Fix typo in haskell example

### DIFF
--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -438,7 +438,7 @@ does not translate exactly the same, but it's possible to do the same things, no
 Fold in Haskell is called Reduce in Raku.
 
     =begin code :lang<haskell>
-    mySum = foldl `+` 0 numList
+    mySum = foldl (+) 0 numList
     =end code
 
     =begin code


### PR DESCRIPTION
## The problem

To make literal behaving like regular function sorround operator with parens. To get opposite sorround function with backticks.

## Solution provided
Proper syntax provided.
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
