### PR TITLE
add a mnemonic for `Iterable.race`

### DIFF
--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -154,7 +154,7 @@ Returns another Iterable that is potentially iterated in parallel, with a
 given batch size and degree of parallelism (number of parallel workers).
 
 Unlike L«C<hyper>|/routine/hyper», C<race> does not preserve the order of
-elements.
+elements (mnemonic: in a race, you never know who will arrive first).
 
     say ([1..100].race.map({ $_ +1 }).list);
 


### PR DESCRIPTION
From IRC:

```
Jun 14 15:37:13 <xinming>	Hi, I always get confused about .hyper/.race, which one ensures order of results, the other doesn't, Any hints on how I can remember this? Thx
Jun 14 15:37:32 <xinming>	I've looked-up the raku doc over and over again :-(
Jun 14 15:38:09 <dakkar>	xinming: in a `.race`, you never know who's goinig to arrive first
Jun 14 15:40:00 <dakkar>	xinming: does that help?
Jun 14 15:42:26 <xinming>	dakkar: got it, thx
Jun 14 15:42:38 <xinming>	this helped a lot.
Jun 14 15:42:48 <dakkar>	maybe https://docs.raku.org/type/Iterable#method_race should say that…
```

## The problem

It may not be obvious, especially to non-native English speakers, that the name `.race` implies unpredictable ordering.

## Solution provided

Mention that in the documentation.