### PR TITLE
Remove references to Str.sprintf

### DIFF
--- a/doc/Type/independent-routines.pod6
+++ b/doc/Type/independent-routines.pod6
@@ -638,11 +638,11 @@ Defined as:
      method printf (*@args)
      multi sub printf(Cool:D $format, *@args)
 
-As a method, takes the object as a format using
-L<the same language as C<Str.sprintf>|/routine/sprintf>; as a sub, its
-first argument will be
-the format string, and the rest of the arguments will be substituted in the
-format following the format conventions.
+Produces output according to a format.  The format used is the invocant
+(if called in method form) or the first argument (if called as a routine).
+The rest of the arguments will be substituted in the format following
+the format conventions.  See L<sprintf|/routine/sprintf> for details on
+acceptable format directives.
 
     "%s is %s".printf("þor", "mighty");    # OUTPUT: «þor is mighty»
     printf( "%s is %s", "þor", "mighty");  # OUTPUT: «þor is mighty»
@@ -658,10 +658,9 @@ Defined as:
     method sprintf(*@args)
     multi sub sprintf(Cool:D $format, *@args)
 
-Formats and returns a string, following
-L<the same language as C<Str.sprintf>|/routine/sprintf>, using as such
-format either the object (if called in method form) or the first argument (if
-called as a routine)
+Returns a string according to a format as described below.  The format
+used is the invocant (if called in method form) or the first argument
+(if called as a routine).
 
     sprintf( "%s the %d%s", "þor", 1, "st").put; # OUTPUT: «þor the 1st␤»
     sprintf( "%s is %s", "þor", "mighty").put;   # OUTPUT: «þor is mighty␤»


### PR DESCRIPTION
While here minor rewriting of {s,}printf's descriptions, including the
acknowledgment that this document's sprintf section holds the reference
to printf format description :-)
