### PR TITLE
Document absolute parameter for IO::Path symlink method

### DIFF
--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -997,7 +997,8 @@ does not exist, creates a dangling symbolic link.
 
 C<symlink> creates a symbolic link using an absolute path
 by default. To create a relative symlink set the C<absolute>
-parameter to C<False> e.g. C<:!absolute>.
+parameter to C<False> e.g. C<:!absolute>. This flag was
+introduced in Rakudo version 2020.11.
 
 To create a hard link, see L«C<link>|/routine/link».
 

--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -987,13 +987,18 @@ X<|symlink (method)>
 
 Defined as:
 
-    method symlink(IO::Path:D $target: IO() $link --> Bool:D)
-    sub    symlink(      IO() $target, IO() $link --> Bool:D)
+    method symlink(IO::Path:D $target: IO() $link, Bool :$absolute = True --> Bool:D)
+    sub    symlink(      IO() $target, IO() $link, Bool :$absolute = True --> Bool:D)
 
 Create a new I<symbolic> link C<$link> to existing C<$target>.
 Returns C<True> on success; L<fails|/routine/fail> with
 L<X::IO::Symlink|/type/X::IO::Symlink> if the symbolic link could not be created. If C<$target>
 does not exist, creates a dangling symbolic link.
+
+C<symlink> creates a symbolic link using an absolute path
+by default. To create a relative symlink set the C<absolute>
+parameter to C<False> e.g. C<:!absolute>.
+
 To create a hard link, see L«C<link>|/routine/link».
 
 B<Note:> on Windows, creation of symbolic links may require escalated


### PR DESCRIPTION
Flag added in https://github.com/rakudo/rakudo/pull/3980

(Probably a bit early to merge right now)
