### PR TITLE
Add description of three new DateTime methods

### DIFF
--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -252,6 +252,36 @@ Returns an L<Instant|/type/Instant> object based on the invocant.
 
     say DateTime.new('2015-12-24T12:23:00+0200').Instant; # OUTPUT: «Instant:1450952616␤»
 
+=head2 method day-fraction
+
+Defined as:
+
+method day-fraction(DateTime:D: --> Real:D)
+
+Returns the instant's time as a fraction of a 24-hour day.
+
+    say DateTime.new('2021-12-24T12:23:00.43Z').day-fraction; # OUTPUT: «0.5159772␤»
+
+=head2 method julian-date
+
+Defined as:
+
+    method julian-date(DateTime:D: --> Real:D)
+
+Returns the L<https://en.wikipedia.org/wiki/Julian_day|Julian Date> (JD) for the UTC date and time.
+
+    say DateTime.new('2021-12-24T12:23:00.43Z').julian-date; # OUTPUT: «2459573.0159772␤»
+
+=head2 method modified-julian-date
+
+Defined as:
+
+    method modified-julian-date(DateTime:D: --> Real:D)
+
+Returns the L<https://en.wikipedia.org/wiki/Julian_day|Modified Julian Date> (MJD) for the UTC date and time.
+
+    say DateTime.new('2021-12-24T12:23:00.43Z').modified-julian-date; # OUTPUT: «59572.5159772␤»
+
 =head2 method posix
 
 Defined as:

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -256,7 +256,7 @@ Returns an L<Instant|/type/Instant> object based on the invocant.
 
 Defined as:
 
-method day-fraction(DateTime:D: --> Real:D)
+    method day-fraction(DateTime:D: --> Real:D)
 
 Returns the instant's time as a fraction of a 24-hour day.
 

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -278,7 +278,7 @@ Returns the L<Julian Date|https://en.wikipedia.org/wiki/Julian_day> (JD) for the
 The C<julian-date> starts at zero at the epoch starting at noon UTC on
 I<Monday, January 1, 4713 BC>, on the Gregorian calendar (the calendar
 in use in much of the world and in international commerce and travel)
-and is used in astronomy to define celestial objects' transits at the
+and is used in astronomy to define times of celestial objects transiting the
 Earth's Prime Meridian.
 
 =head2 method modified-julian-date

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -262,8 +262,8 @@ Returns the instant's time as a fraction of a 24-hour day.
 
     say DateTime.new('2021-12-24T12:23:00.43Z').day-fraction; # OUTPUT: «0.5159772␤»
 
-Notice the `day-fraction` value is the same as the fractional part of
-the `modified-julian-date` for the same instant.
+Notice the C<day-fraction> value is the same as the fractional part of
+the C<modified-julian-date> for the same instant.
 
 =head2 method julian-date
 

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -276,10 +276,10 @@ Returns the L<Julian date|https://en.wikipedia.org/wiki/Julian_day> (JD) for the
     say DateTime.new('2021-12-24T12:23:00.43Z').julian-date; # OUTPUT: «2459573.0159772␤»
 
 The C<julian-date> starts at zero at the epoch of noon UTC on
-I<Monday, January 1, 4713 BC> (-4713-01-01T12:00:00Z), on the Gregorian calendar (the calendar
-in use in much of the world and in international commerce and travel)
-and is used in astronomy to define times of celestial objects transiting the
-Earth's Prime Meridian. For an instant, it is the sum of the number of whole days and
+I<November 24, 4714 B.C.> on the L<proleptic|https://en.m.wikionary.org/wiki/proleptic> Gregorian calendar (the calendar
+in use in much of the world and in international commerce and travel). The JD
+is used in astronomy to define times of celestial objects transiting the
+Earth's Prime Meridian. For any instant, it is the sum of the number of whole days and
 the fraction of a day from that epoch to that instant.
 
 =head2 method modified-julian-date
@@ -294,7 +294,7 @@ Returns the L<Modified Julian Date|https://en.wikipedia.org/wiki/Julian_day> (MJ
 
 Notice the fractional part of the C<modified-julian-date> is same value as the C<day-fraction> for the same instant.
 Likewise, the integral part of the I<MJD> is the same value as the C<daycount> for the same instant since they
-reference the same epoch (Nov. 17, 1858).
+reference the same epoch (November 17, 1858).
 The MJD is obtained by subtracting the constant C<2_400_000.5> from the I<Julian Date> and is used to simplify
 transformations between civil and astronmical time systems.
 

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -262,15 +262,24 @@ Returns the instant's time as a fraction of a 24-hour day.
 
     say DateTime.new('2021-12-24T12:23:00.43Z').day-fraction; # OUTPUT: «0.5159772␤»
 
+Notice the `day-fraction` value is the same as the fractional part of
+the `modified-julian-date` for the same instant.
+
 =head2 method julian-date
 
 Defined as:
 
     method julian-date(DateTime:D: --> Real:D)
 
-Returns the L<https://en.wikipedia.org/wiki/Julian_day|Julian Date> (JD) for the UTC date and time.
+Returns the L<Julian Date|https://en.wikipedia.org/wiki/Julian_day> (JD) for the UTC date and time.
 
     say DateTime.new('2021-12-24T12:23:00.43Z').julian-date; # OUTPUT: «2459573.0159772␤»
+
+The C<julian-date> starts at zero at the epoch starting at noon UTC on
+I<Monday, January 1, 4713 BC>, on the Gregorian calendar (the calendar
+in use in much of the world and in international commerce and travel)
+and is used in astronomy to define celestial objects' transits at the
+Earth's Prime Meridian.
 
 =head2 method modified-julian-date
 
@@ -278,9 +287,15 @@ Defined as:
 
     method modified-julian-date(DateTime:D: --> Real:D)
 
-Returns the L<https://en.wikipedia.org/wiki/Julian_day|Modified Julian Date> (MJD) for the UTC date and time.
+Returns the L<Modified Julian Date|https://en.wikipedia.org/wiki/Julian_day> (MJD) for the UTC date and time.
 
     say DateTime.new('2021-12-24T12:23:00.43Z').modified-julian-date; # OUTPUT: «59572.5159772␤»
+
+Notice the fractional part of the C<modified-julian-date> is same value as the C<day-fraction> for the same instant.
+Likewise, the integral part of the I<MJD> is the same value as the C<daycount> for the same instant since they
+reference the same epoch (Nov. 17, 1858).
+The MJD is obtained by subtracting the constant C<2_400_000.5> from the I<Julian Date> and is used to simplify
+transformations between civil and astronmical time systems.
 
 =head2 method posix
 

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -271,15 +271,16 @@ Defined as:
 
     method julian-date(DateTime:D: --> Real:D)
 
-Returns the L<Julian Date|https://en.wikipedia.org/wiki/Julian_day> (JD) for the UTC date and time.
+Returns the L<Julian date|https://en.wikipedia.org/wiki/Julian_day> (JD) for the UTC date and time.
 
     say DateTime.new('2021-12-24T12:23:00.43Z').julian-date; # OUTPUT: «2459573.0159772␤»
 
-The C<julian-date> starts at zero at the epoch starting at noon UTC on
-I<Monday, January 1, 4713 BC>, on the Gregorian calendar (the calendar
+The C<julian-date> starts at zero at the epoch of noon UTC on
+I<Monday, January 1, 4713 BC> (-4713-01-01T12:00:00Z), on the Gregorian calendar (the calendar
 in use in much of the world and in international commerce and travel)
 and is used in astronomy to define times of celestial objects transiting the
-Earth's Prime Meridian.
+Earth's Prime Meridian. For an instant, it is the sum of the number of whole days and
+the fraction of a day from that epoch to that instant.
 
 =head2 method modified-julian-date
 


### PR DESCRIPTION
## The problem

Three new methods have been added to class `DateTime` to Raku for the next release (via merged Rakudo PR #4288) and need documenting:

+ `day-fraction`
+ `julian-date`
+ `modified-julian-date`

## Solution provided

Proposed doc entries for the three new methods.
