### PR TITLE
issue #3883 remove 404

### DIFF
--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -1619,10 +1619,6 @@ X<| rewinddir - perlfunc>
 
 Not supported in Raku.
 
-The Raku ecosystem has a module L<C<P5rewinddir>|https://modules.raku.org/dist/P5rewinddir>
-which exports a C<rewinddir> function that mimics the original Perl
-behavior as much as possible.
-
 X<| rindex - perlfunc>
 =head2 rindex
 

--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -1619,6 +1619,10 @@ X<| rewinddir - perlfunc>
 
 Not supported in Raku.
 
+The Raku ecosystem has a module L<C<P5openddir>|https://modules.raku.org/dist/P5opendir>
+which exports a C<rewinddir> function that mimics the original Perl
+behavior as much as possible.
+
 X<| rindex - perlfunc>
 =head2 rindex
 


### PR DESCRIPTION
P5rewinddir is referenced, but the module no longer exists at all. I cannot find a substitute.
I see no reason why we don't just state the Raku does not implement the functionality.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
