### PR TITLE
rakudobrew -> rakubrew

### DIFF
--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -76,6 +76,7 @@ Rakudo release of 2015.12 should be avoided.
 There's an official Rakudo Star docker image at
 L<https://hub.docker.com/_/rakudo-star/>
 
+X<|rakubrew (FAQ)>
 X<|rakudobrew (FAQ)>
 =head2 As an advanced user I want to track Rakudo development.
 
@@ -89,10 +90,8 @@ To install the last official monthly release, check out the tag visible
 at L<https://raw.githubusercontent.com/rakudo/rakudo/master/VERSION> or
 set up L<a helper command|https://github.com/zoffixznet/r#table-of-contents>.
 
-Some users choose to use
-L<rakudobrew|https://github.com/tadzik/rakudobrew>,
-which allows installation of multiple versions of rakudo. Be sure to
-L<read its documentation|https://github.com/tadzik/rakudobrew#making-new-scripts-available>.
+Some users choose to use L<rakubrew|https://rakubrew.org/>, which allows
+quick installation of multiple versions of Rakudo in parallel.
 
 In either case you will probably need to also install
 L«C<zef>|https://modules.raku.org/dist/zef:github» and

--- a/resources/i18n/de/README.de.md
+++ b/resources/i18n/de/README.de.md
@@ -60,12 +60,10 @@ Installiere die Abhängigkeiten durch ausführen von
 
 in deinem Checkout-Verzeichnis.
 
-Falls du [`rakudobrew`](https://github.com/tadzik/rakudobrew)
-verwendest, führe den folgenden Befehl aus, um die
-Kompatibilitäts-Anpassungen an den installierten ausführbaren Dateien
-zu aktualisieren:
+Falls du [`rakubrew`](https://rakubrew.org/) im `shim` Modus verwendest, führe
+den folgenden Befehl aus, um neu installierte Scripte verfügbar zu machen:
 
-    $ rakudobrew rehash
+    $ rakubrew rehash
 
 Zusätzlich zu den Raku Abhängigkeiten musst du `graphviz`
 installiert haben. Unter Debian kannst du dies tun mit

--- a/resources/i18n/es/README.es.md
+++ b/resources/i18n/es/README.es.md
@@ -55,9 +55,9 @@ Instala las dependencias ejecutando lo siguiente en el directorio correspondient
 
     $ zef --deps-only install .
 
-Si usas [`rakudobrew`](https://github.com/tadzik/rakudobrew), ejecuta también:
+Si usas [`rakubrew`](https://rakubrew.org/) în modul `shim`, ejecuta también:
 
-    $ rakudobrew rehash
+    $ rakubrew rehash
 
 para actualizar los correctores de compatibilidad de los ejecutables instalados.
 

--- a/resources/i18n/fr/README.fr.md
+++ b/resources/i18n/fr/README.fr.md
@@ -56,9 +56,9 @@ Pour installez les dépendances exécutez la commande suivante dans le répertoi
 
     $ zef --deps-only install .
 
-Si vous utilisez [`rakudobrew`](https://github.com/tadzik/rakudobrew), exécutez également la commande suivante afin de mettre à jour les `shims` pour les exécutables installés:
+Si vous utilisez [`rakubrew`](https://rakubrew.org/) en mode `shim`, exécutez également la commande suivante afin de mettre à jour les `shims` pour les exécutables installés:
 
-    $ rakudobrew rehash
+    $ rakubrew rehash
 
 En plus des dépendances Raku, vous devez avoir `graphviz` installé, que vous pouvez installer avec la commande:
 

--- a/resources/i18n/it/README.it.md
+++ b/resources/i18n/it/README.it.md
@@ -60,11 +60,11 @@ nella directory ove si è fatto il checkout del repository:
 
     $ zef --deps-only install .
 
-Se si sta usando [`rakudobrew`](https://github.com/tadzik/rakudobrew),
+Se si sta usando [`rakubrew`](https://rakubrew.org/) in modalità `shim`,
 è necessario anche eseguire il seguente comando in modo da aggiornare gli "shims"
 per gli eseguibili installati:
 
-    $ rakudobrew rehash
+    $ rakubrew rehash
 
 Oltre alle dipendenze specifiche di  Raku, è necessario anche avere installato `graphviz`,
 che su sistemi Debian può essere installato con il seguente comando

--- a/resources/i18n/jp/README.jp.md
+++ b/resources/i18n/jp/README.jp.md
@@ -43,9 +43,9 @@
 
     $ zef --deps-only install .
 
-[`rakudobrew`](https://github.com/tadzik/rakudobrew)を使用している場合は、次のコマンドも実行してください:
+[`rakubrew`](https://rakubrew.org/)を使用している場合は、次のコマンドも実行してください:
 
-    $ rakudobrew rehash
+    $ rakubrew rehash
 
 Rakuの依存関係に加えて、 `graphiviz` がインストールしてある必要があります。
 Debian環境なら下記のコマンドでインストールすることができます:

--- a/resources/i18n/nl/README.nl.md
+++ b/resources/i18n/nl/README.nl.md
@@ -54,10 +54,10 @@ Installeer de benodigde dependencies door het volgende commando uit te voeren in
 
     $ zef --deps-only install .
 
-Als je gebruik maakt van [`rakudobrew`](https://github.com/tadzik/rakudobrew) heb je ook
+Als je gebruik maakt van [`rakubrew`](https://rakubrew.org/) in `shim`-modus heb je ook
 het volgende commando nodig om de shims voor de geïnstalleerde programma's te updaten:
 
-    $ rakudobrew rehash
+    $ rakubrew rehash
 
 Naast de Raku dependencies dien je ook 'graphviz' geïnstalleerd te hebben; op Debian kun
 je dit bewerkstelligen met het commando:

--- a/resources/i18n/pt/README.pt.md
+++ b/resources/i18n/pt/README.pt.md
@@ -58,9 +58,9 @@ Instale as dependências executando o siguinte no directório onde estão as fon
 
     $ zef --deps-only install .
 
-[`rakudobrew`](https://github.com/tadzik/rakudobrew), precisa que seja executado tabém:
+[`rakubrew`](https://rakubrew.org/), precisa que seja executado tabém:
 
-    $ rakudobrew rehash
+    $ rakubrew rehash
 
 para atualizar os links de compatibilidade de executáveis.
 


### PR DESCRIPTION
Replace `rakudobrew` with its successor `rakubrew` where it makes sense. No need to send readers to a page that then forwards them to rakubrew.