### PR TITLE
Fix error re: delegation and simplify some text.

### DIFF
--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -670,8 +670,8 @@ X<|delegation (trait handles)>
 =head2 Delegation
 
 Delegation is a technique whereby an object, the I«delegator», accepts a
-method call but has designated another object, I«delegatee», to process the
-call in its place.  In other words, the I«delegator» publishes some or all
+method call but has designated another object, the I«delegatee», to process the
+call in its place.  In other words, the I«delegator» publishes one or more
 of the I«delegatee»'s methods as its own.
 
 In Raku, delegation is specified by applying the L«handles|/language/typesystem#trait_handles»

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -669,13 +669,14 @@ $test.Parent::frob;  # calls the frob method of Parent
 X<|delegation (trait handles)>
 =head2 Delegation
 
-Delegation is a technique whereby a member of an object (the I«delegatee») is
-evaluated in the context of another original object (the I«delegator»). In other
-words, all method calls on the delegator are I«delegated» to the delegatee.
+Delegation is a technique whereby an object, the I«delegator», accepts a
+method call but has designated another object, I«delegatee», to process the
+call in its place.  In other words, the I«delegator» publishes some or all
+of the I«delegatee»'s methods as its own.
 
 In Raku, delegation is specified by applying the L«handles|/language/typesystem#trait_handles»
 trait to an attribute. The arguments provided to the trait specify the methods
-the current object and the delegatee object will have in common. Instead of a
+the object and the I«delegatee» attribute will have in common. Instead of a
 list of method names, a C<Pair> (for renaming), a list of C<Pairs>, a C<Regex>
 or a C<Whatever> can be provided.
 


### PR DESCRIPTION
The doc says that  an object delegates all methods to one delegatee.

 The quoting of delegator /delegatee/delegation is inconsistent.

I have simplified the language for finding 'current' and 'original' unhelpful.