### PR TITLE
101-basics: correct secondary/primary designation

### DIFF
--- a/doc/Language/101-basics.pod6
+++ b/doc/Language/101-basics.pod6
@@ -344,8 +344,8 @@ tournament.
 When two array items have the same value, C<sort> leaves them in the same order
 as it found them. Computer scientists call this a I<stable sort>. The program
 takes advantage of this property of Raku's C<sort> to achieve the goal by
-sorting twice: first by the number of sets won (the primary criterion), then
-by the number of matches won (the secondary criterion).
+sorting twice: first by the number of sets won (the secondary criterion), then
+by the number of matches won (the primary criterion).
 
 After the first sorting step, the names are in the order C<Beth Charlie Dave
 Ana>. After the second sorting step, it's still the same, because no one has


### PR DESCRIPTION
The previous paragraph points out that matches is the primary sort criterion.
This line takes advantage of stable sort by sorting by the _secondary_ criterion (sets) _first_ and then sorts by the _primary_ (matches).