### PR TITLE
Remove closures discussion from control flow document

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -39,24 +39,38 @@ executed.
     { say 2; say 3 };         # OUTPUT: «2␤3␤»
     say 4;                    # OUTPUT: «4␤»
 
-Unless it stands alone as a statement, a block simply creates a closure. The
-statements inside are not executed immediately. Closures are another topic
-and how they are used is explained
-L<elsewhere|/language/functions#Blocks_and_lambdas>. For now it is just
-important to understand when blocks run and when they do not:
+This might be useful if you are using an editor that offers code folding,
+so you can use these blocks to add visual sections to your code. 
+Blocks also create their own namespace, so can be used for
+scoping.
+ 
+    my $number = 1;
+    print $number ~ ', ';
+    { 
+        my $number = 2;
+        print $number ~ ', ';
+            {
+                my $number = 3;
+                print $number ~ ', ';
+            }
+    }
+    say $number;
+    # OUTPUT: «1, 2, 3, 1␤»
+
+However, if a block is used in an expression, then it doesn't run immediately. 
 
 =for code
-say "We get here";
-{ say "then here." };
-{ say "not here"; 0; } or die;
+say "We get here";             # Statement
+{ say "then here." };          # Block as statement
+{ say "not here"; 0; } or die; # Block used in expression
 
 In the above example, after running the first statement, the first block stands
-alone as a second statement, so we run the statement inside it. The second
-block is a closure, so instead, it makes an object of type C<Block> but does
-not run it. Object instances are usually considered to be true, so the code
-does not die, even though that block would evaluate to 0, were it to be
-executed. The example does not say what to do with the C<Block> object, so it
-just gets thrown away.
+alone as a second statement, so we enter the block. The following 
+block is used in an expression, so it makes an object of type C<Block>
+but does not run it. Object instances are usually considered to be true,
+so this code does not die, even though that block would evaluate to 0,
+were it to be executed. The example does not say what to do with the 
+C<Block> object, so it just gets thrown away.
 
 Most of the flow control constructs covered below are just ways to tell Raku
 when, how, and how many times, to enter blocks like that second block.

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -25,7 +25,7 @@ also be written as:
 
 Like many other languages, Raku uses C<blocks> enclosed by C<{> and C<}> to
 turn a sequence of statements into a
-[`Block`](https://docs.raku.org/type/Block) that acts as a single one. It is OK
+L<Block|/type/Block> that acts as a single one. It is OK
 to omit the semicolon between the last statement in a block and the closing
 C<}>.
 


### PR DESCRIPTION
## The problem
The whole explanation for the difference between block and closure is LTA #3670

## Solution provided
Removes reference to closures from this document. Blocks are closures, but it doesn't seem relevant in this context, and is a digression. Document is illustrating blocks that run in place v blocks that are controlled.

Adds some explanation of why you might use a block statement.

Also fixes link to Block type - which, perhaps, should have a reference to closures. Either a link to https://docs.raku.org/language/functions#index-entry-closures or a repeat of the information.
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
