### PR TITLE
Replace non-Spanish phrase

### DIFF
--- a/resources/i18n/es/README.es.md
+++ b/resources/i18n/es/README.es.md
@@ -55,7 +55,7 @@ Instala las dependencias ejecutando lo siguiente en el directorio correspondient
 
     $ zef --deps-only install .
 
-Si usas [`rakubrew`](https://rakubrew.org/) în modul `shim`, ejecuta también:
+Si usas [`rakubrew`](https://rakubrew.org/) en modo `shim`, ejecuta también:
 
     $ rakubrew rehash
 


### PR DESCRIPTION
## The problem

The text `în modul` is not Spanish. It was copied by accident from a different language.

## Solution provided

It was replaced by the equivalent "en modo".