### PR TITLE
Update testing.pod6

### DIFF
--- a/doc/Language/testing.pod6
+++ b/doc/Language/testing.pod6
@@ -177,13 +177,13 @@ if they fail to load.
 
 =head1 Testing exceptions
 
-L<C<dies-ok>|/type/Test#dies-ok> and L<C<lives-ok>|/type/Test#lives-ok> are
+L<C<dies-ok>|/type/Test#sub_dies-ok> and L<C<lives-ok>|/type/Test#sub_lives-ok> are
 opposites ways of testing code; the first checks that it throws an exception,
-the second that it does not; L<C<throws-like>|/type/Test#throws-like> checks
+the second that it does not; L<C<throws-like>|/type/Test#sub_throws-like> checks
 that the code throws the specific exception it gets handed as an argument;
-L<C<fails-like>|/type/Test#fails-like>, similarly, checks if the code returns a
-specific type of L<Failure|/type/Failure>. L<C<eval-dies-ok>|/type/Test#eval-dies-ok> and
-L<C<eval-lives-ok>|/type/Test#eval-lives-ok> work similarly on strings that are
+L<C<fails-like>|/type/Test#sub_fails-like>, similarly, checks if the code returns a
+specific type of L<Failure|/type/Failure>. L<C<eval-dies-ok>|/type/Test#sub_eval-dies-ok> and
+L<C<eval-lives-ok>|/type/Test#sub_eval-lives-ok> work similarly on strings that are
 evaluated prior to testing.
 
 =head1 Grouping tests


### PR DESCRIPTION
Fix anchors in links under the "Testing exceptions" section.

## The problem
Anchors broken on links under the "Testing exceptions" section.

## Solution provided
Fixed anchors in links under the "Testing exceptions" section.