### PR TITLE
Uniname examples fix/update

### DIFF
--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -1035,13 +1035,13 @@ codepoints, and L<uniparse|/routine/uniparse> for the opposite direction.
 
     # Camelia in Unicode
     say ‘»ö«’.uniname;
-    # OUTPUT: «"RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK"␤»
+    # OUTPUT: «RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK␤»
     say "Ḍ̇".uniname; # Note, doesn't show "COMBINING DOT ABOVE"
-    # OUTPUT: «"LATIN CAPITAL LETTER D WITH DOT BELOW"␤»
+    # OUTPUT: «LATIN CAPITAL LETTER D WITH DOT BELOW␤»
 
     # Find the char with the longest Unicode name.
     say (0..0x1FFFF).sort(*.uniname.chars)[*-1].chr.uniname;
-    # OUTPUT: ««ARABIC LIGATURE UIGHUR KIRGHIZ YEH WITH HAMZA ABOVE WITH ALEF MAKSURA INITIAL FORM␤»␤»
+    # OUTPUT: «BOX DRAWINGS LIGHT DIAGONAL UPPER CENTRE TO MIDDLE RIGHT AND MIDDLE LEFT TO LOWER CENTRE␤»
 
 =head2 routine uninames
 


### PR DESCRIPTION
This fixes routine examples' excessive nested quoting;
longest uniname probably from older data, current one is 6 chars longer.
