### PR TITLE
Reference error to .^

### DIFF
--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -10,7 +10,7 @@ A type defines a new object by creating a type object that provides an
 interface to create instances of objects or to check values against. Any type
 object is a subclass of L<Any|/type/Any> or L<Mu|/type/Mu>. Introspection
 methods are provided via inheritance from those base classes and the
-introspection postfix L<.^|/language/operators#postfix_.^>. A new type is
+introspection metamethod L<.^|/language/operators#methodop_.^>. A new type is
 introduced to the current scope by one of the following type declarators at
 compile time or with the L<metaobject protocol|/language/mop> at runtime. All
 type names must be unique in their scope.


### PR DESCRIPTION
Part of  #3841 . But I'm flagging this error because the orginal documentation calls `.^` a postfix op, but in `
language/operators` it is called a metamethod. So I have also change 'postfix' to 'metamethod' to be consistent.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
