### PR TITLE
Largely rework the Object Tutorial

### DIFF
--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -5,11 +5,16 @@
 =SUBTITLE A tutorial about creating and using classes in Raku
 
 X<|OOP>
+Raku provides a rich built-in syntax for defining and using classes. It makes writing classes
+expressive and short for most cases, but also provides mechanisms to cover
+the rare corner cases.
 
-Raku has a rich built-in syntax for defining and using classes.
-
-A default constructor allows the setting of attributes for the created
-object:
+Like many other languages the C<class> keyword is used to define a
+class. In general one uses the C<has> keyword to add
+attributes and the C<method> keyword to add behaviors to a class. It is rarely necessary to explicitly write
+a constructor, as the default construction mechanism
+automatically initializes attributes from the default constructors named parameters. The default constructor
+is called C<new>. The following example showcases this:
 
 =begin code
 class Point {
@@ -33,57 +38,80 @@ my $r = Rectangle.new(lower => Point.new(x => 0, y => 0),
 say $r.area(); # OUTPUT: «100␤»
 =end code
 
-In the two classes, the default constructor is being used. This
-constructor will use named parameters in its invocation: C«Point.new(x =>
-0, y => 0)».
+Don't get confused by the C<$.> and C<$!>. They are called twigils and will be explained further down.
 
-You can also provide your own constructor and C<BUILD> implementation.
-You need to do it for cases in which there are private attributes that
-might need to be populated during object construction, as in the
-example below:
+To add custom logic to the construction process, one can use the C<TWEAK> submethod.
 
 =begin code
-# Example taken from
-# https://medium.freecodecamp.org/a-short-overview-of-object-oriented-software-design-c7aa0a622c83
-class Hero {
-    has @!inventory;
-    has Str $.name;
-    submethod BUILD( :$name, :@inventory ) {
-        $!name = $name;
-        @!inventory = @inventory
-    }
+class Point {
+    has Int $.x;
+    has Int $.y;
 
-    method act {
-        return @!inventory.pick;
+    submethod TWEAK(:$log) {
+        say "Constructing Point ($!x|$!y)" if $log;
     }
 }
-my $hero = Hero.new(:name('Þor'),
-                    :inventory(['Mjölnir','Chariot','Bilskirnir']));
-say $hero.act;
+
+my $p = Point.new(x => 1, y => 2, :log);
+# OUTPUT: Constructing Point (1|2)
 =end code
 
-In this case, we I<encapsulate> the private attribute C<@!inventory>; but
-private instance variables cannot be set by the default constructor, which is
-why we add a C<BUILD> submethod that takes care of that.
+Just remember to always make C<TWEAK> a C<submethod> and not a normal C<method> N<If in a class hierarchy a class contains a C<TWEAK> method (declared as a C<method> instead of a C<submethod>) that method is inherited to its subclass and will thus be called twice during construction of the subclass! The effects are even worse with C<BUILD>, but that is best read about in the L<Object Construction Reference|/language/objects#Object_construction>.>.
 
-The following, more elaborate example, shows how a dependency handler might look
-in Raku.  It showcases custom constructors, private and public attributes,
-L<Submethod|/type/Submethod>s, methods, and various aspects of signatures. It's
-not a lot of code, and yet the result is interesting and useful.
+X<|DESTROY>
+X<|submethod DESTROY>
+
+C<DESTROY> is the submethod that gets called when an object is garbage
+collected. That is going to happen only if the runtime needs the memory, so we
+can't rely on when it's going to happen. In particular, it could happen in the
+middle of some running code in a thread, so we must take special care to not
+assume any context during that event. We can use it to close any kind of handles
+or supplies or delete temporary files that are no longer going to be used.
+
+=begin code
+my $in_destructor = 0;
+
+class Foo {
+    submethod DESTROY { $in_destructor++ }
+}
+
+my $foo;
+for 1 .. 6000 {
+    $foo = Foo.new();
+}
+
+say "DESTROY called $in_destructor times";
+=end code
+
+This might print something like C<DESTROY called 5701 times> and possibly only kicks
+in after we have stomped over former instances of C<Foo> a few thousand times. We also can't
+rely, on the order of destruction.
+
+Same as C<TWEAK>, make sure to always declare C<DESTROY> as a C<submethod>.
+
+=head1 The Task example
+
+X<|class>
+X<|classes>
+
+X<|state>
+X<|has>
+X<|classes,has>
+X<|behavior>
+X<|classes,behavior>
+
+The following piece of code implements a dependency handler. It's not a lot of code, and yet the result is interesting and useful.
+It will be used as an example throughout the following sections.
 
 =begin code
 class Task {
-    has      &!callback;
-    has Task @!dependencies;
+    has      &!callback     is built;
+    has Task @!dependencies is built;
     has Bool $.done;
 
-    # Normally doesn't need to be written
     method new(&callback, *@dependencies) {
         return self.bless(:&callback, :@dependencies);
     }
-
-    # BUILD is the equivalent of a constructor in other languages
-    submethod BUILD(:&!callback, :@!dependencies) { }
 
     method add-dependency(Task $dependency) {
         push @!dependencies, $dependency;
@@ -112,125 +140,6 @@ my $eat =
 $eat.perform();
 =end code
 
-In this case, C<BUILD> is needed since we have overridden the default
-C<new> constructor. C<bless> is eventually invoking it with the two named
-arguments that correspond to the two properties without a default value. With
-its signature, C<BUILD> converts the two positionals to the two attributes,
-C<&!callback> and C<@!dependencies>, and returns the object (or turns it in to
-the next phase, C<TWEAK>, if available).
-
-Declaring C<new> as a C<method> and not as a C<multi method> prevents us
-from using the default constructor; this implicit constructor uses the
-attributes as named parameters. This is one of the reasons why using
-C<new> as a method's name is discouraged. If you need to declare it anyway,
-use C<multi method new> if you do not want to disable the default constructor.
-
-C<TWEAK> is the last submethod to be called, and it has the
-advantage of having the object properties available without needing to
-use the metaobject protocol. It can be used, for instance, to assign
-values to instance variables based on the values of other attributes or
-instance variables:
-
-=begin code
-class Str-with-ID is Str {
-    my $.counter = 0;
-    has Str $.string;
-    has Int $.ID;
-
-    method TWEAK() {
-        $!ID = $.counter++;
-    }
-}
-
-say Str-with-ID.new(string => 'First').ID;  # OUTPUT: «0»
-say Str-with-ID.new(string => 'Second').ID; # OUTPUT: «1»
-=end code
-
-In this case, we need to compute C<$.ID> from the value of a counter that is a
-class variable, C<$.counter>, thus we simply assign a value to it and increment
-the counter at the same time. Please check also
-L<this section on C<TWEAK> in the Object Orientation (OO) document|/language/objects#index-entry-TWEAK>
-for the mechanics of object construction.
-
-X<|DESTROY>
-X<|submethod DESTROY>
-
-C<DESTROY> is the submethod that gets called when an object is garbage
-collected. That is going to happen only if the runtime needs the memory, so we
-can't rely on when it's going to happen. In particular, it could happen in the
-middle of some running code in a thread, so we must take special care to not
-assume any context during that event. We can use it to close any kind of handles
-or supplies or delete temporary files that are no longer going to be used.
-
-=begin code
-my $in_destructor = 0;
-
-class Foo {
-    submethod DESTROY { $in_destructor++ }
-}
-
-my $foo;
-for 1 .. 6000 {
-    $foo = Foo.new();
-}
-
-say "DESTROY called $in_destructor times";
-=end code
-
-This might print something like C<DESTROY called 5701 times>, but it only kicks
-in after we have stomped over former instances of C<Foo> 6000 times. We can't
-rely, however, on the order of destruction, for instance.
-
-=head1 Starting with class
-
-X<|class>
-X<|classes>
-
-X<|state>
-X<|has>
-X<|classes,has>
-X<|behavior>
-X<|classes,behavior>
-
-Raku, like many other languages, uses the C<class> keyword to define a
-class. The block that follows may contain arbitrary code, just as with
-any other block, but classes commonly contain state and behavior
-declarations. The example code includes attributes (state), introduced
-through the C<has> keyword, and behaviors, introduced through the C<method>
-keyword.
-
-X<|type object>
-X<|DEFINITE>
-X<|.DEFINITE>
-
-Declaring a class creates a new I<type object> which, by default, is installed
-into the current package (just like a variable declared with C<our> scope).
-This type object is an "empty instance" of the class. For example, types such as
-C<Int> and C<Str> refer to the type object of one of the Raku built-in
-classes. The example above uses the class name C<Task> so that other code can
-refer to it later, such as to create class instances by calling the C<new>
-method.
-
-You can use the C<.DEFINITE> method to find out if what you have is an instance
-or a type object:
-
-=begin code
-say Int.DEFINITE; # OUTPUT: «False␤» (type object)
-say 426.DEFINITE; # OUTPUT: «True␤»  (instance)
-
-class Foo {};
-say Foo.DEFINITE;     # OUTPUT: «False␤» (type object)
-say Foo.new.DEFINITE; # OUTPUT: «True␤»  (instance)
-=end code
-
-You can also use type "smileys" to only accept instances or type objects:
-
-=begin code
-multi foo (Int:U) { "It's a type object!" }
-multi foo (Int:D) { "It's an instance!"   }
-say foo Int; # OUTPUT: «It's a type object!␤»
-say foo 42;  # OUTPUT: «It's an instance!␤»
-=end code
 
 X<|attributes>
 X<|classes,attributes>
@@ -238,23 +147,25 @@ X<|encapsulation>
 X<|classes,encapsulation>
 =head1 State
 
-In the C<Task> class, the first three lines inside the block all
+In the C<Task> class above, the first three lines inside the block all
 declare attributes (called I<fields> or I<instance storage> in other
 languages). Just as a C<my> variable cannot be accessed from outside its
 declared scope, attributes are not accessible outside of the class.
 This I<encapsulation> is one of the key principles of object oriented design.
 
-The first declaration specifies instance storage for a callback (i.e.,
+=head2 Twigil C<$!>
+
+The first declaration specifies instance storage for a callback (i.e.
 a bit of code to invoke in order to perform the task that an object
 represents):
 
 =for code
-has &!callback;
+has &!callback is built;
 
 X<|sigils,&>
 X<|twigils>
 X<|twigils,!>
-
+(The C<is built> is explained further down.)
 The C<&> sigil indicates that this attribute represents something invocable.
 The C<!> character is a I<twigil>, or secondary sigil. A twigil forms part
 of the name of the variable. In this case, the C<!> twigil emphasizes that
@@ -263,13 +174,15 @@ this attribute is private to the class.
 The second declaration also uses the private twigil:
 
 =for code :preamble<class Task {}>
-has Task @!dependencies;
+has Task @!dependencies is built;
 
 However, this attribute represents an array of items, so it requires the
 C<@> sigil. These items each specify a task that must be completed before
 the present one is completed. Furthermore, the type declaration on this
 attribute indicates that the array may only hold instances of the C<Task>
 class (or some subclass of it).
+
+=head2 Twigil C<$.>
 
 The third attribute represents the state of completion of a task:
 
@@ -300,6 +213,8 @@ without having to write the method by hand. You are free instead to write
 your own accessor method, if at some future point you need to do something
 more complex than returning the value.
 
+=head2 C<is rw> trait
+
 X<|traits,is rw>
 Note that using the C<.> twigil has created a method that will provide
 read-only access to the attribute. If instead the users of this object
@@ -311,6 +226,35 @@ has Bool $.done is rw;
 
 The C<is rw> trait causes the generated accessor method to return a container
 so external code can modify the value of the attribute.
+
+=head2 C<is built> trait
+
+=for code
+has &!callback is built;
+
+X<|traits,is built>
+By default private attributes are not automatically set by the default constructor. (They are private after
+all.) In the above example we want to allow the user to provide the initial value but keep the attribute
+otherwise private. The C<is built> trait allows to do just that.
+
+One can also use it to do the opposite for public attributes, i.e. prevent them to be automatically
+initialized with a user provided value, but still generate the accessor method:
+
+=for code
+has $.done is built(False);
+
+=head2 C<is required> trait
+
+X<|traits,is required>
+Providing a value for an attribute during initialization is optional by default. Which in the task example
+makes sense for all three, the C<&!callback>, the C<@!dependencies> and the C<$.done> attribute. But lets say
+we want to add another attribute, C<$.name>, that holds a tasks name and we want to force the user to
+provide a value on initialization. We can do that as follows:
+
+=for code
+has $.name is required;
+
+=head2 Default values
 
 You can also supply default values to attributes (which works equally for
 those with and without accessors):
@@ -340,91 +284,40 @@ C<.an-attribute()> syntax. See also
 L<the C<is rw> trait on classes|/language/typesystem#trait_is_rw> for examples
 on how this works on the whole class.
 
+=head2 Class variables
+
 X<|class variables>
 A class declaration can also include I<class variables>, which are variables
 whose value is shared by all instances, and can be used for things like
-counting the number of instantiations or any other shared state.
-Class variables use the same syntax as the rest of the attributes, but are
-declared as C<my> or C<our>, depending on the scope; C<our> variables will be
-shared by subclasses, since they have package scope.
+counting the number of instantiations or any other shared state. So I<class variables> act similar to
+I<static> variables known from other programming languages.
+They look the same as normal (non class) lexical variables (and in fact they are the same):
 
 =begin code
 class Str-with-ID is Str {
     my $counter = 0;
-    our $hierarchy-counter = 0;
     has Str $.string;
-    has Int $.ID;
+    has Int $.ID is built(False);
 
-    method TWEAK() {
+    submethod TWEAK() {
         $!ID = $counter++;
-        $hierarchy-counter++;
     }
-
-}
-
-class Str-with-ID-and-tag is Str-with-ID {
-    has Str $.tag;
 }
 
 say Str-with-ID.new(string => 'First').ID;  # OUTPUT: «0␤»
 say Str-with-ID.new(string => 'Second').ID; # OUTPUT: «1␤»
-say Str-with-ID-and-tag.new( string => 'Third', tag => 'Ordinal' ).ID;
-# OUTPUT: «2␤»
-say $Str-with-ID::hierarchy-counter;       # OUTPUT: «4␤»
 =end code
 
-In this case, using C<new> might be the easiest way to initialize the C<$.ID>
-field and increment the value of the counter at the same time. C<new>, through
-C<bless>, will invoke the default C<BUILD>, assigning the values to their
-properties correctly. You can obtain the same effect using C<TWEAK>, which is
-considered a better practice by Raku experts. Please check L<the section on
-submethods|/language/classtut#index-entry-OOP> for an alternative example on how
-to do this. Since C<TWEAK> is called in every object instantiation, it's
-incremented twice when creating objects of class C<Str-with-ID-and-tag>; this is
-a I<class hierarchy> variable that is shared by all subclasses of
-C<Str-with-ID>. Additionally, class variables declared with package scope are
-visible via their fully qualified name (FQN), while lexically scoped class
-variables are "private".
-
-=head1 Static fields?
-
-Raku has no B<static> keyword. Nevertheless, any class may declare anything
-that a module can, so making a scoped variable sounds like a good idea.
-
-=begin code
-class Singleton {
-    my Singleton $instance;
-    method new {!!!}
-    submethod instance {
-        $instance = Singleton.bless unless $instance;
-        $instance;
-    }
-}
-=end code
-
-Class attributes defined by L<my|/syntax/my> or L<our|/syntax/our> may also be
-initialized when being declared, however we are implementing the Singleton
-pattern here and the object must be created during its first use. It is not 100%
-possible to predict the moment when attribute initialization will be executed,
-because it can take place during compilation, runtime or both, especially when
-importing the class using the L<use|/syntax/use> keyword.
-
-=begin code :preamble<class Foo {}; sub some_complicated_subroutine {}>
-class HaveStaticAttr {
-    my Foo $.foo = some_complicated_subroutine;
-}
-=end code
-
-Class attributes may also be declared with a secondary sigil – in a similar
-manner to instance attributes – that will generate read-only accessors if the
-attribute is to be public.
+The example shows how to subclass the core C<Str> class to extend it to also keep a unique ID.
+We compute C<$!ID> from the value of a counter that is a
+class variable, C<$counter> and simply assign and increment the value in C<TWEAK>.
 
 =head1 Methods
 
 X<|methods>
 X<|classes,methods>
 
-While attributes give objects state, methods give objects behaviors. Let's
+While attributes give objects state, methods give objects behaviors. Back to our C<Task> example. Let's
 ignore the C<new> method temporarily; it's a special type of method.
 Consider the second method, C<add-dependency>, which adds a new task to a
 task's dependency list:
@@ -519,13 +412,17 @@ Trust relationships are not subject to inheritance. To trust the global
 namespace, the pseudo package C<GLOBAL> can be used.
 
 X<|constructors>
-=head1 Constructors
+=head1 Construction
+
+The object construction mechanisms described up to now suffice for most use cases. But if one actually needs
+to tweak object construction more than said mechanisms allow, it's good to understand how object construction
+works in more detail.
 
 Raku is rather more liberal than many languages in the area of
 constructors. A constructor is anything that returns an instance of the
 class. Furthermore, constructors are ordinary methods. You inherit a
 default constructor named C<new> from the base class C<Mu>, but you are
-free to override C<new>, as this example does:
+free to override C<new>, as the Task example does:
 
 =begin code
 method new(&callback, *@dependencies) {
@@ -533,59 +430,50 @@ method new(&callback, *@dependencies) {
 }
 =end code
 
+=head2 bless
+
 X<|objects,bless>
 X<|bless>
-
 The biggest difference between constructors in Raku and constructors in
 languages such as C# and Java is that rather than setting up state on a
 somehow already magically created object, Raku constructors create the
-object themselves. The easiest way to do this is by calling the
+object themselves. They do this by calling the
 L<bless|/routine/bless> method, also inherited from L<Mu|/type/Mu>.
 The C<bless> method expects a set of named parameters to provide the initial
 values for each attribute.
 
 The example's constructor turns positional arguments into named arguments,
-so that the class can provide a nice constructor for its users. The first
+so that the class can provide a nicer constructor for its users. The first
 parameter is the callback (the thing which will execute the task). The rest
 of the parameters are dependent C<Task> instances. The constructor captures
 these into the C<@dependencies> slurpy array and passes them as named
 parameters to C<bless> (note that C<:&callback> uses the name of the
 variable – minus the sigil – as the name of the parameter).
+One should refrain from putting logic other than reformulating the parameters in the constructor, because
+constructor methods are not recursively called for parent classes. This is different from e.g. Java.
+
+Declaring C<new> as a C<method> and not as a C<multi method> prevents access to the default constructor.
+So if you intend to keep the default constructor available, use C<multi method new>.
+
+=head2 C<TWEAK>
+
+X<|TWEAK>
+After C<bless> has initialized the classes attributes from the passed values, it will in turn call C<TWEAK>
+for each class in the inheritance hierarchy.
+C<TWEAK> gets passed all the arguments passed to bless.
+This is where custom initialization logic should go.
+
+Again remember to always make C<TWEAK> a C<submethod> and not a normal C<method>. (Otherwise C<TWEAK>s in
+subclasses could prevent the C<TWEAK> of this class from running.)
+
+=head2 C<BUILD>
 
 X<|BUILD>
-Private attributes really are private. This means that C<bless> is not
-allowed to bind things to C<&!callback> and C<@!dependencies> directly. To
-do this, we override the C<BUILD> submethod, which is called on the brand
-new object by C<bless>:
-
-=begin code :preamble<has &.callback; has @.dependencies;>
-submethod BUILD(:&!callback, :@!dependencies) { }
-=end code
-
-Since C<BUILD> runs in the context of the newly created C<Task> object, it
-is allowed to manipulate those private attributes. The trick here is that
-the private attributes (C<&!callback> and C<@!dependencies>) are being used
-as the bind targets for C<BUILD>'s parameters. Zero-boilerplate
-initialization! See L<objects|/language/objects#Object_construction> for
-more information.
-
-The C<BUILD> method is responsible for initializing all attributes and must
-also handle default values:
-
-=begin code
-has &!callback;
-has @!dependencies;
-has Bool ($.done, $.ready);
-submethod BUILD(
-        :&!callback,
-        :@!dependencies,
-        :$!done = False,
-        :$!ready = not @!dependencies,
-    ) { }
-=end code
-
-See L<Object Construction|/language/objects#Object_construction> for more
-options to influence object construction and attribute initialization.
+It is possible to disable the automatic attribute initialization and perform the initialization of 
+attributes oneself. To do so one needs to write a custom C<BUILD> submethod. There are several edge cases one
+needs to be aware of and take into account though. This is detailed in the
+L<Object Construction Reference|/language/objects#Object_construction>. Because of the difficulty of using
+C<BUILD>, it is recommended to only make use of it when none of the other approaches described above suffices.
 
 =head1 Consuming our class
 
@@ -631,6 +519,41 @@ buying food
 cleaning kitchen
 making dinner
 eating dinner. NOM!
+=end code
+
+=head2 A word on types
+
+X<|type object>
+X<|DEFINITE>
+X<|.DEFINITE>
+
+Declaring a class creates a new I<type object> which, by default, is installed
+into the current package (just like a variable declared with C<our> scope).
+This type object is an "empty instance" of the class. For example, types such as
+C<Int> and C<Str> refer to the type object of one of the Raku built-in
+classes. One can call methods on these type objects. So there is nothing special
+with calling the C<new> method on a type object.
+
+You can use the C<.DEFINITE> method to find out if what you have is an instance
+or a type object:
+
+=begin code
+say Int.DEFINITE; # OUTPUT: «False␤» (type object)
+say 426.DEFINITE; # OUTPUT: «True␤»  (instance)
+
+class Foo {};
+say Foo.DEFINITE;     # OUTPUT: «False␤» (type object)
+say Foo.new.DEFINITE; # OUTPUT: «True␤»  (instance)
+=end code
+
+In function signatures one can use so called type "smileys" to only accept instances
+or type objects:
+
+=begin code
+multi foo (Int:U) { "It's a type object!" }
+multi foo (Int:D) { "It's an instance!"   }
+say foo Int; # OUTPUT: «It's a type object!␤»
+say foo 42;  # OUTPUT: «It's an instance!␤»
 =end code
 
 =head1 Inheritance
@@ -863,10 +786,10 @@ But there are other applications too. For instance, a routine that serializes
 objects to a bunch of bytes needs to know the attributes of that object,
 which it can find out via introspection.
 
-=head2 X<Overriding default gist method>
+=head2 X<Overriding C<gist>>
 
-Some classes might need its own version of C<gist>, which overrides the terse
-way it is printed when called to provide a default representation of the class.
+Some classes might need their own version of C<gist>, which overrides the terse
+way they are printed when called to provide a default representation of the class.
 For instance, L<exceptions|/language/exceptions#Uncaught_exceptions> might want
 to write just the C<payload> and not the full object so that it is clearer what
 to see what's happened. However, this isn't limited to exceptions; you can


### PR DESCRIPTION
With the advent of `is built` all the common use-cases of object
construction are now covered by our attribute syntax. This means that the
need to fall back to using `BUILD` has lessened enormously. Given that
`BUILD` has a number of behaviours that are non-obvious and require
knowing and understanding them, it makes sense to consider `BUILD` the
last resort mechanism to use when all else fails and recommend using
automatic attribute initialization and `TWEAK` for everything else.
Communicating this clearly in our object tutorial is very valuable, it
shows newcomers the sane default first. We do not want to send them off in
the wrong direction as `BUILD` has proven to be a stumbling block for new
users numerous times.

(Probably not entirely complete) List of Changes:

- Try to be more structured by reordering things.
- Add more headings for easier navigation.
- Explain `is built`.
- Rework examples to not use `BUILD` anymore.
- Remove wrong explanation of the `Task` example stating one would need a
  `BUILD` when custom constructors are used.
- Remove in-depth explanation of `BUILD`. Add respective documentation for
  `TWEAK`. `BUILD` is still explained in detail in the Object Reference.
- State that `BUILD` is only intended for advanced use-cases.
- Remove `Hero` example which is made obsolete by `is built`.
- Simplify the `Str-with-ID` example and remove bits promoting making
  `TWEAK` a `method` instead of a `submethod`.
- Remove confusing bit about `my` vs `our` class variables.
- Rename `Static Fields?` heading to `Class variables`
- Replace the `Singleton` example with the `Str-with-ID` example as that
  shows the "variable shared by all instances" aspect better than a
  singleton (of which there usually only is one).