### PR TITLE
Related #3841

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1979,7 +1979,7 @@ aspects of the particular character like capitalization.
 
 The main difference between C<coll> and C<unicmp> is that the behavior of the
 former can be changed by the
-L<C<$*COLLATION>|/type/Any#index-entry-%24*COLLATION-%24*COLLATION> dynamic
+L<C<$*COLLATION>|/type/Any#index-entry-%24*COLLATION> dynamic
 variable.
 
 B<NOTE:> These are not yet implemented in the JVM.


### PR DESCRIPTION
Removing B<..> **inside** a X<> for $*COLLATION .  
The problem is that there is no specification for a corresponding `L<>` in another file. As the present, the link author has to know how the target will be rendered. So `B<>` could be rendered as `<b> ... </b>` or `<strong>...</strong>` in HTML. **BUT** if this were to be rendered in some other output format (pdf? epub? latex?), the link would fail. This has already happened in `Language/Operators`, where the link author did not include `<strong>...</strong>` in the link.

So, I have removed B<> inside the X<>, and simplified the X<>, and corrected the link in Operators.
If this has a knock-on effect in other documents, it will be picked up in `Collection` tests when the documentation files are re-rendered.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
