### PR TITLE
Correct the description of the epoch (posix) DateTime new method.

### DIFF
--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -56,7 +56,7 @@ multi method new(Int() $year, Int() $month, Int() $day,
                  Int() $hour, Int $minute, $second,
                  Int() :$timezone = 0, :&formatter)
 multi method new(Instant:D $i,  :$timezone=0, :&formatter)
-multi method new(Int:D $posix,  :$timezone=0, :&formatter)
+multi method new(Numeric:D $posix,  :$timezone=0, :&formatter)
 multi method new(Str:D $format, :$timezone=0, :&formatter)
 
 Creates a new C<DateTime> object. One option for creating a new DateTime object
@@ -64,7 +64,7 @@ is from the components (year, month, day, hour, ...) separately. Another is to
 pass a L<Date|/type/Date> object for the date component, and specify the time
 component-wise. Yet another is to obtain the time from an
 L<Instant|/type/Instant>, and only supply the time zone and formatter. Or
-instead of an Instant you can supply an L<Int|/type/Int> as a UNIX timestamp.
+instead of an Instant you can supply an L<Numeric|/type/Numeric> as a UNIX timestamp.
 
 You can also supply a L<Str|/type/Str> formatted in ISO 8601 timestamp
 notation or as a full L<RFC 3339|https://tools.ietf.org/html/rfc3339>
@@ -94,7 +94,7 @@ L<X::DateTime::TimezoneClash|/type/X::DateTime::TimezoneClash> is thrown.
                              1, 1, 1);   # Hour, minute, second with default time zone
     $datetime = DateTime.new(now);                       # Instant.
     # from a Unix timestamp
-    say $datetime = DateTime.new(1470853583);            # OUTPUT: «2016-08-10T18:26:23Z␤»
+    say $datetime = DateTime.new(1470853583.3);          # OUTPUT: «2016-08-10T18:26:23.300000Z␤»
     $datetime = DateTime.new("2015-01-01T03:17:30+0500") # Formatted string
 
 =head2 method now


### PR DESCRIPTION
## The problem

The description is wrong, the new method for epoch (posix) takes a Numeric:D argument, not an Int.

## Solution provided

Corrected the description
