### PR TITLE
Remove link from List #3841

### DIFF
--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -277,7 +277,7 @@ Defined as:
     method join(List:D: $separator = "")
 
 Treats the elements of the list as strings by calling
-L<C<.Str>|/type/Any#routine_Str> on each of them, interleaves them with
+C<.Str> on each of them, interleaves them with
 C<$separator> and concatenates everything into a single string.
 
 Example:

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -277,7 +277,7 @@ Defined as:
     method join(List:D: $separator = "")
 
 Treats the elements of the list as strings by calling
-C<.Str> on each of them, interleaves them with
+L<C<.Str>|/type/Mu#method_Str> on each of them, interleaves them with
 C<$separator> and concatenates everything into a single string.
 
 Example:


### PR DESCRIPTION
This is another false link that probably needs removing.
There is no `routine_Str`or `method_Str` documented in `Any`. I could not find a single reference to `.Str` that I could replace the reference with.
Removing the link does not seem to me to be important, but it probably should be an issue that `Str` is not documented in a single place. Strings and stringification are important enough to need a separate document.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
