### PR TITLE
Insert missing target into Proc #3841

### DIFF
--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -8,7 +8,7 @@
 
 C<Proc> is a representation of an invocation of an external
 process. It provides access to the input, output and error stream as well as
-the exit code. It is typically created through the C<run> subroutine:
+the exit code. It is typically created through the X<C<run>|sub_run> subroutine:
 
 =for code
 my $proc = run 'echo', 'Hallo world', :out;


### PR DESCRIPTION
`Type/Independent-routines` contains a reference to `Proc#sub_run` but `Type/Proc` does not contain any target for `run`.

So I have inserted a X<> around the first explanation of `run` in Proc. This provides a target for Independent-routines (also opening separate PR with new target)

BUT, for consistency, `run` should be listed as sub along with `new` and `shell`. Also relationship with new should be illustrated. This is not done in this PR.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
