### PR TITLE
Improve documentation of Map.new

### DIFF
--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -56,17 +56,21 @@ Defined as:
 
 Creates a new Map from a list of alternating keys and values, with
 L<the same semantics|/language/hashmap#Hash_assignment> as described
-in the L<Hashes and maps|/language/hashmap> documentation, B<except>
-for literal pair handling. To ensure pairs correctly get passed, add
-extra parentheses around all the arguments.
+in the L<Hashes and maps|/language/hashmap> documentation, but also
+accepts C<Pair>s instead of separate keys and values. Use the
+L<grouping operator|/language/operators#term_(_)> or quote the key to
+ensure that a literal pair is not interpreted as a named argument.
 
     my %h = Map.new('a', 1, 'b', 2);
 
     # WRONG: :b(2) interpreted as named argument
-    say Map.new('a', 1, :b(2) ).keys; # OUTPUT: «(a)␤»
+    say Map.new('a', 1, :b(2)).keys; # OUTPUT: «(a)␤»
 
-    # RIGHT: :b(2) interpreted as part of Map's contents
-    say Map.new( ('a', 1, :b(2)) ).keys; # OUTPUT: «(a b)␤»
+    # RIGHT: :b(2) interpreted as Pair because of extra parentheses
+    say Map.new( ('a', 1, :b(2)) ).keys.sort; # OUTPUT: «(a b)␤»
+
+    # RIGHT: 'b' => 2 always creates a Pair
+    say Map.new('a', 1, 'b' => 2).keys.sort; # OUTPUT: «(a b)␤»
 
 A shorthand syntax for creating Maps is provided:
 


### PR DESCRIPTION
There are two ways to ensure that a literal pair is not interpreted
as a named argument. Quoting the key is arguably the clearest.