### PR TITLE
Corrected Ruby nutshell typo

### DIFF
--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -289,7 +289,10 @@ add(2, 3);                       # => 5, and it works without it
 =end code
 
 =for code :lang<ruby>
-foo_method = &foo;     # Ruby
+def foo
+  ...
+end
+foo_method = method(:foo);     # Ruby
 =for code
 sub foo { ... };
 my &foo_method = &foo; # Raku


### PR DESCRIPTION
## The problem

The Ruby "in a nutshell" page shows the following syntax

    foo_method = &foo

This is not valid Ruby syntax.

## Solution provided

Ruby methods are strictly in a different namespace than values. To convert a method (such as one named `foo`) to a first-class value, we use the built-in method called, appropriately, `method`.

    def foo
      ...
    end
    foo_method = method(:foo)

Then we call it using the call syntax. The following two lines are equivalent

    foo_method.()
    foo_method.call

This PR updates the Ruby code snippet in question.