### PR TITLE
fix typo in Callable.pod6

### DIFF
--- a/doc/Type/Callable.pod6
+++ b/doc/Type/Callable.pod6
@@ -34,7 +34,7 @@ This method is required for the L«C<( )> postcircumfix operator|/language/opera
 and the L«C<.( )> postcircumfix operator|/language/operators#index-entry-.(_)». It's what makes
 an object actually call-able and needs to be overloaded to let a given object
 act like a routine. If the object needs to be stored in a C<&>-sigiled
-container, is has to implement Callable.
+container, it has to implement Callable.
 
     class A does Callable {
         submethod CALL-ME(|c){ 'called' }


### PR DESCRIPTION
## The problem

Text in [Callable](https://docs.raku.org/type/Callable#___top):

> If the object needs to be stored in a &-sigiled container, **is** has to implement Callable.

(my emphasis).

## Solution provided

the one-character change 

> is has to -> **it** has to 

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
