### PR TITLE
fix Python (dict key string) syntax

### DIFF
--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -141,7 +141,7 @@ Python
 =begin code :lang<python>
 s = 10
 l = [1, 2, 3]
-d = { a : 12, b : 99 }
+d = { 'a' : 12, 'b' : 99 }
 
 print s
 print l[2]


### PR DESCRIPTION
was wrong Python syntax, or, dict() definition (with {} literal) in fact tried to use (non-existent) variables instead of string literals

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
