### PR TITLE
Fixed ctest and aspell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ xtest:
 
 # Content tests
 ctest:
-	prove --exec raku -r t/07-tabs.t xt/perl-nbsp.t  xt/trailing-whitespace.t
+	prove --exec raku -r t/05-tabs.t xt/perl-nbsp.t  xt/trailing-whitespace.t
 
 start: run
 

--- a/xt/pws/words.pws
+++ b/xt/pws/words.pws
@@ -314,6 +314,7 @@ decont
 decontainerization
 decontainerize
 decontainerized
+decrementing
 deepmap
 defaultparent
 definedness
@@ -330,6 +331,8 @@ deparse
 dependencyspecification
 deprecations
 deps
+dequeue
+dequeues
 deref
 dereference
 dereferenced
@@ -395,6 +398,8 @@ endnetent
 endprotoent
 endpwent
 endservent
+enqueue
+enqueues
 entrapments
 ents
 enum
@@ -598,6 +603,7 @@ imprecisions
 inb
 inblock
 incrementer
+incrementing
 indir
 indirections
 inet
@@ -618,6 +624,7 @@ installermaker
 instanceof
 instantiation
 instantiations
+interoperate
 interoperation
 intmax
 introspectable
@@ -1504,6 +1511,7 @@ uint
 ulong
 ulonglong
 unallowed
+unary
 unbuffered
 uncomment
 uncontainerized


### PR DESCRIPTION
## The problem
`make ctest` was broken, unable to find the `tabs` test.
This was due to a incomplete test renumbering from 201128008 and 04702f1fb .

Also, the aspell test was failing from missing new words.

## Solution provided
One-line test renumbering in Makefile .
Words added to words.pws .
No separate Github issue was created. Please let me know if I should have created an issue for a minor fix like this.