### PR TITLE
clarify .& methodop

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -779,8 +779,11 @@ Technically, not a real operator; it's syntax special-cased in the compiler.
 X«|methodop .&»
 =head2 methodop C«.&»
 
-The operator to call a subroutine (with at least one positional argument), such
-as a method. The invocant will be bound to the first positional argument.
+The operator to call a L<Callable|/type/Callable>, such as a 
+L<Block|/type/Block>, a L<Method|/type/Method>, or a L<Sub|/type/Sub>
+with method syntax. The invocant will be bound to the first positional 
+argument (and thus dispatch will fail if the C<Callable> does not accept
+at least one positional argument).
 
 Technically, not a real operator; it's syntax special-cased in the compiler.
 


### PR DESCRIPTION
Based on the current docs, I thought that `foo.&{...}` created an unnamed method and called it on `foo`.  However, [Jonathan's recent Stack Overflow answer](https://stackoverflow.com/questions/68308991/what-is-the-intended-value-of-routine/68327774) clarified that `.&` creates a `Block` and calls that `Block` with method syntax.

This commit clarifies the description to avoid similar confusion.

