### PR TITLE
clarify sentence, fix typo

### DIFF
--- a/doc/Language/js-nutshell.pod6
+++ b/doc/Language/js-nutshell.pod6
@@ -102,7 +102,7 @@ our $*foo = 1; # Dynamic variable; package scoped
 GLOBAL::<$foo> := 1; # Globally scoped
 
 Use C<my> where you'd use C<let>, C<our> for variables you'd define in the
-outermost scope needed, and C<constant> where you'd uses C<const>.
+outermost scope needed, and C<constant> where you'd use C<const>.
 
 You may have noticed the C<$> and C<$*> symbols placed before variable names.
 These are known as sigils and twigils respectively, and define what container
@@ -110,9 +110,9 @@ the variable has. Refer to the documentation on
 L<variables|/language/variables> for more information on sigils, twigils, and
 containers.
 
-Variables in Node.js can override others from outer scopes with the same name
-(though linters will usually complain about it depending on how they're
-configured):
+Variables in Node.js can have the same name as others from outer scopes without
+conflicting (though linters will usually complain about it depending on how
+they're configured):
 
 =begin code :lang<javascript>
 let foo = 1;

--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -777,7 +777,8 @@ print(tuple3)                                      # OUTPUT: «(1, 'two', 3, 'ha
 
 Raku
 
-Raku does not have a builtin Tuple type. You can get the same behavior from Raku using the List type, or from an external module.
+Raku does not have a builtin Tuple type. You can get the same behavior from
+Raku using the List type, or from an external module.
 
     my $list1 = (1, "two", 3, "hat");
     my $list2 = (5, 6, "seven");

--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -777,8 +777,7 @@ print(tuple3)                                      # OUTPUT: «(1, 'two', 3, 'ha
 
 Raku
 
-Raku does not have a builtin Tuple type, though they are available as modules.
-You can obtain the same behavior from Raku using the List type.
+Raku does not have a builtin Tuple type. You can get the same behavior from Raku using the List type, or from an external module.
 
     my $list1 = (1, "two", 3, "hat");
     my $list2 = (5, 6, "seven");


### PR DESCRIPTION
Previously, 'override' implied that the value of the outer scope may change if a variable of the same name is defined in an inner scope. I have clarified this.