### PR TITLE
Improve documentation of Hash.push

### DIFF
--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -313,9 +313,9 @@ its return value will be used instead of the original C<@list>'s item:
 
 Defined as:
 
-    multi method push(Hash:D: *@new)
+    method push(Hash:D: +new)
 
-Adds the C<@new> elements to the hash with the same semantics as hash
+Adds the C<new> elements to the hash with the same semantics as hash
 assignment, but with three exceptions:
 
 =item The hash isn't emptied first, i.e. old pairs are not deleted.
@@ -336,15 +336,13 @@ Example:
     %h.push('c' => 4);              # a => [1,1,1,1,1], b => 3, c => 4
     push %h, 'd' => 5;              # a => [1,1,1,1,1], b => 3, c => 4, d => 5
 
-Please note that C<Pair>s or
-L<colon pairs|/language/glossary#index-entry-Colon_Pair> as arguments to push
-will be treated as extra named arguments and as such wont end up the C<Hash>.
-The same applies to the sub C<push>.
+Please note that literal pairs in the argument list may be interpreted as
+L<named arguments|/type/Capture> and as such won't end up in the C<Hash>.
+The C<push> subroutine will throw if it receives a named argument.
 
     my %h .= push(e => 6);
-    push %h, f => 7;
-    say %h.raku;
-    # OUTPUT: «{}␤»
+    try push %h, f => 7;
+    say %h.raku; # OUTPUT: «{}␤»
 
 Also note that push can be used as a replacement for assignment during hash
 initialization very useful ways. Take for instance the case of an inverted


### PR DESCRIPTION
* correct signature
* sub `push` throws if it receives an unexpected named argument
