### PR TITLE
Use absolute path to routine's documentation

### DIFF
--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -81,7 +81,7 @@ arguments or in a L<slip|/type/Slip>:
    my @c = <E F>;
    say @a.push: @c.Slip;        # OUTPUT: «[1 a b E F]␤»
 
-See L<method append|#method_append> if you want to append multiple values that
+See L<method append|/type/Array#method_append> if you want to append multiple values that
 are produced by a single non-slipping C<Iterable>.
 
 =head2 method append
@@ -100,7 +100,7 @@ The C<Array> class adds the provided values to the end of the array, and returns
 the modified array. It throws if the invocant array or an argument that
 requires flattening L<is lazy|/routine/is-lazy>.
 
-The difference with method L<method push|#method_push> is that if you append a
+The difference with method L<method push|/type/Array#method_push> is that if you append a
 B<single> non-L<itemized|/language/mop#VAR> C<Iterable>, C<append> will try to
 flatten it. For example:
 
@@ -202,10 +202,10 @@ Example:
     @foo.unshift: 1, 3 ... 11;
     say @foo;                   # OUTPUT: «[(1 3 5 7 9 11) a b c]␤»
 
-The notes in L<the documentation for method push|#method_push> apply,
+The notes in L<the documentation for method push|/type/Array#method_push> apply,
 regarding how many elements are added to the array.
 
-The L<routine prepend|#routine_prepend> is the equivalent for adding multiple elements from one
+The L<routine prepend|/type/Array#routine_prepend> is the equivalent for adding multiple elements from one
 list or array.
 
 =head2 routine prepend


### PR DESCRIPTION
When a type's routine documentation is rendered as a part of
'/routine/RoutineName', a link to the documentation of another routine for
the same type needs to provided with an absolute path ('/type/Type#...').
