### PR TITLE
\d is for decimal

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -472,16 +472,16 @@ character that is not whitespace.
 
 =head3 X<C<\d> and C<\D>|regex,\d;regex,\D>
 
-C<\d> matches a single digit (Unicode property C<N>) and C<\D> matches a
-single character that is not a digit.
+C<\d> matches a single decimal number (Unicode property C<Nd>) and C<\D> matches a
+single character that is not a decimal number.
 
     'ab42' ~~ /\d/ and say ~$/;     # OUTPUT: «4␤»
     'ab42' ~~ /\D/ and say ~$/;     # OUTPUT: «a␤»
 
 Note that not only the Arabic digits (commonly used in the Latin
-alphabet) match C<\d>, but also digits from other scripts.
+alphabet) match C<\d>, but also decimal numbers from other scripts.
 
-Examples of digits are:
+Examples of decimal numbers are:
 
 =begin code :lang<text>
 U+0035 5 DIGIT FIVE
@@ -489,6 +489,21 @@ U+0BEB ௫ TAMIL DIGIT FIVE
 U+0E53 ๓ THAI DIGIT THREE
 U+17E5 ៥ KHMER DIGIT FIVE
 =end code
+
+Also note that "decimal number" is a narrower category than "Number" because (Unicode) numbers include
+not only decimal numbers (C<Nd>) but also leter numbers (C<Nl>) and other numbers (C<No>)
+Examples of Unicode numbers that are not decimal numbers include:
+
+=begin code :lang<text>
+U+2464 ⑤ CIRCILED DIGIT FIVE
+U+2476 ⑶ PARENTHESIZED DIGIT THREE
+U+2083 ₃ SUBSCRIPT THREE
+=end code
+
+To match against all numbers, you can use the L<Unicode property|#unicode_properties> C<N>:
+
+    say ⑤ ~~ /<:N>/ # OUTPUT: «｢⑤｣␤»
+
 
 =head3 X<C<\w> and C<\W>|regex,\w;regex,\W>
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -472,16 +472,16 @@ character that is not whitespace.
 
 =head3 X<C<\d> and C<\D>|regex,\d;regex,\D>
 
-C<\d> matches a single decimal number (Unicode property C<Nd>) and C<\D> matches a
-single character that is not a decimal number.
+C<\d> matches a single decimal digit (Unicode General Category I<Number, Decimal Digit>, C<Nd>) and C<\D> matches a
+single character that is not a decimal digit.
 
     'ab42' ~~ /\d/ and say ~$/;     # OUTPUT: «4␤»
     'ab42' ~~ /\D/ and say ~$/;     # OUTPUT: «a␤»
 
 Note that not only the Arabic digits (commonly used in the Latin
-alphabet) match C<\d>, but also decimal numbers from other scripts.
+alphabet) match C<\d>, but also decimal digits from other scripts.
 
-Examples of decimal numbers are:
+Examples of decimal digits include:
 
 =begin code :lang<text>
 U+0035 5 DIGIT FIVE
@@ -490,19 +490,19 @@ U+0E53 ๓ THAI DIGIT THREE
 U+17E5 ៥ KHMER DIGIT FIVE
 =end code
 
-Also note that "decimal number" is a narrower category than "Number" because (Unicode) numbers include
-not only decimal numbers (C<Nd>) but also leter numbers (C<Nl>) and other numbers (C<No>)
-Examples of Unicode numbers that are not decimal numbers include:
+Also note that "decimal digit" is a narrower category than "Number" because (Unicode) numbers include
+not only decimal numbers (C<Nd>) but also letter numbers (C<Nl>) and other numbers (C<No>)
+Examples of Unicode numbers that are not decimal digits include:
 
 =begin code :lang<text>
-U+2464 ⑤ CIRCILED DIGIT FIVE
+U+2464 ⑤ CIRCLED DIGIT FIVE
 U+2476 ⑶ PARENTHESIZED DIGIT THREE
 U+2083 ₃ SUBSCRIPT THREE
 =end code
 
 To match against all numbers, you can use the L<Unicode property|#unicode_properties> C<N>:
 
-    say ⑤ ~~ /<:N>/ # OUTPUT: «｢⑤｣␤»
+    say '⑤' ~~ /<:N>/ # OUTPUT: «｢⑤｣␤»
 
 
 =head3 X<C<\w> and C<\W>|regex,\w;regex,\W>


### PR DESCRIPTION
As we correctly note [further down the page](https://docs.raku.org/language/regexes#Predefined_character_classes), `\d` matches _decimal digits_ (Unicode `Nd`) not all numbers (Unicode `N`).  This PR fixes the description here, adds an example of where that makes a difference, and provides a way to match against Numbers if that's what the user meant.
