### PR TITLE
Remove &eager sub form

### DIFF
--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -837,7 +837,6 @@ Examples:
 Defined as:
 
     multi method eager(List:D: --> List:D)
-    multi sub eager(*@elems --> List:D)
 
 Evaluates all elements in the C<List> eagerly, and returns them as a C<List>.
 


### PR DESCRIPTION
This removes the `&eager` Sub, which does not seem to exist.

(There's an `.eager` method and an `eager` statement prefix, but no Sub)

