### PR TITLE
Correct a link to Hash

### DIFF
--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -44,7 +44,7 @@ a C<Map> has been initialized:
    $m{ 'c' } = 'foo'; # WRONG!
                       # Cannot modify an immutable Str
 
-Unlike its mutable companion type L<Hash>, Map cannot be parameterized by key or value types.
+Unlike its mutable companion type L<Hash|/type/Hash>, Map cannot be parameterized by key or value types.
 
 =head1 Methods
 

--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -44,7 +44,7 @@ a C<Map> has been initialized:
    $m{ 'c' } = 'foo'; # WRONG!
                       # Cannot modify an immutable Str
 
-Unlike its mutable companion type L<Hash|/type/Hash>, Map cannot be parameterized by key or value types.
+Unlike its mutable companion type L<Hash|/type/Hash>, a Map cannot be parameterized by key or value types.
 
 =head1 Methods
 


### PR DESCRIPTION
Hash → /type/Hash

## The problem

A link to the Hash class page generates a 404 error

## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
