### PR TITLE
Document new Proc(::Async) arg `arg0`

### DIFF
--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -201,10 +201,14 @@ shell 'ls /qqq';
 
 =head2 method spawn
 
-    method spawn(*@args ($, *@), :$cwd = $*CWD, Hash() :$env = %*ENV, :$win-verbatim-args = False --> Bool:D)
+    method spawn(*@args ($, *@), :$cwd = $*CWD, Hash() :$env = %*ENV, :$arg0,
+                 :$win-verbatim-args = False --> Bool:D)
 
 Runs the C<Proc> object with the given command, argument list, working directory,
 and environment.
+
+If C<:arg0> is set to a value, that value is passed as arg0 to the process
+instead of the program name.
 
 On Windows the flag C<$win-verbatim-args> disables all automatic quoting of
 process arguments. See L<this blog|https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way>

--- a/doc/Type/Proc/Async.pod6
+++ b/doc/Type/Proc/Async.pod6
@@ -116,10 +116,10 @@ An example of piping several commands like C<echo "Hello, world" | cat -n>:
 
 =head2 method new
 
-    multi method new(*@ ($path, *@args), :$w, :$enc, :$translate-nl,
+    multi method new(*@ ($path, *@args), :$w, :$enc, :$translate-nl, :$arg0,
                      :$win-verbatim-args = False,
                      :$started = False --> Proc::Async:D)
-    multi method new(   :$path, :@args,  :$w, :$enc, :$translate-nl,
+    multi method new(   :$path, :@args,  :$w, :$enc, :$translate-nl, :$arg0,
                      :$win-verbatim-args = False,
                      :$started = False --> Proc::Async:D)
 
@@ -137,6 +137,9 @@ to C<utf8>.
 If C<:translate-nl> is set to C<True> (default value), OS-specific
 newline terminators (e.g. C<\r\n> on Windows) will be automatically
 translated to C<\n>.
+
+If C<:arg0> is set to a value, that value is passed as arg0 to the process
+instead of the program name.
 
 The C<:started> attribute is set by default to C<False>, so that you need to
 start the command afterwards using

--- a/doc/Type/independent-routines.pod6
+++ b/doc/Type/independent-routines.pod6
@@ -535,6 +535,7 @@ sub run(
     Str:D :$nl = "\n",
     :$cwd = $*CWD,
     Hash() :$env = %*ENV,
+    :$arg0,
     :$win-verbatim-args = False
 --> Proc:D)
 


### PR DESCRIPTION
Add documentation for the new Proc::Async :arg0 argument implemented in [rakudo/rakudo#4166](https://github.com/rakudo/rakudo/pull/4166).