### PR TITLE
Fix code highlighting using the correct scope name

### DIFF
--- a/highlights/highlight-file.coffee
+++ b/highlights/highlight-file.coffee
@@ -4,8 +4,15 @@ Highlights = require 'highlights'
 fs = require 'fs'
 path = require 'path'
 highlighter = new Highlights()
+modPath = require.resolve('./atom-language-perl6/package.json')
 highlighter.requireGrammarsSync
-  modulePath: require.resolve('./atom-language-perl6/package.json')
+  modulePath: modPath
+
+rakuGrammarPath = path.join(path.dirname(modPath), 'grammars', 'raku.cson')
+if fs.existsSync(rakuGrammarPath)
+    rakuScopeName = 'source.raku'
+else
+    rakuScopeName = 'source.perl6fe'
 
 file_to_hl = path.resolve(process.argv[2])
 foo = ->
@@ -13,6 +20,6 @@ foo = ->
 
 html = highlighter.highlightSync
   fileContents: foo()
-  scopeName: 'source.perl6fe'
+  scopeName: rakuScopeName
 
 console.log html

--- a/highlights/highlight-filename-from-stdin.coffee
+++ b/highlights/highlight-filename-from-stdin.coffee
@@ -4,8 +4,15 @@ Highlights = require 'highlights'
 fs = require 'fs'
 path = require 'path'
 highlighter = new Highlights()
+modPath = require.resolve('./atom-language-perl6/package.json')
 highlighter.requireGrammarsSync
-  modulePath: require.resolve('./atom-language-perl6/package.json')
+  modulePath: modPath
+
+rakuGrammarPath = path.join(path.dirname(modPath), 'grammars', 'raku.cson')
+if fs.existsSync(rakuGrammarPath)
+    rakuScopeName = 'source.raku'
+else
+    rakuScopeName = 'source.perl6fe'
 
 stdin = process.openStdin()
 stdin.setEncoding 'utf8'
@@ -27,7 +34,7 @@ process_file = (given_path) ->
     if read_err
       console.error read_err
     else
-      highlighter.highlight (fileContents: file_str, scopeName: 'source.perl6fe'), (hl_err, html) ->
+      highlighter.highlight (fileContents: file_str, scopeName: rakuScopeName), (hl_err, html) ->
         if hl_err
           console.error hl_err
         else

--- a/highlights/highlight-folder.coffee
+++ b/highlights/highlight-folder.coffee
@@ -2,8 +2,15 @@ Highlights = require 'highlights'
 fs = require 'fs'
 path = require 'path'
 highlighter = new Highlights()
+modPath = require.resolve('./atom-language-perl6/package.json')
 highlighter.requireGrammarsSync
-  modulePath: require.resolve('./atom-language-perl6/package.json')
+  modulePath: modPath)
+
+rakuGrammarPath = path.join(path.dirname(modPath), 'grammars', 'raku.cson')
+if fs.existsSync(rakuGrammarPath)
+    rakuScopeName = 'source.raku'
+else
+    rakuScopeName = 'source.perl6fe'
 
 TestFolder = path.resolve('TestFolder')
 files = fs.readdirSync(TestFolder)
@@ -13,6 +20,6 @@ for file in files
     fs.readFileSync path.resolve(TestFolder, file), 'utf8'
   html = highlighter.highlightSync
     fileContents: foo()
-    scopeName: 'source.perl6fe'
+    scopeName: rakuScopeName
 
   console.log html


### PR DESCRIPTION
... when using a recent version of Raku/atom-language-perl6

Recently the scope name for Raku code has changed from 'source.perl6fe'
to 'source.raku' in the package atom-language-perl6.
See Raku/atom-language-perl6#96

We try to detect this change by testing for the presence of grammar file
'raku.cson', which beforehand was named 'perl6fe.cson'

Also, I suspect the script highlights/highlight-folder.coffee is not really used anymore. Perhaps it could be removed ?