### PR TITLE
Undocumented L<> behaviour

### DIFF
--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -561,6 +561,9 @@ Comments L<#Comments>
 
 L<Comments|#Comments>
 
+Alongside the normal way of describing a path, viz. C< L<Some reference|path/to/filename> >, it is also
+possible to use the I<Perlish> "module" notation, eg., C< L<Some reference|path::to::filename> >.
+
 =head2 Placement links
 
 This code is not implemented in C<Pod::To::HTML>, but is partially implemented


### PR DESCRIPTION
The `Pod::To::HTML` renderer automatically translates the token `::` in a L<> to `/`

In Perl sibling languages, a Module called `Some::Module` resides in `lib/Some/Module`, so the token `::` is a synonym for `/` or directory marker.

This assumption has been carried unremarked into Raku, even though there is no need for directory markers to be followed. 

In VERY many Pod6 files documentation authors have used the notation `L<some reference|type/X::Inheritance::NotComposed>` to refer to the file `doc/Type/X/Inheritance/NotComposed.pod6`.

Since there tens of such references, changing the behaviour is not worth the effort.

Consequently, the behaviour should simply be documented.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
