### PR TITLE
Make user aware of the risk of using qqx

### DIFF
--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -447,11 +447,6 @@ command, then the C<qqx> shell quoting construct should be used:
     my $world = "there";
     say qqx{echo "hello $world"};  # OUTPUT: «hello there␤»
 
-Be aware of the content of the Raku variable used within an external command, a malicious content can be use to execute arbitrary code:
-
-    my $world = "there\";rm -rf /path/to/dir\"";
-    say qqx{echo "hello $world"};  # OUTPUT: «hello there␤»
-
 Again, the output of the external command can be kept in a variable:
 
     my $word = "cool";
@@ -460,6 +455,8 @@ Again, the output of the external command can be kept in a variable:
     my $output = qqx{grep $option $word $file};
     # runs the command: grep -i cool /usr/share/dict/words
     say $output;      # OUTPUT: «Cooley␤Cooley's␤Coolidge␤Coolidge's␤cool␤...»
+
+Be aware of the content of the Raku variable used within an external command; malicious content can be used to execute arbitrary code. See L<qqx traps|/language/traps/Beware_of_variables_used_within_qqx>
 
 See also L<run|/routine/run> and L<Proc::Async|/type/Proc::Async> for
 better ways to execute external commands.

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -447,6 +447,11 @@ command, then the C<qqx> shell quoting construct should be used:
     my $world = "there";
     say qqx{echo "hello $world"};  # OUTPUT: «hello there␤»
 
+Be aware of the content of the Raku variable used within an external command, a malicious content can be use to execute arbitrary code:
+
+    my $world = "there\";rm -rf /path/to/dir\"";
+    say qqx{echo "hello $world"};  # OUTPUT: «hello there␤»
+
 Again, the output of the external command can be kept in a variable:
 
     my $word = "cool";

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -456,7 +456,7 @@ Again, the output of the external command can be kept in a variable:
     # runs the command: grep -i cool /usr/share/dict/words
     say $output;      # OUTPUT: «Cooley␤Cooley's␤Coolidge␤Coolidge's␤cool␤...»
 
-Be aware of the content of the Raku variable used within an external command; malicious content can be used to execute arbitrary code. See L<qqx traps|/language/traps/Beware_of_variables_used_within_qqx>
+Be aware of the content of the Raku variable used within an external command; malicious content can be used to execute arbitrary code. See L<C<qqx> traps|/language/traps/Beware_of_variables_used_within_qqx>
 
 See also L<run|/routine/run> and L<Proc::Async|/type/Proc::Async> for
 better ways to execute external commands.

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -654,10 +654,7 @@ my $world = "there\";rm -rf /path/to/dir\"";
 say qqx{echo "hello $world"};
 # OUTPUT: «hello there␤»
 
-The above code will also delete I</path/to/dir>. You can avoid this problem by making sure the variable content does not have shell special characters.
-
-Or use L<run|/routine/run> and L<Proc::Async|/type/Proc::Async> for
-better ways to execute external commands.
+The above code will also delete I</path/to/dir>, you can avoid this problem by making sure the variable content does not have shell special characters, or use L<run|/routine/run> and L<Proc::Async|/type/Proc::Async> for better ways to execute external commands.
 
 =head2 Strings are not iterable
 

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -645,6 +645,20 @@ my $a = 1;
 say Q:c«{$a}()$b()»;
 # OUTPUT: «1()$b()␤»
 
+=head2 Beware of variables used within C<qqx>
+
+Variables within C<qqx[]> can introduce a security hole; the variable content can be set to well-crafted string and execute arbitrary code:
+
+=for code
+my $world = "there\";rm -rf /path/to/dir\"";
+say qqx{echo "hello $world"};
+# OUTPUT: «hello there␤»
+
+The above code will also delete I</path/to/dir>. You can avoid this problem by making sure the variable content does not have shell special characters.
+
+Or use L<run|/routine/run> and L<Proc::Async|/type/Proc::Async> for
+better ways to execute external commands.
+
 =head2 Strings are not iterable
 
 There are methods that L<Str|/type/Str> inherits from L<Any|/type/Any> that work


### PR DESCRIPTION
## The problem

It is not clear from `qqx` examples that it can be used to execute arbitrary code if the user did not take the necessary precautions to prevent such issue.

## Solution provided

Add example in traps page to show how the content of a variable used by `qqx` can be used to execute malicious code, also warned the user about it in quoting page. so that the user is aware of such cases before deciding to use `qqx`

Note: please let me know about any grammar/punctuation corrections.