### PR TITLE
Remove out of place AUTHORS section

### DIFF
--- a/doc/Programs/03-environment-variables.pod6
+++ b/doc/Programs/03-environment-variables.pod6
@@ -154,15 +154,4 @@ X<|RAKUDO_SNAPPER>
 Indicates the period in which the telemetry snapper will take a snapshot.
 Defaults to .1 for 10 snapshots per second.
 
-=head1 AUTHORS
-
-Initial version written by the Rakudo contributors, see the
-L<CREDITS file|https://github.com/rakudo/rakudo/blob/master/CREDITS>.
-
-The L<initial version of this manual
-page|https://github.com/rakudo/rakudo/blob/master/docs/running.pod> was written
-by Reini Urban, Moritz Lenz and the Rakudo contributors.
-
-=end pod
-
 # vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6


### PR DESCRIPTION
If we choose to have an AUTHORS section of the documentation it should be in a central place and not in a random sub page.

This is a draft PR, because I'd like to answer the following questions first:

- Do we want to have an AUTHORS section on the docs page?
- Where would such a section live?
- Who should be credited?
