### PR TITLE
Update regexes.pod6

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -2278,7 +2278,7 @@ When two adverbs are used together, they keep their colon at the front
 
     "þor is Þor" ~~ m:g:i/þ/;  # OUTPUT: «(｢þ｣ ｢Þ｣)␤»
 
-That implies that when there are two vowels together after a C<:>, they
+That implies that when there are multiple characters together after a C<:>, they
 correspond to the same adverb, as in C<:ov> or C<:P5>.
 
 =head3 X<Ignorecase|regex adverb,:ignorecase;regex adverb,:i>


### PR DESCRIPTION
Change "two vowels together after a C<:>" to "multiple characters after a C<:>".

Both 'vowels'  and  'two'  are too restrictive.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
