### PR TITLE
Describe use of non-$ sigils with ^ and : twigils

### DIFF
--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -241,9 +241,9 @@ variable, that is, where that variable is defined and can be changed.
 
 =end table
 
-X<|$*>
 X<|Dynamically scoped variables>
 =head2 The C<*> twigil
+X<|twigil,*>X<|twigil,$*>X<|twigil,@*>X<|twigil,%*>X<|twigil,&*>
 
 This twigil is used for dynamic variables which are looked up through the
 caller's, not through the outer, scope. Look at the example below.N<The example
@@ -307,7 +307,7 @@ symbol tables introduced with C<our> are two orthogonal issues.
 
 
 =head2 The C<?> twigil
-X<|$?>
+X<|twigil,?>X<|twigil,$?>X<|twigil,@?>X<|twigil,%?>X<|twigil,&?>
 
 Compile-time variables may be addressed via the C<?> twigil. They are known
 to the compiler and may not be modified after being compiled in. A popular
@@ -321,7 +321,7 @@ For a list of these special variables, see
 L<compile-time variables|/language/variables#Compile-time_variables>.
 
 =head2 The C<!> twigil
-X<|$!>
+X<|twigil,!>X<|twigil,$!>X<|twigil,@!>X<|twigil,%!>X<|twigil,&!>
 
 L<Attributes|/language/objects#Attributes> are variables that exist per instance
 of a class. They may be directly accessed from within the class via C<!>:
@@ -344,7 +344,7 @@ L<object orientation|/language/objects>.
 
 
 =head2 The C<.> twigil
-X<|$.>
+X<|twigil,.>X<|twigil,$.>X<|twigil,@.>X<|twigil,%.>X<|twigil,&.>
 
 The C<.> twigil isn't really for variables at all. In fact, something along
 the lines of
@@ -377,10 +377,8 @@ For more details on objects, classes and their attributes and methods see
 L<object orientation|/language/objects>.
 
 =head2 The C<^> twigil
-X<|$^>
-X<|@^>
-X<|%^>
-X<|&^>
+X<|twigil,^>X<|twigil,$^>X<|twigil,@^>X<|twigil,%^>X<|twigil,&^>
+
 
 The C<^> twigil declares a formal positional parameter to blocks or subroutines;
 that is, variables of the form C<$^variable> are a type of placeholder variable.
@@ -415,15 +413,13 @@ single upper-case letter (this is disallowed to enable catching some
 Perl-isms).
 
 The C<^> twigil can be combined with any sigil to create a placeholder variable
-with the appropriate type constraint.  Thus C<@^positional>,C<%^associative>,and
-C<&^callable> are all valid placeholder variables.
+with that sigil.  The sigil will have its normal semantic effects, as described
+in the L<Sigils table|#Sigils>. Thus C<@^array>, C<%^hash>, and C<&^fun> are all
+valid placeholder variables.
 
 
 =head2 The C<:> twigil
-X<|$:>
-X<|@:>
-X<|%:>
-X<|&:>
+X<|twigil,:>X<|twigil,$:>X<|twigil,@:>X<|twigil,%:>X<|twigil,&:>
 
 The C<:> twigil declares a formal named parameter to a block or subroutine.
 Variables declared using this form are a type of placeholder variable too.
@@ -459,13 +455,14 @@ only one (but refers to it twice).  This can be especially significant with cons
 such as C<with>, C<for>, and C<if> that are often used without much consideration of
 the fact that they create blocks.
 
-Just like the C<^>twigil, the C<:> twigil can can be combined with any sigil; using
-C<:> with a sigil will create a formal named parameter of the appropriate type.  Thus
-C<@:positional>,C<%:associative>,and C<&:callable> are all valid, and each creates
-a formal named parameter with the respective type constraint.
+Just like the C<^>twigil, the C<:> twigil can be combined with any sigil; using
+C<:> with a sigil will create a formal named parameter with that sigil (applying
+the L<semantics of that sigil|#Sigil>).  Thus C<@:array>, C<%:hash>, and
+C<&:fun> are all valid, and each creates a formal named parameter with the
+specified sigil.
 
 =head2 The C<=> twigil
-X<|$=>
+X<|twigil,=>X<|twigil,$=>X<|twigil,@=>X<|twigil,%=>X<|twigil,&=>
 
 The C<=> twigil is used to access Pod variables. Every Pod block in the
 current file can be accessed via a Pod object, such as C<$=data>,
@@ -489,7 +486,7 @@ Note that all those C<$=someBlockName> support the C<Positional> and the
 C<Associative> roles.
 
 =head2 The C<~> twigil
-X<|$~>
+X<|twigil,$~>X<|twigil,~>
 
 The C<~> twigil is for referring to sublanguages (called slangs). The
 following are useful:

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -378,6 +378,9 @@ L<object orientation|/language/objects>.
 
 =head2 The C<^> twigil
 X<|$^>
+X<|@^>
+X<|%^>
+X<|&^>
 
 The C<^> twigil declares a formal positional parameter to blocks or subroutines;
 that is, variables of the form C<$^variable> are a type of placeholder variable.
@@ -411,8 +414,16 @@ Placeholder variables cannot have type constraints or a variable name with a
 single upper-case letter (this is disallowed to enable catching some
 Perl-isms).
 
+The C<^> twigil can be combined with any sigil to create a placeholder variable
+with the appropriate type constraint.  Thus C<@^positional>,C<%^associative>,and
+C<&^callable> are all valid placeholder variables.
+
+
 =head2 The C<:> twigil
 X<|$:>
+X<|@:>
+X<|%:>
+X<|&:>
 
 The C<:> twigil declares a formal named parameter to a block or subroutine.
 Variables declared using this form are a type of placeholder variable too.
@@ -447,6 +458,11 @@ The first line declares I<two> formal positional parameters, while the second de
 only one (but refers to it twice).  This can be especially significant with constructs
 such as C<with>, C<for>, and C<if> that are often used without much consideration of
 the fact that they create blocks.
+
+Just like the C<^>twigil, the C<:> twigil can can be combined with any sigil; using
+C<:> with a sigil will create a formal named parameter of the appropriate type.  Thus
+C<@:positional>,C<%:associative>,and C<&:callable> are all valid, and each creates
+a formal named parameter with the respective type constraint.
 
 =head2 The C<=> twigil
 X<|$=>


### PR DESCRIPTION
This PR describes the use of non-`$` sigils (that is, `@`, `%`, and `&`) with the `^` and `:` twigils.  It also adds `@^`, `%^`, `&^`, `@:`, `%:`, and `&:` to the index.

Closes #3953
