### PR TITLE
Explain behavior of non-alphanumerics in <[ ]>

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -696,17 +696,17 @@ whitespace.
 
 As the last line above illustrates, within C«<[ ]>» you do I<not> need to
 quote or escape most non-alphanumeric characters the way you do in regex text
-outside of C«<[ ]>».  You do, however, need to escape the much smaller set of 
+outside of C«<[ ]>».  You do, however, need to escape the much smaller set of
 characters that have special meaning within C«<[ ]>», such as C<\>, C<[>, and
-C<]>.  
+C<]>.
 
 X<|escaping characters>
 To escape characters that would have some meaning inside the C«<[ ]>», precede
 the character with a C<\>.
 
     say "[ hey ]" ~~ /<-[ \] \[ \s ]>+/; # OUTPUT: «｢hey｣␤»
-    
-You do not have the option of quoting special characters inside a C«<[ ]>» – 
+
+You do not have the option of quoting special characters inside a C«<[ ]>» –
 a C<'> just matches a literal C<'>.
 
 Within the C«< >» you can use C<+> and C<-> to add or remove multiple range

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -691,6 +691,23 @@ whitespace.
     "ÀÁÂÃÄÅÆ" ~~ / <[ \x[00C0] .. \x[00C6] ]>* /;
     # Unicode named codepoint range
     "αβγ" ~~ /<[\c[GREEK SMALL LETTER ALPHA]..\c[GREEK SMALL LETTER GAMMA]]>*/;
+    # Non-alphanumeric
+    '$@%!' ~~ /<[ ! @ $ % ]>+/  # OUTPUT: «｢$@%!｣␤»
+
+As the last line above illustrates, within C«<[ ]>» you do I<not> need to
+quote or escape most non-alphanumeric characters the way you do in regex text
+outside of C«<[ ]>».  You do, however, need to escape the much smaller set of 
+characters that have special meaning within C«<[ ]>», such as C<\>, C<[>, and
+C<]>.  
+
+X<|escaping characters>
+To escape characters that would have some meaning inside the C«<[ ]>», precede
+the character with a C<\>.
+
+    say "[ hey ]" ~~ /<-[ \] \[ \s ]>+/; # OUTPUT: «｢hey｣␤»
+    
+You do not have the option of quoting special characters inside a C«<[ ]>» – 
+a C<'> just matches a literal C<'>.
 
 Within the C«< >» you can use C<+> and C<-> to add or remove multiple range
 definitions and even mix in some of the Unicode categories above. You can also
@@ -705,12 +722,6 @@ You can include Unicode properties in the list as well:
 
     /<:Zs + [\x9] - [\xA0]>/
     # Any character with "Zs" property, or a tab, but not a "no-break space"
-
-X<|escaping characters>
-You can use C<\> to escape characters that would have some meaning in the
-regular expression:
-
-    say "[ hey ]" ~~ /<-[ \] \[ \s ]>+/; # OUTPUT: «｢hey｣␤»
 
 To negate a character class, put a C<-> after the opening angle bracket:
 


### PR DESCRIPTION
The docs previously mentioned that you can  use `\` to escape characters inside `<[  ]>` ; this PR adds the fact that you don't need to escape most non-alphanumeric characters the way you do in the portion of a regex outside `<[ ]>` and that you must escape (rather than quote) characters inside `<[ ]>` for them to have their literal meaning.
