### PR TITLE
Fix slip example error

### DIFF
--- a/doc/Type/Slip.pod6
+++ b/doc/Type/Slip.pod6
@@ -36,7 +36,7 @@ it behaves closer to the C<.Slip> method than the C<slip> subroutine.
 =for code
 my $l = (1, 2, 3);
 say (1, slip 2, 3).raku;  # says (1, 2, 3)      , slips 2, 3 into (1, …)
-say (0, slip $l).raku;    # says (0, $(1, 2, 3)), $l does not break apart
+say (0, slip $l).raku;    # says (0, 1, 2, 3)   , slips from $l into (0, …)
 say (0, $l.Slip).raku;    # says (0, 1, 2, 3)   , slips from $l into (0, …)
 say (|$l).raku;           # says slip(1, 2, 3)  , breaks apart $l
 say (0, (|$l, 4), 5);     # says (0 (1 2 3 4) 5), slips from $l into (…, 4)

--- a/doc/Type/Slip.pod6
+++ b/doc/Type/Slip.pod6
@@ -35,14 +35,16 @@ it behaves closer to the C<.Slip> method than the C<slip> subroutine.
 
 =for code
 my $l = (1, 2, 3);
-say (1, slip 2, 3).raku;  # says (1, 2, 3)      , slips 2, 3 into (1, …)
-say (0, slip $l).raku;    # says (0, 1, 2, 3)   , slips from $l into (0, …)
-say (0, $l.Slip).raku;    # says (0, 1, 2, 3)   , slips from $l into (0, …)
-say (|$l).raku;           # says slip(1, 2, 3)  , breaks apart $l
-say (0, (|$l, 4), 5);     # says (0 (1 2 3 4) 5), slips from $l into (…, 4)
-say (0, ($l.Slip, 4), 5); # says (0 (1 2 3 4) 5), slips from $l into (…, 4)
-say (0, (slip $l, 4), 5); # says (0 (1 2 3) 4 5), slips ($l, 4) into (0, …, 5)
-say (0, ($l, 4).Slip, 5); # says (0 (1 2 3) 4 5), slips ($l, 4) into (0, …, 5)
+say (1, slip 2, 3).raku;  # says (1, 2, 3)          , slips 2, 3 into (1, …)
+say (0, slip $l, 4).raku; # says (0, $(1, 2, 3), 4) , $l does not break apart
+say (0, slip $l).raku;    # says (0, 1, 2, 3)       , slips from $l into (0, …)
+say (0, $l.Slip).raku;    # says (0, 1, 2, 3)       , slips from $l into (0, …)
+say (0, $l.Slip, 4).raku; # says (0, 1, 2, 3, 4)    , slips from $l into (0, …, 4)
+say (|$l).raku;           # says slip(1, 2, 3)      , breaks apart $l
+say (0, (|$l, 4), 5);     # says (0 (1 2 3 4) 5)    , slips from $l into (…, 4)
+say (0, ($l.Slip, 4), 5); # says (0 (1 2 3 4) 5)    , slips from $l into (…, 4)
+say (0, (slip $l, 4), 5); # says (0 (1 2 3) 4 5)    , slips ($l, 4) into (0, …, 5)
+say (0, ($l, 4).Slip, 5); # says (0 (1 2 3) 4 5)    , slips ($l, 4) into (0, …, 5)
 
 Loops that do not want to produce a value for an iteration use C<Slips>, rather
 than empty C<List>s to do so, as do C<if> statements that do not run their


### PR DESCRIPTION
## The problem
Slip documentation give example result that doesn't mesh with current rakudo result #3709

## Solution provided
Fixed example result. Checked with v6.c and the result in the original example was still wrong, so no versioning required.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
