### PR TITLE
Add $#array equivalent

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -404,7 +404,6 @@ An array's biggest index is now available with the C<.end> method:
 say $#item;    # Perl
 =for code :preamble<no strict;>
 say @item.end; # Raku
-=end item
 
 =head2 {} Hash indexing/slicing
 

--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -398,6 +398,14 @@ operator rather than a special syntactic form, and thus L<checking for
 existence of elements|#exists> and L<unsetting elements|#delete> is done
 with adverbs.
 
+An array's biggest index is now available with the C<.end> method:
+
+=for code :lang<perl>
+say $#item;    # Perl
+=for code :preamble<no strict;>
+say @item.end; # Raku
+=end item
+
 =head2 {} Hash indexing/slicing
 
 Index and slice operations on hashes no longer inflect the variable's


### PR DESCRIPTION
## The problem

I was converting Perl 5 code to Raku and didn't know what the equivalent of `$#array` was, to find the max element of the array. I looked in the Perl-to-Raku guides, but couldn't find the string `$#` in any of them.

## Solution provided

The `.end` method appears to be what I was looking for. That was hard to find. Add a mention in the Perl-to-Raku overview, so others can find it.

I'm not completely sure this is definitely the best place to put it, but it's with other array-index things, and having it somewhere is better than not having it at all.