### PR TITLE
Note that &?ROUTINE refers to current multi

### DIFF
--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -1351,6 +1351,24 @@ sub do-work {
 do-work;
 =end code
 
+Note that, in a L<C«multi»|/language/functions#index-entry-declarator_multi-Multi-dispatch>,
+C<&?ROUTINE> refers to the current candidate, I<not> the C<multi>
+as a whole.
+
+Thus, the following recursive definition does B<not> work:
+
+=begin code
+multi broken-fibonacci($n where * ≤ 1) { $n }
+multi broken-fibonacci($n where * > 0) {
+    &?ROUTINE($n - 1) + &?ROUTINE($n - 2)
+}
+=end code
+
+If called, C<&?ROUTINE> would always refer to the second
+multi candidate and would never dispatch to the first.  If
+you want to use self-recursion for the whole C<proto>, either
+use the function name or L<C«samewith»|language/functions#sub_samewith>.
+
 =head3 X<&?BLOCK>
 
 The special compile variable C<?&BLOCK> behaves similarly to


### PR DESCRIPTION
This PR adds a note that `&?ROUTINE` refers to the current `multi` candidate and compares it to `samewith`, which allows self-recursion to the entire proto.
