### PR TITLE
Issue #3883 remove 404 replace with working

### DIFF
--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -250,8 +250,8 @@ X<|Core standard library (FAQ)>
 X<|Rakudo Star distribution and compiler-only release (FAQ)>
 =head2 Does Rakudo have a core standard library?
 
-L<Rakudo Star distribution|https://rakudo.raku.org/downloads/> does come
-with L<many useful modules|https://github.com/rakudo/star/tree/master/modules>.
+L<Rakudo Star distribution|https://rakudo.org/downloads/> does come
+with L<many useful modules|https://github.com/rakudo/star/etc/modules.txt>.
 
 Rakudo compiler-only release includes
 L<only a couple of the most basic modules|/language/modules-core>.
@@ -877,7 +877,7 @@ X<|Rakudo Star release cycle (FAQ)>
 =head2 When will the next version of Rakudo Star be released?
 
 A Rakudo Star release is typically produced quarterly, with release
-announcements L<posted on rakudo.org|https://rakudo.org/posts>.
+announcements L<posted on rakudo.org|https://rakudo.org/news>.
 
 =head1 Metaquestions and advocacy
 


### PR DESCRIPTION
- Replace 'posts' with 'news', which is a working page on rakudo.org
- correct download path reference
- reference 'star/etc/modules.txt' which exists. (Possibly better to eliminate this link altogether, but being minimal here)

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
