### PR TITLE
Talk about collections rather than containers

### DIFF
--- a/doc/Type/independent-routines.pod6
+++ b/doc/Type/independent-routines.pod6
@@ -1200,9 +1200,9 @@ Routines that manipulate arrays and other mutable collections.
 
 Defined as:
 
-    multi sub pop(@collection) is raw
+    multi sub pop(@a) is raw
 
-Calls method C<pop> on the C<Positional> collection. That method is supposed to
+Calls method C<pop> on the C<Positional> argument. That method is supposed to
 remove and return the last element, or return a L<C<Failure>|/type/Failure> if
 the collection is empty.
 
@@ -1213,9 +1213,9 @@ for an example.
 
 Defined as:
 
-    multi sub shift(@collection) is raw
+    multi sub shift(@a) is raw
 
-Calls method C<shift> on the C<Positional> collection. That method, on
+Calls method C<shift> on the C<Positional> argument. That method, on
 a mutable collection that actually implements it (such as an
 L<C<Array>|/routine/shift#(Array)_method_shift> or a
 L<C<Buf>|/routine/shift#(Buf)_method_shift>), is supposed to remove
@@ -1235,40 +1235,41 @@ say shift @a; # ERROR: «Cannot shift from an empty Array[Int]␤»
 
 Defined as:
 
-    multi sub push(\collection, **@values is raw)
-    multi sub push(\collection, \arg)
+    multi sub push(\a, **@b is raw)
+    multi sub push(\a, \b)
 
-Calls method C<push> on the collection, which is supposed to add the provided
-values to the end of the collection or parts thereof. See the documentation of
-the L<C<Hash> method|/routine/push#(Hash)_method_push> for an example where
+Calls method C<push> on the first argument, passing the remaining arguments.
+Method C<push> is supposed to add the provided values to the end of the
+collection or parts thereof. See the documentation of the
+L<C<Hash> method|/routine/push#(Hash)_method_push> for an example where
 indirection via this subroutine can be helpful.
 
-The C<push> method of the collection is supposed to flatten all arguments of
-type C<Slip>. Therefore, if you want to implement a conforming method for a new
-collection type, it should behave as if its signature was just:
+The C<push> method is supposed to flatten all arguments of type C<Slip>.
+Therefore, if you want to implement a conforming method for a new collection
+type, it should behave as if its signature was just:
 
-    multi method push(::?CLASS:D: **@values --> ::?CLASS:D)
+    multi method push(::?CLASS:D: **@values is raw --> ::?CLASS:D)
 
 Autovivification to an instance of the new type is L<provided by the default
 base class|/routine/append#(Any)_method_append> if the new type implements the
 C<Positional> role. If the new type is not C<Positional>, autovivification can
-be implemented by an additional multi method with a signature like
+be supported by an adding a multi method with a signature like
 
-    multi method push(::?CLASS:U: **@values --> ::?CLASS:D)
+    multi method push(::?CLASS:U: **@values is raw --> ::?CLASS:D)
 
 =head2 sub append
 
 Defined as:
 
-    multi sub append(\collection, **@values is raw)
-    multi sub append(\collection, \arg)
+    multi sub append(\a, **@b is raw)
+    multi sub append(\a, \b)
 
-Calls method C<append> on the collection, which is supposed to add the provided
-values to the end of the collection or parts thereof. Unlike method C<push>,
-method C<append> should follow the L<single argument
-rule|/language/functions#Slurpy_conventions>. So if you want to implement a
-conforming method C<append> for a new collection type, it should behave as if
-its signature was just:
+Calls method C<append> on the first argument, passing the remaining arguments.
+Method C<append> is supposed to add the provided values to the end of the
+collection or parts thereof. Unlike method C<push>, method C<append> should
+follow the L<single argument rule|/language/functions#Slurpy_conventions>. So
+if you want to implement a conforming method C<append> for a new collection
+type, it should behave as if its signature was just:
 
     multi method append(::?CLASS:D: +values --> ::?CLASS:D)
 

--- a/doc/Type/independent-routines.pod6
+++ b/doc/Type/independent-routines.pod6
@@ -1194,17 +1194,17 @@ hashes, whose use is advised.
 
 =head1 Array manipulation
 
-Routines that manipulate arrays and other containers.
+Routines that manipulate arrays and other mutable collections.
 
 =head2 sub pop
 
 Defined as:
 
-    multi sub pop(@container) is raw
+    multi sub pop(@collection) is raw
 
-Calls method C<pop> on the C<Positional> container. That method is supposed to
+Calls method C<pop> on the C<Positional> collection. That method is supposed to
 remove and return the last element, or return a L<C<Failure>|/type/Failure> if
-the container is empty.
+the collection is empty.
 
 See the documentation of the L<C<Array> method|/routine/pop#(Array)_method_pop>
 for an example.
@@ -1213,14 +1213,14 @@ for an example.
 
 Defined as:
 
-    multi sub shift(@container) is raw
+    multi sub shift(@collection) is raw
 
-Calls method C<shift> on the C<Positional> container. That method, on
-a mutable container that actually implements it (such as an
+Calls method C<shift> on the C<Positional> collection. That method, on
+a mutable collection that actually implements it (such as an
 L<C<Array>|/routine/shift#(Array)_method_shift> or a
 L<C<Buf>|/routine/shift#(Buf)_method_shift>), is supposed to remove
 and return the first element, or return a L<C<Failure>|/type/Failure> if the
-container is empty.
+collection is empty.
 
 Example:
 
@@ -1235,17 +1235,17 @@ say shift @a; # ERROR: «Cannot shift from an empty Array[Int]␤»
 
 Defined as:
 
-    multi sub push(\container, **@values is raw)
-    multi sub push(\container, \arg)
+    multi sub push(\collection, **@values is raw)
+    multi sub push(\collection, \arg)
 
-Calls method C<push> on the container, which is supposed to add the provided
-values to the end of the container or parts thereof. See the documentation of
+Calls method C<push> on the collection, which is supposed to add the provided
+values to the end of the collection or parts thereof. See the documentation of
 the L<C<Hash> method|/routine/push#(Hash)_method_push> for an example where
 indirection via this subroutine can be helpful.
 
-The C<push> method of the container is supposed to flatten all arguments of type
-C<Slip>. Therefore, if you want to implement a conforming method for a new
-container type, it should behave as if its signature was just:
+The C<push> method of the collection is supposed to flatten all arguments of
+type C<Slip>. Therefore, if you want to implement a conforming method for a new
+collection type, it should behave as if its signature was just:
 
     multi method push(::?CLASS:D: **@values --> ::?CLASS:D)
 
@@ -1260,15 +1260,15 @@ be implemented by an additional multi method with a signature like
 
 Defined as:
 
-    multi sub append(\container, **@values is raw)
-    multi sub append(\container, \arg)
+    multi sub append(\collection, **@values is raw)
+    multi sub append(\collection, \arg)
 
-Calls method C<append> on the container, which is supposed to add the provided
-values to the end of the container or parts thereof. Unlike method C<push>,
+Calls method C<append> on the collection, which is supposed to add the provided
+values to the end of the collection or parts thereof. Unlike method C<push>,
 method C<append> should follow the L<single argument
 rule|/language/functions#Slurpy_conventions>. So if you want to implement a
-conforming method C<append> for a new container type, it should behave as if its
-signature was just:
+conforming method C<append> for a new collection type, it should behave as if
+its signature was just:
 
     multi method append(::?CLASS:D: +values --> ::?CLASS:D)
 


### PR DESCRIPTION
In Raku parlance, a container generally refers to a scalar container. 
Arrays and hashes are mutable _collections_ that store values in scalar 
containers. To avoid confusion it's better to refer to these composite
types as  collections.
