### PR TITLE
py-nutshell: Add how to enumerate in iteration

### DIFF
--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -357,6 +357,46 @@ I<Raku>
         say $c;
     }
 
+Uses of Python's C<for… in enumerate(…)> and C<.items()> mechanisms for
+iterating lists or dict/maps can both be achieved using the same
+L<kv|/routine/kv> method in Raku (because the "key" of a list is its
+arraylike numeric index):
+
+I<Python>
+
+=begin code :lang<python>
+elems = ["neutronium", "hydrogen", "helium", "lithium"]
+for i, e in enumerate(elems):
+    print "elem no. %d is %s" % (i, e)
+symbols = ["n", "H", "He", "Li"]
+elem4Symbol = {s: e for s, e in zip(symbols, elems)}
+for symbol, elem in elem4Symbol.items():
+    print "Symbol '%s' stands for %s" % (symbol, elem)
+# elem no. 0 is neutronium
+# elem no. 1 is hydrogen
+# elem no. 2 is helium
+# elem no. 3 is lithium
+# Symbol 'H' stands for hydrogen
+# Symbol 'He' stands for helium
+# Symbol 'Li' stands for lithium
+# Symbol 'n' stands for neutronium
+=end code
+
+I<Raku>
+
+    my @elems = <neutronium hydrogen helium lithium>;
+    for @elems.kv -> $i, $e {
+        say "elem no. $i is $e"
+    }
+    
+    my @symbols = <n H He Li>;
+    my %elem-for-symbol;
+    %elem-for-symbol{@symbols} = @elems;
+    
+    # Note that the iteration order will differ from Python
+    for %elem-for-symbol.kv -> $symbol, $element {
+        say "Symbol '$symbol' stands for $element";
+    }
 
 =head2 X<Lambdas, functions and subroutines|Python>
 

--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -357,7 +357,7 @@ I<Raku>
         say $c;
     }
 
-Uses of Python's C<for… in enumerate(…)> and C<.items()> mechanisms for
+Uses of Python's C<enumerate()> and C<.items()> mechanisms for
 iterating lists or dict/maps can both be achieved using the same
 L<kv|/routine/kv> method in Raku (because the "key" of a list is its
 arraylike numeric index):
@@ -367,15 +367,15 @@ I<Python>
 =begin code :lang<python>
 elems = ["neutronium", "hydrogen", "helium", "lithium"]
 for i, e in enumerate(elems):
-    print "elem no. %d is %s" % (i, e)
+    print "Elem no. %d is %s" % (i, e)
 symbols = ["n", "H", "He", "Li"]
 elem4Symbol = {s: e for s, e in zip(symbols, elems)}
 for symbol, elem in elem4Symbol.items():
     print "Symbol '%s' stands for %s" % (symbol, elem)
-# elem no. 0 is neutronium
-# elem no. 1 is hydrogen
-# elem no. 2 is helium
-# elem no. 3 is lithium
+# Elem no. 0 is neutronium
+# Elem no. 1 is hydrogen
+# Elem no. 2 is helium
+# Elem no. 3 is lithium
 # Symbol 'H' stands for hydrogen
 # Symbol 'He' stands for helium
 # Symbol 'Li' stands for lithium
@@ -386,7 +386,7 @@ I<Raku>
 
     my @elems = <neutronium hydrogen helium lithium>;
     for @elems.kv -> $i, $e {
-        say "elem no. $i is $e"
+        say "Elem no. $i is $e"
     }
     
     my @symbols = <n H He Li>;


### PR DESCRIPTION
Resolves #3924.

Modified from suggestion in issue to include `kv()`’s other use case in maps,
matching Python’s `dict.items()`.