### PR TITLE
Add output to "multiple heredoc" example

### DIFF
--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -567,7 +567,9 @@ that line only. Then, until you get an error, add each line in turn.
 (Creating a Raku program to do that is left as an exercise for the
 reader.)
 
-You can begin multiple Heredocs in the same line.
+You can begin multiple Heredocs in the same line. If you do so, the
+second heredoc will not start until after the first heredoc has
+ended.
 
 =begin code
 my ($first, $second) = qq:to/END1/, qq:to/END2/;
@@ -579,6 +581,8 @@ my ($first, $second) = qq:to/END1/, qq:to/END2/;
    MULTILINE
    STRING
    END2
+say $first;  # OUTPUT: «FIRST␤MULTILINE␤STRING␤»
+say $second; # OUTPUT: «SECOND␤MULTILINE␤STRING␤»
 =end code
 
 X<|Unquoting>


### PR DESCRIPTION
The docs previously stated that you can start multiple heredocs on a single line, but neither said what effect that had nor showed the output in the accompanying example.

This PR adds both an explanation and example output.
