### PR TITLE
Add missing "#" on OUTPUT comment

### DIFF
--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -329,7 +329,7 @@ To get a hexadecimal list of each byte of a string (i.e. hex encoder),
 first convert the string to a L<Blob|/type/Blob> with L<.encode|/routine/encode>.
 
 =begin code
-say "I ❤ 🦋".encode>>.base(16);  OUTPUT: «(49 20 E2 9D A4 20 F0 9F A6 8B)␤»
+say "I ❤ 🦋".encode>>.base(16);  # OUTPUT: «(49 20 E2 9D A4 20 F0 9F A6 8B)␤»
 =end code
 
 Note that L<.gist|/routine/gist> or L<.raku|/routine/raku> methods can be useful for variable introspection:

--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -166,7 +166,7 @@ array's underlying iterator.
 
 =for code
 my @a = <a 2 c>;
-say @a.flat.^name; OUTPUT: «Seq␤»
+say @a.flat.^name; # OUTPUT: «Seq␤»
 
 
 =head2 method shift

--- a/doc/Type/Parameter.pod6
+++ b/doc/Type/Parameter.pod6
@@ -182,7 +182,7 @@ Returns C<True> for raw parameters.
             say $sig.params[$_].raw;
         }
     }
-    f(17, "4711", 42); OUTPUT: «False␤True␤True␤»
+    f(17, "4711", 42); # OUTPUT: «False␤True␤True␤»
 
 Raw parameters bind either a variable or a value passed to it, with
 no decontainerization taking place.  That means that if a variable was passed


### PR DESCRIPTION
Just a small fix to add missing `#` character on OUTPUT comment.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
