### PR TITLE
add Set operator character explanations

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1602,6 +1602,7 @@ details.
 
 X<Intersection operator>.
 
+'&' as in left hand side arguments 'and' right hand side arguments.
 Returns the B<intersection> of all of its arguments. This creates a new
 L<Set|/type/Set> that contains only the elements common to all of the
 arguments if none of the arguments are a L<Bag|/type/Bag>,
@@ -1661,6 +1662,8 @@ resulting in a positive match. See also L<Junction|/type/Junction> for more deta
     multi sub infix:<(|)>(**@p)
 
 X<Union operator>.
+
+'|' as in left hand side arguments 'or' right hand side arguments.
 
 Returns the B<union> of all of its arguments. This creates a new
 L<Set|/type/Set> that contains all the elements its arguments contain if none


### PR DESCRIPTION
## The problem

The choice of Set operator characters was awkward to me until @lizmat explained them to me on IRC.

## Solution provided

This is the beginning of a try to add explanations to (all of?) them to clarify why they where chosen to make it easier to remember them.