### PR TITLE
Input Unicode characters with two-key combinations

### DIFF
--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -76,6 +76,75 @@ ibus-daemon command as shown above, with the C<--desktop> option set to
 C<--desktop=plasma>. Click OK. It should now launch automatically when you
 log in again.
 
+=head3 How to enter Unicode characters using a two-key combination
+
+Using the XCompose input method it is possible to enter Unicode characters using simple two-key combinations.
+Here's an example of a configuration which would enable entering all the Unicode characters used by Raku.
+This example uses both Super keys as C<dead keys>. For example, to enter the C<π> symbol one has to press and
+release the right C<Super> (or "Windows") key, then press and release the C<p> key.
+
+=for code :lang<shell>
+<Super_R> <less>               : "«" guillemotleft
+<Super_R> <greater>            : "»" guillemotright
+<Super_R> <minus>              : "⁻"   U207B
+<Super_R> <0>                  : "⁰"   U2070
+<Super_R> <1>                  : "¹"   U00B9
+<Super_R> <2>                  : "²"   U00B2
+<Super_R> <3>                  : "³"   U00B3
+<Super_R> <4>                  : "⁴"   U2074
+<Super_R> <5>                  : "⁵"   U2075
+<Super_R> <6>                  : "⁶"   U2076
+<Super_R> <7>                  : "⁷"   U2077
+<Super_R> <8>                  : "⁸"   U2078
+<Super_R> <9>                  : "⁹"   U2079
+<Super_R> <asterisk>           : "×"   U00D7
+<Super_R> <slash>              : "÷"   U00F7
+<Super_R> <E>                  : "𝑒"   U1D452
+<Super_R> <p>                  : "π"   U03C0
+<Super_R> <t>                  : "τ"   U03C4
+<Super_R> <grave>              : "‘"   U2018
+<Super_R> <apostrophe>         : "’"   U2019
+<Super_R> <comma>              : "‚"   U201A
+<Super_R> <colon>              : "“"   U201C
+<Super_R> <quotedbl>           : "”"   U201D
+<Super_R> <L>                  : "„"   U201E
+<Super_R> <period>             : "…"   U2026
+<Super_R> <bracketleft>        : "≡"   U2261
+<Super_R> <bracketright>       : "≢"   U2262
+<Super_L> <8>                  : "∞"   U221E
+<Super_L> <O>                  : "∅"   U2205
+<Super_L> <e>                  : "∈"   U2208
+<Super_L> <E>                  : "∉"   U2209
+<Super_L> <3>                  : "∋"   U220B
+<Super_L> <numbersign>         : "∌"   U220C
+<Super_L> <minus>              : "−"   U2212
+<Super_L> <slash>              : "∖"   U2216
+<Super_L> <o>                  : "∘"   U2218
+<Super_L> <U>                  : "∩"   U2229
+<Super_L> <u>                  : "∪"   U222A
+<Super_L> <asciitilde>         : "≅"   U2245
+<Super_L> <equal>              : "≠"   U2260
+<Super_L> <less>               : "≤"   U2264
+<Super_L> <greater>            : "≥"   U2265
+<Super_L> <c>                  : "⊂"   U2283
+<Super_L> <C>                  : "⊃"   U2283
+<Super_L> <v>                  : "⊄"   U2284
+<Super_L> <V>                  : "⊅"   U2285
+<Super_R> <d>                  : "⊆"   U2286
+<Super_R> <D>                  : "⊇"   U2287
+<Super_R> <f>                  : "⊈"   U2288
+<Super_R> <F>                  : "⊉"   U2289
+<Super_R> <U>                  : "⊍"   U228D
+<Super_R> <u>                  : "⊎"   U228E
+<Super_L> <t>                  : "⊖"   U2296
+<Super_L> <L>                  : "｢"   UFF62
+<Super_L> <l>                  : "｣"   UFF63
+
+One can add these lines to their ~/.XCompose file. To activate the changes one needs to exit their X session
+and login back again.
+Note that since Ubuntu Gnome uses one C<Super> key for its own purposes, one might want to substitute one or
+both the Super_* keys with, for example, Meta_R.
+
 =head1 WinCompose (Windows)
 X<|WinCompose>
 


### PR DESCRIPTION
Please review and advice: I had some doubts about adding a 55 line-long example.

## The problem

Input of Unicode characters can be simplified by using dead keys and XCompose

## Solution provided

This PR shows a way to add several two-key combinations to a user's ~/.XCompose file in order to let them enter easily all the relevant Unicode characters used by Raku.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
