### PR TITLE
Add complete example of a callable sort routine #3883

### DIFF
--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -162,6 +162,10 @@ Examples:
     say 'bca'.comb.sort({$^b cmp $^a}).join;    # OUTPUT: «cba␤»
     say '231'.comb.sort(&infix:«<=>»).join;     # OUTPUT: «123␤»
 
+    sub by_character_count { $^a.chars <=> $^b.chars }
+    say <Let us impart what we have seen tonight unto young Hamlet>.sort(&by_character_count);
+    # OUTPUT: «(us we Let what have seen unto young impart Hamlet tonight)␤»
+
 =head2 routine map
 
 Defined as:

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -162,8 +162,8 @@ Examples:
     say 'bca'.comb.sort({$^b cmp $^a}).join;    # OUTPUT: «cba␤»
     say '231'.comb.sort(&infix:«<=>»).join;     # OUTPUT: «123␤»
 
-    sub by_character_count { $^a.chars <=> $^b.chars }
-    say <Let us impart what we have seen tonight unto young Hamlet>.sort(&by_character_count);
+    sub by-character-count { $^a.chars <=> $^b.chars }
+    say <Let us impart what we have seen tonight unto young Hamlet>.sort(&by-character-count);
     # OUTPUT: «(us we Let what have seen unto young impart Hamlet tonight)␤»
 
 =head2 routine map


### PR DESCRIPTION
## The problem

The only example of a named sort routine is using the trick of referencing a operator by its "name".
No example is provided of creating a new separate sort routine, and passing it to .sort .

## Solution provided

A minimal code example is added: a short named sub, and usage of that sub on data whose results highlights the sorting *and* the stability,  since ties are included in the data.