### PR TITLE
Rephrase descriptions

### DIFF
--- a/doc/Type/Test.pod6
+++ b/doc/Type/Test.pod6
@@ -268,8 +268,8 @@ is-approx $value, $expected, :$abs-tol, :$rel-tol, 'test description';
 
 =head3 Absolute tolerance
 
-When an absolute tolerance is set, it's used as the actual maximum value by
-which the C<$value> and C<$expected> can differ. For example:
+When an absolute tolerance is set, it's used as the actual maximum value
+by which the first and the second parameters can differ. For example:
 
 =begin code :preamble<use Test;>
 is-approx 3, 4, 2; # success
@@ -341,7 +341,7 @@ Defined as:
     multi sub is-deeply(Mu $got, Seq:D $expected, $reason = '')
     multi sub is-deeply(Mu $got, Mu $expected, $reason = '')
 
-Marks a test as passed if C<$value> and C<$expected> are equivalent, using the
+Marks a test as passed if the first and second parameters are equivalent, using the
 same semantics as the L<eqv operator|/routine/eqv>. This is the best way to
 check for equality of (deep) data structures. The function accepts an optional
 description of the test as the last argument.
@@ -487,9 +487,10 @@ Use it this way:
 =for code :preamble<use Test;>
 like 'foo', /fo/, 'foo looks like fo';
 
-Marks a test as passed if the C<$value>, when coerced to a string, matches the
-C<$expected-regex>.  The function accepts an optional description of the
-test with a default value printing the expected match.
+Marks a test as passed if the first parameter when coerced to a string,
+matches the regular expression specified as the second parameter.
+The function accepts an optional description of the test with a default
+value printing the expected match.
 
 =head2 sub unlike
 
@@ -502,9 +503,10 @@ Used this way:
 =for code :preamble<use Test;>
 unlike 'foo', /bar/, 'foo does not look like bar';
 
-Marks a test as passed if the C<$value>, when coerced to a string, does B<not>
-match the C<$expected-regex>.  The function accepts an optional description
-of the test, which defaults to printing the text that did not match.
+Marks a test as passed if the first parameter, when coerced to a string,
+does B<not> match the regular expression specified as the second
+parameter.  The function accepts an optional description of the test,
+which defaults to printing the text that did not match.
 
 =head2 sub use-ok
 


### PR DESCRIPTION
... to untie them from the parameters' names
