### PR TITLE
Clarify where rx declarator allows adverbs

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -84,12 +84,14 @@ of a L<comment|/language/syntax#Single-line_comments> that runs until the end of
 the line.
 =end item
 
-Secondly, the C<rx> form enables the use of
-L<regex adverbs|/language/regexes#Regex_adverbs>, which may be placed between C<rx> and the
-opening delimiter to modify the definition of the entire regex:
+Secondly, the C<rx> form allows you to insert
+L<regex adverbs|/language/regexes#Regex_adverbs> between C<rx> and the
+opening delimiter to modify the definition of the entire regex.  This is equivalent to
+inserting the adverb at the beginning of the regex, but may be clearer:
 
     rx:r:s/pattern/;            # :r (:ratchet) and :s (:sigspace) adverbs, defining
                                 # a ratcheting regex in which whitespace is significant
+    rx/:r:s pattern/;           # Same, but possibly less readable
 
 Although anonymous regexes are not, as such, I<named>, they may effectively be
 given a name by putting them inside a named variable, after which they can be


### PR DESCRIPTION
A regex declared with `rx` allows adverbs both before the delimiter (`rx:s/pattern/`) and after (`rx/:s pattern/`), but the docs only mentioned the first option.  This fixes that, and brings the rx section of the page into alignment with the adverb section.
