### PR TITLE
Document behavior of the + slurpy

### DIFF
--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -563,7 +563,8 @@ two nuances:
 
 =item L<List|/type/List>s created with a L<C<,>|/routine/,> at the top level only count as one L<Iterable|/type/Iterable>.
 
-This can be achieved by using a slurpy with a C<+> or C<+@> instead of C<**>:
+This can be achieved by using a slurpy with a
+L<C<+>|/type/Signature#index-entry-trait__is_raw> or C<+@> instead of C<**@>:
 
     sub grab(+@a) { "grab $_".say for @a }
 

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -1081,6 +1081,7 @@ designers.
 X<|trait, is raw>
 The L<C<is raw> trait|/type/Parameter#method_raw> is automatically applied to
 parameters declared with a L<backslash|/language/variables#Sigilless_variables>
+or a L<plus sign|#Single_argument_rule_slurpy>
 as a "sigil", and may also be used to make normally sigiled parameters behave
 like these do. In the special case of slurpies, which normally produce an
 C<Array> full of C<Scalar>s as described above, C<is raw> will instead cause


### PR DESCRIPTION
The difference between `+` and `+@` slurpies was not clear.