### PR TITLE
Update haskell-to-p6.pod6 — section Fold

### DIFF
--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -444,7 +444,7 @@ Fold in Haskell is called Reduce in Raku.
     =begin code
     my @numbers = {...};
     reduce { $^a + $^b }, 0, |@numbers;
-    @numbers.reduce({$^a + $^b}, with => 0)
+    @numbers.reduce: {$^a + $^b}
     =end code
 
 However, in Raku, if you want to use an infix operator (+ - / % etc)
@@ -452,8 +452,8 @@ there is a nice little helper called the Reduction metaoperator.
 
     =begin code
     my @numbers = {...};
-    [+] @numbers    # This is the same
-    [+] 0, @numbers # as this
+    [+] @numbers     # This is the same
+    [+] 0, |@numbers # as this
     =end code
 
 It inserts the operator in between all values in the list and produces a result, just like Fold.


### PR DESCRIPTION
## The problem
`reduce` has not named parameter `with`.
In `[+] 0, @numbers`, `@numbers` must be slipped.

## Solution provided
This PR removes the named parameter `with`.
`[+] 0, |@numbers`