### PR TITLE
Add a warning paragraph about type of arguments of Signature.new

### DIFF
--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -1172,7 +1172,7 @@ Throws C<X::Cannot::Capture>.
 =head1 Runtime creation of Signature objects (6.d, 2019.03 and later)
 
 =for code :preamble<role Type {}>
-Signature.new(params => (...), returns => Type, arity => 1, count => 1)
+Signature.new(params => (...), returns => Type, arity => 1, count => 1.Num)
 
 In some situations, specifically when working with the MetaObject Protocol,
 it makes sense to create C<Signature> objects programmatically.  For this
@@ -1198,6 +1198,12 @@ the C<params> parameter.
 The I<maximal> number of positional arguments which can be bound to the
 signature. Defaults to the C<arity> if not specified.  Specify C<Inf> if
 there is a slurpy positional parameter.
+
+I<Warning>: although the logical type of the C<count> parameter is integer,
+the value assigned to it must explicitly be of type C<Num>. If any other
+type is used, the C<new> method silently fails and returns an empty signature.
+The same trouble occurs when the value assigned to the C<arity> parameter is
+not of type C<Int>.
 
 =end pod
 


### PR DESCRIPTION
## The problem
The runtime creation of a `Signature` object silently fails when arguments of `Signature.new` have a wrong type. This issue currently is not documented.
Moreover the given example precisely show a wrong type for the parameter `count` and would not work.
(See rakudo/rakudo issue #4014)

## Solution provided
1. Modify the example to show the right type
2. Add a small explanatory paragraph to warn the users

