### PR TITLE
#3883 remove non-existent host

### DIFF
--- a/doc/Language/community.pod6
+++ b/doc/Language/community.pod6
@@ -228,13 +228,6 @@ You can also use it to see when was the last time somebody talked.
 =end item
 
 =begin item
-B<Undercover> (L<details|https://github.com/zoffixznet/undercover>)
-
-Very similar to SourceBaby, except points to
-L<rakudo.party|https://wtf.rakudo.party/> indicating stress test coverage of code.
-=end item
-
-=begin item
 B<undersightable> (L<details|https://github.com/Raku/whateverable/wiki/Undersightable>)
 
 An IRC bot for checking that important things are operating correctly (websites are up,


### PR DESCRIPTION
The domain `rakudo.party` no longer exists. Since `Undercover` bot only differs from SourceBaby because it points to wtf.rakudo.party,
this link is pointless. Zoffix, perhaps could point to a different domain???

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
