### PR TITLE
Improve documentation of the list routine

### DIFF
--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -677,6 +677,9 @@ grab($b);        # OUTPUT: «grab 1␤grab 2␤»
 my \c = (1, 2);  # Sigilless variables always bind, even with '='
 grab(c);         # OUTPUT: «grab 1␤grab 2␤»
 
+See the L«documentation of the C<list> subroutine|/type/List#routine_list» for
+more examples of how to use a routine that adheres to the single argument rule.
+
 =head1 Functions are first-class objects
 
 Functions and other code objects can be passed around as values, just like any

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -84,9 +84,8 @@ L<none|/routine/none>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-    multi method list(Any:U: --> List)
-    multi method list(Any:D \SELF: --> List)
-
+    multi method list(Any:U:)
+    multi method list(Any:D \SELF:)
 
 Applies the infix L«C<,>|/routine/,» operator to the invocant and returns
 the resulting L<List|/type/List>:

--- a/doc/Type/Channel.pod6
+++ b/doc/Type/Channel.pod6
@@ -120,7 +120,7 @@ phaser to enforce the C<.close> call in this case.
 
 Defined as:
 
-    method list(Channel:D: --> List:D)
+    method list(Channel:D:)
 
 Returns a list based on the C<Seq> which will iterate items in the queue and
 remove each item from it as it iterates. This can only terminate once the

--- a/doc/Type/Failure.pod6
+++ b/doc/Type/Failure.pod6
@@ -174,6 +174,15 @@ the failure as handled.
     say $v.defined; # OUTPUT: «False␤»
     say $v.handled; # OUTPUT: «True␤»
 
+=head2 method list
+
+Defined as:
+
+    multi method list(Failure:D:)
+
+Marks the failure as handled and throws the invocant's
+L<exception|/type/Failure#method_exception>.
+
 =head2 sub fail
 
 Defined as:

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -207,7 +207,7 @@ list contextualizer|/type/Any#index-entry-@_list_contextualizer>:
     put list($tuple<>).raku;    # OUTPUT: «(1, 2)␤»
     put list(@$tuple).raku;     # OUTPUT: «(1, 2)␤»
 
-Note that listing the elements of a type object may not do what you expect:
+Note that converting a type object to a list may not do what you expect:
 
     put List.list.raku;         # OUTPUT: «(List,)␤»
 
@@ -218,25 +218,27 @@ type whose type object should be a valid representation of an empty collection,
 you may want to provide your own candidate for undefined invocants or override
 the C<Any:> candidates with an "only" method. For example:
 
-    my class LinkedList {
-        has $.value;            # the value stored in this node
-        has LinkedList $.next;  # undefined if there is no next node
+=begin code
+my class LinkedList {
+    has $.value;            # the value stored in this node
+    has LinkedList $.next;  # undefined if there is no next node
 
-        method values( --> Seq:D) {
-            my $node := self;
-            gather while $node {
-                take $node.value;
-                $node := $node.next;
-            }
-        }
-
-        method list( --> List:D) {
-            self.values.list;
+    method values( --> Seq:D) {
+        my $node := self;
+        gather while $node {
+            take $node.value;
+            $node := $node.next;
         }
     }
 
-    my LinkedList $nodes;       # an empty linked list
-    put $nodes.list.raku;       # OUTPUT: «()␤»
+    method list( --> List:D) {
+        self.values.list;
+    }
+}
+
+my LinkedList $nodes;       # an empty linked list
+put $nodes.list.raku;       # OUTPUT: «()␤»
+=end code
 
 =head2 routine elems
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -175,6 +175,69 @@ If C<$topic> is I<not> an L<Iterable|/type/Iterable>, returns the invocant if
 the invocant has no elements or its first element is a L<Match|/type/Match>
 object (this behavior powers C<m:g//> smartmatch), or C<False> otherwise.
 
+=head2 routine list
+
+Defined as:
+
+    multi sub    list(+list)
+    multi method list(List:D:)
+
+The method just returns the invocant L<self|/routine/self>. The subroutine
+adheres to the L<single argument rule|/language/functions#Slurpy_conventions>:
+if called with a single argument that is a non-L<itemized|/language/mop#VAR>
+C<Iterable> it returns a C<List> based on the argument's
+L<iterator|/routine/iterator>; otherwise it just returns the argument list.
+
+For example:
+
+    my $tuple = (1, 2);         # an itemized List
+    put $tuple.list.raku;       # OUTPUT: «(1, 2)␤»
+    put list($tuple).raku;      # OUTPUT: «($(1, 2),)␤»
+    put list(|$tuple).raku;     # OUTPUT: «(1, 2)␤»
+
+The last statement uses the L«C<prefix:<|>>|/language/operators#prefix_|»
+operator to flatten the tuple into an argument list, so it is equivalent to:
+
+    put list(1, 2).raku;        # OUTPUT: «(1, 2)␤»
+
+There are other ways to list the elements of an itemized single argument. For
+example, you can L«decontainerize|/routine/<>» the argument or use the L<C<@>
+list contextualizer|/type/Any#index-entry-@_list_contextualizer>:
+
+    put list($tuple<>).raku;    # OUTPUT: «(1, 2)␤»
+    put list(@$tuple).raku;     # OUTPUT: «(1, 2)␤»
+
+Note that listing the elements of a type object may not do what you expect:
+
+    put List.list.raku;         # OUTPUT: «(List,)␤»
+
+This is because the C<.list> candidate accepting a type object as the invocant
+is provided by L<C<Any>|/routine/list#(Any)_method_list>. That candidate returns
+a list with one element: the type object self. If you're developing a collection
+type whose type object should be a valid representation of an empty collection,
+you may want to provide your own candidate for undefined invocants or override
+the C<Any:> candidates with an "only" method. For example:
+
+    my class LinkedList {
+        has $.value;            # the value stored in this node
+        has LinkedList $.next;  # undefined if there is no next node
+
+        method values( --> Seq:D) {
+            my $node := self;
+            gather while $node {
+                take $node.value;
+                $node := $node.next;
+            }
+        }
+
+        method list( --> List:D) {
+            self.values.list;
+        }
+    }
+
+    my LinkedList $nodes;       # an empty linked list
+    put $nodes.list.raku;       # OUTPUT: «()␤»
+
 =head2 routine elems
 
 Defined as:

--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -197,7 +197,7 @@ Returns a C<Seq> of keys and values interleaved.
 
 Defined as:
 
-    method list(Map:D: --> List:D)
+    multi method list(Map:D: --> List:D)
 
 Returns a C<List> of L<Pair|/type/Pair> objects of all keys and values in the Map.
 

--- a/doc/Type/PositionalBindFailover.pod6
+++ b/doc/Type/PositionalBindFailover.pod6
@@ -56,7 +56,7 @@ Subsequent calls to C<cache> always return the same C<List> object.
 
 =head2 method list
 
-    method list(PositionalBindFailover:D: --> List:D)
+    multi method list(::?CLASS:D:)
 
 Returns a L<List|/type/List> based on the C<iterator> method without caching it.
 

--- a/doc/Type/QuantHash.pod6
+++ b/doc/Type/QuantHash.pod6
@@ -52,6 +52,15 @@ Defined as
 
 Returns the object as a C<Capture> by previously coercing it to a C<Hash>.
 
+=head2 method list
+
+Defined as:
+
+    multi method list(QuantHash:D:)
+
+Returns a list of L<Pair|/type/Pair> objects of all keys and values in the
+QuantHash.
+
 =head2 method Setty
 
     method Setty(--> Setty:D)

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -307,7 +307,7 @@ either end point was specified as C<*>.
 
 =head2 method list
 
-    method list(Range:D: --> List:D)
+    multi method list(Range:D:)
 
 Generates the list of elements that the range represents.
 

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -187,7 +187,7 @@ the exception that was passed to C<quit>).
 
 =head2 method list
 
-    method list(Supply:D: --> List:D)
+    multi method list(Supply:D:)
 
 Taps the C<Supply> it is called on, and returns a lazy list that will be reified
 as the C<Supply> emits values. The list will be terminated once the C<Supply> is

--- a/doc/Type/Uni.pod6
+++ b/doc/Type/Uni.pod6
@@ -23,6 +23,14 @@ C<NFKD> and C<NFKC>, which represent strings in one of the L<Unicode Normalizati
 
 Creates a new C<Uni> instance from the given codepoint numbers.
 
+=head2 method list
+
+Defined as:
+
+    method list(Uni:D:)
+
+Returns a C<Seq> of integer codepoints.
+
 =head2 method NFC
 
     method NFC(Uni:D: --> NFC:D)


### PR DESCRIPTION
The documentation of the `list` subroutine is a good place to explain the
single argument rule yet again.

Most core types implementing a `list` method only accept an object instance
as the invocant. If the core type implements `list` as a multi method,
listing the type object is handled by

    multi method list(Any:U: --> List)
