### PR TITLE
Search/test for the word 'boolean', ref #3517

### DIFF
--- a/xt/word-variants.t
+++ b/xt/word-variants.t
@@ -13,21 +13,25 @@ Make sure certain words are normalized by checking regular expressions.
 my @files = Test-Files.pods;
 
 my %variants = %(
-    filehandle => 'file [\s+|\-] handle',
-    filesystem => 'file [\s+|\-] system',
-    lookahead  => 'look \- ahead',
-    lookbehind => 'look [\s+|\-] behind',
-    meta      => '<!after [ method || \$ || \- || \" ] \s*> meta [\s+|\-] << <!before ok >> >',
-    metadata  => 'meta [\s+|\+] data',
-    NYI        => 'niy',
-    precompil => 'pre \- compil',
-    runtime    => 'run [\s+|\-] time',
-    semicolon => 'semi [\s+|\-] colon',
-    shorthand  => 'short [\s+|\-] hand',
-    sigiled => 'sigilled',
-    smartmatch => 'smart  [\s+|\-] match',
-    subdirectory => 'sub \- directory',
-    zero-width => 'zero \s+ width<!before \' joiner\'><!before \' no-break space\'>',
+    # no lowercase 'boolean', unless it is followed by some selected
+    # characters as it might be included in a code snippet,
+    # see for example doc/Language/js-nutshell.pod6
+    Boolean    => rx/ << boolean <!before \s* <[ \= \< \> \{ \} ]> > /,
+    filehandle => rx:i/ << file [\s+|\-] handle /,
+    filesystem => rx:i/ << file [\s+|\-] system /,
+    lookahead  => rx:i/ << look \- ahead /,
+    lookbehind => rx:i/ << look [\s+|\-] behind /,
+    meta      => rx:i/ << <!after [ method || \$ || \- || \" ] \s*> meta [\s+|\-] << <!before ok >> > /,
+    metadata  => rx:i/ << meta [\s+|\+] data /,
+    NYI        => rx:i/ << niy /,
+    precompil => rx:i/ << pre \- compil /,
+    runtime    => rx:i/ << run [\s+|\-] time /,
+    semicolon => rx:i/ << semi [\s+|\-] colon /,
+    shorthand  => rx:i/ << short [\s+|\-] hand /,
+    sigiled => rx:i/ << sigilled /,
+    smartmatch => rx:i/ << smart  [\s+|\-] match /,
+    subdirectory => rx:i/ << sub \- directory /,
+    zero-width => rx:i/ << zero \s+ width<!before ' joiner'><!before ' no-break space'> /,
 );
 
 plan +@files;
@@ -40,7 +44,7 @@ for @files.race -> $file {
     my @bad;
     my $content =  $file.IO.slurp.lines.join(" ");
     for %variants.kv -> $word, $rx {
-        if $content ~~ m/:i << <{$rx}> / {
+        if $content ~~ $rx {
             $ok = False;
             @bad.push: "«$/» found. We prefer ｢$word｣";
         }


### PR DESCRIPTION
... as it should be written 'Boolean'.

This word variant test is all about case, thus the %variants hash now
contains Regex values with the case-insensitive adverb when applicable.
