### PR TITLE
Correct description of samewith

### DIFF
--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -1087,18 +1087,18 @@ a 1;        # OUTPUT: «Int 1␤Any 2␤»
 
 X<|dispatch,samewith>
 
-C<samewith> calls current candidate again with arguments provided by users
-and returns the return value of the new instance of current candidate.
+C<samewith> calls the multi again with arguments provided at the callsite
+and returns the value provided by the call.  This can be used for self-recursion.
 
 =begin code
-proto a(|) {*}
+proto factorial(|) {*}
 
-multi a(Int $x) {
-  return 1 unless $x > 1;
-  return $x * samewith($x-1);
+multi factorial(Int $x where * ≤ 1) { 1 }
+multi factorial(Int $x) {
+    $x * samewith($x-1);
 }
 
-say (a 10); # OUTPUT: «36288000␤»
+say (factorial 10); # OUTPUT: «36288000␤»
 =end code
 
 X<|dispatch,nextcallee>


### PR DESCRIPTION
The docs previously stated that `samewith` calls the same multi _candidate_, but `samewith` calls the entire `multi`.  This PR corrects that, and adds an example that illustrates `samewith`'s behavior.  It also changes the name of the example function (which computes the factorial of a number) from `a` to `factorial` for clarity.
