### PR TITLE
Document attribute aliases

### DIFF
--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -184,6 +184,24 @@ class Journey {
 }
 =end code
 
+Alternatively, you can omit the twigil, which will still create the private
+attribute (with a C<!> twigil), and will also create an alias that binds
+the name (without the twigil) to that attribute.  Thus, you can declare the
+same class above with
+
+=begin code
+class Journey {
+    has $origin;
+    has $destination;
+    has @travelers;
+    has $notes;
+}
+=end code
+
+If you declare the class like this, you can subsequently access the attributes
+either with or without the twigil – e.g., C<$!origin> and C<$origin> refer to
+same attribute.
+
 While there is no such thing as a public (or even protected) attribute,
 there is a way to have accessor methods generated automatically: replace the
 C<!> twigil with the C<.> twigil (the C<.> should remind you of a method


### PR DESCRIPTION
Part of the spec in Roast [S12-class/attributes.t](https://github.com/Raku/roast/blob/master/S12-class/attributes.t#L23-L33).
