### PR TITLE
Update syntax.pod6

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -178,7 +178,8 @@ if $age > 250 {     # catch obvious outliers
 
 Multi-line and embedded comments start with a hash character, followed by a
 backtick, and then some opening bracketing character, and end with the matching
-closing bracketing character. Only the paired characters (), {}, [], and <> are
+closing bracketing character. Whitespace is not permitted between the backtick and the
+bracketing character; it will be treated as a single-line comment. Only the paired characters (), {}, [], and <> are
 valid for bounding comment blocks. (Unlike matches and substitutions, where pairs
 such as !!, || or @ may be used.) The content can not only span multiple lines,
 but can also be embedded inline.
@@ -200,7 +201,9 @@ say "No more";
 =end code
 
 Curly braces inside the comment can be nested, so in C<#`{ a { b } c }>,
-the comment goes until the very end of the string. You may also use multiple
+the comment goes until the very end of the string. If the opening bracketing character
+occurs in the body of the comment, e.g. #`[ This is a box [ of stuff ]
+], it must have a paired closing character, as shown.  You may also use multiple
 curly braces, such as C<#`{{ double-curly-brace }}>, which might help
 disambiguate from nested delimiters. You can embed these comments in
 expressions, as long as you don't insert them in the middle of keywords or


### PR DESCRIPTION
Clarify rules about whitespace and bounding characters of multi-line comments.

## The problem         Confusion about some rules for multi-line comments


## Solution provided  Additional explanation of the rules
