### PR TITLE
Introduce a way to mark versioned paragraphs

### DIFF
--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -385,11 +385,13 @@ printing a backtrace along with the message:
 
 =head1 Control exceptions
 
-Control exceptions are raised when throwing an Exception which does the
-L<X::Control|/type/X::Control> role (since Rakudo 2019.03). They are
+=begin para :versioned<down>
+Since Rakudo 2019.03 control exceptions are raised when throwing an Exception which does the
+L<X::Control|/type/X::Control> role. They are
 usually thrown by certain L<keywords|/language/phasers#CONTROL> and are
 handled either automatically or by the appropriate L<phaser|/language/phasers#Loop_phasers>.
 Any unhandled control exception is converted to a normal exception.
+=end para
 
 =begin code
 { return; CATCH { default { $*ERR.say: .^name, ': ', .Str } } }

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -378,9 +378,13 @@ X<|Data::Dumper (FAQ)>
 Typical options are to use the L<say|/routine/say> routine that uses
 the L<gist|/routine/gist> method which gives the "gist" of the object being
 dumped. More detailed output can be obtained by calling the
-L<perl|/routine/perl> method (soon to be deprecated in favor of C<$obj.raku>,
-available since the Rakudo 2019.11 release) that typically returns an object's
+L<perl|/routine/perl> method that typically returns an object's
 representation in L<EVAL|/routine/EVAL>-able code.
+
+=begin para :versioned<up>
+Since the Rakudo 2019.11 release the C<.raku> method is available, it works just as C<.perl>
+and is advised to use instead of C<.perl> which will be eventually deprecated and removed.
+=end para
 
 If you're using the L<rakudo|https://rakudo.org> implementation, you can use
 the L«rakudo-specific C<dd> routine|/programs/01-debugging#Dumper_function_dd»

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -312,15 +312,16 @@ my $ints = CArray[int32].allocate($number_of_ints); # instantiates an array with
 my $n = get_n_ints($ints, $number_of_ints);
 =end code
 
-I<Note>: C<allocate> was introduced in Rakudo 2018.05. Before that, you had to
+=begin para :versioned<down>
+C<allocate> was introduced in Rakudo 2018.05. Before that, you had to
 use this mechanism to extend an array to a number of elements:
+=end para
 
 =begin code :preamble<use NativeCall>
 my $ints = CArray[int32].new;
 my $number_of_ints = 10;
 $ints[$number_of_ints - 1] = 0; # extend the array to 10 items
 =end code
-
 
 The memory management of arrays is important to understand. When you create an
 array yourself, then you can add elements to it as you wish and it will be

--- a/doc/Language/pragmas.pod6
+++ b/doc/Language/pragmas.pod6
@@ -102,8 +102,10 @@ poke;
 # Cannot access '$y' through CALLER, because it is not declared as dynamic
 =end code
 
+=begin para :versioned<up>
 This pragma is not currently part of any Raku specification and was added
 in Rakudo 2019.03.
+=end para
 
 X<|experimental, pragma>
 =head2 experimental

--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -108,8 +108,9 @@ Raku supports all Unicode names. X<|\c[] unicode name>
     say "\c[PENGUIN]"; # OUTPUT: «🐧␤»
     say "\c[BELL]";    # OUTPUT: «🔔␤» (U+1F514 BELL)
 
-All Unicode codepoint names/named seq/emoji sequences are now case-insensitive:
-[Starting in Rakudo 2017.02]
+=begin para :versioned<down>
+Starting from Raku 2017.02, all Unicode codepoint names/named seq/emoji sequences are now case-insensitive:
+=end para
 
     say "\c[latin capital letter ae with macron]"; # OUTPUT: «Ǣ␤»
     say "\c[latin capital letter E]";              # OUTPUT: «E␤» (U+0045)
@@ -151,8 +152,10 @@ Abbreviations:
 
 =head2 Named sequences
 
-You can also use any of the L<Named Sequences|https://www.unicode.org/Public/UCD/latest/ucd/NamedSequences.txt>,
-these are not single codepoints, but sequences of them. [Starting in Rakudo 2017.02]
+=begin para :versioned<down>
+Starting from Rakudo 2017.02, you can also use any of the L<Named Sequences|https://www.unicode.org/Public/UCD/latest/ucd/NamedSequences.txt>,
+these are not single codepoints, but sequences of them.
+=end para
 
     say "\c[LATIN CAPITAL LETTER E WITH VERTICAL LINE BELOW AND ACUTE]";      # OUTPUT: «É̩␤»
     say "\c[LATIN CAPITAL LETTER E WITH VERTICAL LINE BELOW AND ACUTE]".ords; # OUTPUT: «(201 809)␤»

--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -113,17 +113,21 @@ be removed in future language versions entirely.
 The C<:out-buffer> controls output buffering and by default behaves as if
 it were C<Nil>. See method L<out-buffer|/routine/out-buffer> for details.
 
-B<Note (Rakudo versions before 2017.09): Filehandles are NOT flushed or closed
-when they go out of scope>. While they I<will> get closed when garbage
+=begin para :versioned<up>
+For Rakudo versions before 2017.09: Filehandles are NOT flushed or closed
+when they go out of scope. While they I<will> get closed when garbage
 collected, garbage collection isn't guaranteed to get run. This means I<you
 should> use an explicit C<close> on handles opened for writing, to avoid data
 loss, and an explicit C<close> is I<recommended> on handles opened for reading
 as well, so that your program does not open too many files at the same time,
 triggering exceptions on further C<open> calls.
+=end para
 
-B<Note (Rakudo versions 2017.09 and after):> Open filehandles are automatically
+=begin para :versioned<up>
+For Rakudo versions 2017.09 and above: Open filehandles are automatically
 closed on program exit, but it is still highly recommended that you C<close>
 opened handles explicitly.
+=end para
 
 =head2 method comb
 

--- a/doc/Type/Proc/Async.pod6
+++ b/doc/Type/Proc/Async.pod6
@@ -143,7 +143,7 @@ start the command afterwards using
 L<C<.start>|/type/Proc::Async#method_start>. You probably don't want to do this
 if you want to bind any of the handlers, but it's OK if you just need to
 start a external program immediately.
-
+=begin para :versioned<up>
 On Windows the flag C<$win-verbatim-args> disables all automatic quoting of
 process arguments. See
 L<this blog|https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way>
@@ -151,6 +151,7 @@ for more information on windows command quoting. The flag is ignored on all
 other platforms. The flag was introduced in Rakudo version 2020.06 and is not
 present in older releases. By default, it's set to C<False>, in which case
 arguments will be quoted according to Microsoft convention.
+=end para
 
 =head2 method stdout
 
@@ -316,20 +317,23 @@ Returns a L<Promise|/type/Promise> that will be kept once the process
 has successfully started. L<Promise|/type/Promise> will be broken if the program
 fails to start.
 
-B<Implementation-specific note:> Starting from Rakudo 2018.04, the
-returned promise will hold the process id (PID).
+=begin para :versioned<up>
+Starting from Rakudo 2018.04, the returned promise will hold the process id (PID).
+=end para
 
 =head2 method pid
 
     method pid(Proc::Async:D: --> Promise:D)
+
+=begin para :versioned<down>
+Available since Rakudo 2018.04.
+=end para
 
 Equivalent to L<ready|/routine/ready>.
 
 Returns a L<Promise|/type/Promise> that will be kept once the process
 has successfully started. L<Promise|/type/Promise> will be broken if the program
 fails to start. Returned promise will hold the process id (PID).
-
-B<Implementation-specific note:> Available starting from Rakudo 2018.04.
 
 =head2 method path
 

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -71,27 +71,33 @@ invocant right from the start of the invocant string and returns C<True>.
 In the third case, the C<'Hello'> string is not found since we have
 started looking from the second position (index 1) in C<'Hello, World'>.
 
+=begin para :versioned<down>
 Since Rakudo version 2020.02, the C<$needle> can also be
 a L<C<Regex>|/type/Regex> in which case the C<contains> method
 quickly returns whether the regex matches the string at least
 once. No L<C<Match>|/type/Match> objects are created, so this is
 relatively fast.
+=end para
 
     say 'Hello, World'.contains(/\w <?before ','>/);    # OUTPUT: «True␤»
     say 'Hello, World'.contains(/\w <?before ','>/, 5); # OUTPUT: «False␤»
 
+=begin para :versioned<down>
 Since Rakudo version 2020.02, if the optional named parameter
 C<:ignorecase>, or C<:i>, is specified, the search for C<$needle>
 ignores the distinction between upper case, lower case and title
 case letters.
+=end para
 
     say "Hello, World".contains("world");              # OUTPUT: «False␤»
     say "Hello, World".contains("world", :ignorecase); # OUTPUT: «True␤»
 
+=begin para :versioned<down>
 Since Rakudo version 2020.02, if the optional named parameter
 C<:ignoremark>, or C<:m>, is specified, the search for C<$needle>
 only considers base characters, and ignores additional marks such as
 combining accents.
+=end para
 
     say "abc".contains("ä");               # OUTPUT: «False␤»
     say "abc".contains("ä", :ignoremark);  # OUTPUT: «True␤»

--- a/doc/Type/X/Control.pod6
+++ b/doc/Type/X/Control.pod6
@@ -10,10 +10,12 @@ This role turns an exception into a
 L<control exception|/language/exceptions#Control_exceptions>, such as
 C<CX::Next> or C<CX::Take>. It has got no code other than the definition.
 
+=begin para :versioned<down>
 Since Rakudo 2019.03, C<throw>ing an object that mixes in this role
 C<X::Control> can raise a control exception which is caught by the L<CONTROL
 phaser|/language/phasers#CONTROL> instead of L<CATCH|/language/phasers#CATCH>.
 This allows to define custom control exceptions.
+=end para
 
 For example, the custom C<CX::Oops> control exception we define below:
 

--- a/doc/Type/X/Method/NotFound.pod6
+++ b/doc/Type/X/Method/NotFound.pod6
@@ -42,8 +42,10 @@ Returns C<True> for private methods, and C<False> for public methods.
 
     method addendum(--> Str:D)
 
-Returns additional explanations or hints.
+=begin para :versioned<down>
+C<addendum> was introduced in Rakudo 2019.03.
+=end para
 
-I<Note>: C<addendum> was introduced in Rakudo 2019.03.
+Returns additional explanations or hints.
 
 =end pod


### PR DESCRIPTION
## The problem

https://github.com/Raku/doc/issues/302

Right now, there is no standard way to document what things are part of what version. As the documentation is written by a lot of people, eventually people start to write different things in different styles. Given we render this _very important_ text just as the usual text, it is really hard for the user to actually see this important info immediately.

## Solution provided

The discussion in the ticket mentioned suggests Pod6 tags, because "IMO the metadata tags is the way to go: they're trivial to implement, simple to use, and they can always be converted to branches or whatever we need in the future, with a simple porting program.".

Right now, configuration of paragraphs is ignored by most tools, but such metadata creates an opportunity for tools to render
these blocks in a clear way, stating this is a versioned thing.

## Important note

In this PR I _purposely_ went with a simplest way, just "versioned" tag with a direction of the text, stating something is versioned.

This results in e.g.:

![2020-11-15-204701_1920x1080_scrot](https://user-images.githubusercontent.com/5764435/99193759-cb4dba80-2783-11eb-8391-070d75244302.png)

Let's discuss here and settle the final syntax we have to support && render eventually!