### PR TITLE
Clarify that enum iteration is unordered

### DIFF
--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -788,7 +788,12 @@ the keys.
     enum E <one two>;
     my @keys = E::.values;
     say @keys.map: *.raku;
-    # OUTPUT: «(E::one E::two)␤»
+    # OUTPUT: «(E::one E::two)␤» or «(E::two E::one)␤»
+
+Note that, as the output above indicates, the iteration order of enums
+is not guaranteed.  This is because enums are C<Map>s.  If you need
+to iterate an enum in order, you may do so by sorting on its C<value>,
+for example with C<E.enums.sort(*.value)>
 
 With the use of B<()> parentheses, an enum can be defined using any
 arbitrary dynamically defined list. The list should consist of Pair


### PR DESCRIPTION
Because enums are `Map`s, they do not iterate in any defined order.  But the docs didn't mention this, and provided an example that suggested ordered iteration.  This PR adds a note to that effect and updates the example.
