### PR TITLE
Correct equivalent for split without a pattern

### DIFF
--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -1935,8 +1935,10 @@ also now works as a method: C<"a;b;c".split(';')>
 
 =item split
 
-The zero argument version must now be called with an explicit empty string, as
-described above.
+C<split> now requires a pattern. For the equivalent of Perl's behaviour
+of splitting on whitespace when no pattern is specified, use
+L<words|/routine/words> (or specify the pattern explicitly with
+C<split /\s+/>).
 
 X<| sprintf - perlfunc>
 =head2 sprintf

--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -1937,8 +1937,8 @@ also now works as a method: C<"a;b;c".split(';')>
 
 C<split> now requires a pattern. For the equivalent of Perl's behaviour
 of splitting on whitespace when no pattern is specified, use
-L<words|/routine/words> (or specify the pattern explicitly with
-C<split /\s+/>).
+L<words|/routine/words> (or specify the appropiate space-matching
+pattern explicitly).
 
 X<| sprintf - perlfunc>
 =head2 sprintf

--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -1937,8 +1937,8 @@ also now works as a method: C<"a;b;c".split(';')>
 
 C<split> now requires a pattern. For the equivalent of Perl's behaviour
 of splitting on whitespace when no pattern is specified, use
-L<words|/routine/words> (or specify the appropiate space-matching
-pattern explicitly).
+L<words|/routine/words> (or use C<split> with C</\s+/> as the pattern
+and C<:skip-empty> as a named argument).
 
 X<| sprintf - perlfunc>
 =head2 sprintf


### PR DESCRIPTION
## The problem

In Perl, split without a pattern is different from split "" — telling users of the former to switch to the latter changes from splitting by words to splitting by characters.

## Solution provided

Suggest using words instead, which is probably the most useful Raku alternative, while also mentioning the correct explicit pattern.