### PR TITLE
Programs/03-Environment... remove F<

### DIFF
--- a/doc/Programs/03-environment-variables.pod6
+++ b/doc/Programs/03-environment-variables.pod6
@@ -78,7 +78,7 @@ page|https://github.com/rakudo/rakudo/wiki/dev-env-vars#moarvm>.
 =head2 Module loading
 
 X<|RAKUDOLIB>X<|RAKULIB>X<|PERL6LIB>
-=item C<RAKUDOLIB>, C<RAKULIB> (I<Str>; F<src/core/Inc.pm>)
+=item C<RAKUDOLIB>, C<RAKULIB> (I<Str>; B<src/core/Inc.pm>)
 
 C<RAKUDOLIB> and C<RAKULIB> append a comma-delimited list of paths to the
 search list for modules. C<RAKUDOLIB> is evaluated first. B<NOTE:> These env
@@ -86,7 +86,7 @@ vars were added in the Rakudo compiler in version 2020.05. The deprecated older
 env var C<PERL6LIB> is still available.
 
 X<|RAKUDO_MODULE_DEBUG>
-=item C<RAKUDO_MODULE_DEBUG> (I<Bool>; F<src/Perl6/ModuleLoader.nqp>)
+=item C<RAKUDO_MODULE_DEBUG> (I<Bool>; B<src/Perl6/ModuleLoader.nqp>)
 
 If true, causes the module loader to print debugging information to standard
 error.
@@ -106,32 +106,32 @@ as of version 2019.12, and before that it was available as
 C<PERL6_EXCEPTIONS_HANDLER>.
 
 X<|RAKUDO_NO_DEPRECATIONS>
-=item C<RAKUDO_NO_DEPRECATIONS> (I<Bool>; F<src/core.c/Deprecations.pm6>)
+=item C<RAKUDO_NO_DEPRECATIONS> (I<Bool>; B<src/core.c/Deprecations.pm6>)
 
 If true, suppresses deprecation warnings triggered by the C<is DEPRECATED>
 trait.
 
 X<|RAKUDO_DEPRECATIONS_FATAL>
-=item C<RAKUDO_DEPRECATIONS_FATAL> (I<Bool>; F<src/core.c/Deprecations.pm6>)
+=item C<RAKUDO_DEPRECATIONS_FATAL> (I<Bool>; B<src/core.c/Deprecations.pm6>)
 
 If true, deprecation warnings become thrown exceptions.
 
 X<|RAKUDO_VERBOSE_STACKFRAME>
-=item C<RAKUDO_VERBOSE_STACKFRAME> (I<UInt>; F<src/core.c/Backtrace.pm6>)
+=item C<RAKUDO_VERBOSE_STACKFRAME> (I<UInt>; B<src/core.c/Backtrace.pm6>)
 
 Displays source code in stack frames surrounded by the specified number of
 lines of context; for instance C<RAKUDO_VERBOSE_STACKFRAME = 1> will use one
 context line.
 
 X<|RAKUDO_BACKTRACE_SETTING>
-=item C<RAKUDO_BACKTRACE_SETTING> (I<Bool>; F<src/core.c/Backtrace.pm6>)
+=item C<RAKUDO_BACKTRACE_SETTING> (I<Bool>; B<src/core.c/Backtrace.pm6>)
 
 Controls whether C<.setting> files are included in backtraces.
 
 =head2 Affecting precompilation
 
 X<|RAKUDO_PREFIX>
-=item C<RAKUDO_PREFIX> (I<Str>; F<src/core.c/CompUnit/RepositoryRegistry.pm6>)
+=item C<RAKUDO_PREFIX> (I<Str>; B<src/core.c/CompUnit/RepositoryRegistry.pm6>)
 
 When this is set, Rakudo will look for the standard repositories (perl, vendor,
 site) in the specified directory. This is intended as an escape hatch for
@@ -139,11 +139,11 @@ build-time bootstrapping issues, where Rakudo may be built as an unprivileged
 user without write access to the runtime paths in NQP's config.
 
 X<|RAKUDO_PRECOMP_DIST>
-=item C<RAKUDO_PRECOMP_DIST> (F<src/core.c/CompUnit/PrecompilationRepository.pm6>)
+=item C<RAKUDO_PRECOMP_DIST> (B<src/core.c/CompUnit/PrecompilationRepository.pm6>)
 X<|RAKUDO_PRECOMP_LOADING>
-=item C<RAKUDO_PRECOMP_LOADING> (F<src/core.c/CompUnit/PrecompilationRepository.pm6>)
+=item C<RAKUDO_PRECOMP_LOADING> (B<src/core.c/CompUnit/PrecompilationRepository.pm6>)
 X<|RAKUDO_PRECOMP_WITH>
-=item C<RAKUDO_PRECOMP_WITH> (F<src/core.c/CompUnit/PrecompilationRepository.pm6>)
+=item C<RAKUDO_PRECOMP_WITH> (B<src/core.c/CompUnit/PrecompilationRepository.pm6>)
 
 These are internal variables for passing serialized state to precompilation jobs
 in child processes. Please do not set them manually.
@@ -187,19 +187,19 @@ L«C<$*DEFAULT-READ-ELEMS>|/language/variables#$*DEFAULT-READ-ELEMS» dynamic
 variable.
 
 X<|RAKUDO_ERROR_COLOR>
-=item C<RAKUDO_ERROR_COLOR> (I<Bool>; F<src/core.c/Exception.pm6>)
+=item C<RAKUDO_ERROR_COLOR> (I<Bool>; B<src/core.c/Exception.pm6>)
 
 Controls whether to emit ANSI codes for error highlighting. Defaults to true
 if unset, except on Windows.
 
 X<|RAKUDO_MAX_THREADS>
-=item C<RAKUDO_MAX_THREADS> (I<UInt>; F<src/core.c/ThreadPoolScheduler.pm6>)
+=item C<RAKUDO_MAX_THREADS> (I<UInt>; B<src/core.c/ThreadPoolScheduler.pm6>)
 
 Indicates the maximum number of threads used by default when creating a
 C<ThreadPoolScheduler>. Defaults to 64.
 
 X<|TMPDIR>X<|TEMP>X<|TMP>
-=item C<TMPDIR>, C<TEMP>, C<TMP> (I<Str>; F<src/core.c/IO/Spec/>)
+=item C<TMPDIR>, C<TEMP>, C<TMP> (I<Str>; B<src/core.c/IO/Spec/>)
 
 The C<IO::Spec::Unix.tmpdir> method will return C<$TMPDIR> if it points to a
 directory with full access permissions for the current user, with a fallback
@@ -209,7 +209,7 @@ C<IO::Spec::Cygwin> and C<IO::Spec::Win32> use more Windows-appropriate lists
 which also include the C<%TEMP%> and C<%TMP%> environment variables.
 
 X<|PATH>
-=item C<PATH>, C<Path> (I<Str>; F<src/core.c/IO/Spec/>)
+=item C<PATH>, C<Path> (I<Str>; B<src/core.c/IO/Spec/>)
 
 The C<IO::Spec::Unix.path> method splits C<$PATH> as a
 shell would; i.e. as a colon-separated list. C<IO::Spec::Cygwin> inherits this


### PR DESCRIPTION
## The problem

`F<...>` is not a standard FormatCode, either in the current Pod6 documentation, or in Damian Conway's original spec. This is the only Raku documentation content file to contain `F<...>`. The current standard HTML renderer just stringifies `F< ... >` to `F< ...>`, which is quite ugly imho. 

## Solution provided

I have replaced `F<...>` with `B<...>`, which is a standard FormatCode.

