### PR TITLE
passing indeterminate number of parameters to MAIN

### DIFF
--- a/doc/Language/create-cli.pod6
+++ b/doc/Language/create-cli.pod6
@@ -100,6 +100,19 @@ Another way to do this is to make C<sub MAIN> a C<multi sub>:
 Which would give the same output as the examples above. Whether you should
 use either method to achieve the desired goal is entirely up to you.
 
+If you want to pass an indeterminate number of parameters to be dealt within
+C<sub MAIN>, you can use L<slurpy parameters|/type/Signature/#Flattened_slurpy>:
+
+    # inside file 'hello-all.raku'
+    sub MAIN(*@all) { @all.map: -> $name { say "Hello, " ~ $name } }
+
+=begin code :lang<shell>
+$ raku hello-all.raku peter paul mary
+Hello, peter
+Hello, paul
+Hello, mary
+=end code
+
 A more complicated example using a single positional and multiple
 named parameters, and also showing that C<where> clauses can also be applied
 to C<MAIN> arguments:


### PR DESCRIPTION
## The problem
When passing an indeterminate number of parameters to `sub MAIN` there might be some confusion that `sub MAIN(@a)` might work. It took me a while to debug that such a declaration will not accept any number of parameters.

## Solution provided
A simple example that uses slurpy parameters `sub MAIN(*@a)` to accept multiple arguments.

PR is relevant to the issue: https://github.com/Raku/doc/issues/2167