### PR TITLE
Document sequences like 'aa'…'cc'

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -3113,7 +3113,7 @@ L<Junctions|/type/Junction>.
 
 The sequence operator invokes the generator with as many arguments as necessary.
 The arguments are taken from the initial elements and the already generated
-elements. 
+elements.
 
 An endpoint of C<*> (L<Whatever|/type/Whatever>), C<Inf> or C<∞>
 generates on demand an infinite sequence, with a default generator of
@@ -3186,9 +3186,9 @@ same number of characters, then the sequence operator will deduce a sequence of
 all strings where each letter is C<le> the letter at the corresponding position
 in the final element:
 
-    say 'aa' … 'cc';          # OUTPUT: «(aa ab ac bb bc ca cb cc)␤»
+    say 'aa' … 'cc';          # OUTPUT: «(aa ab ac ba bb bc ca cb cc)␤»
     # Which is the same as
-    say 'a'..'c' X~ 'a'..'c'; # OUTPUT: «(aa ab ac bb bc ca cb cc)␤»
+    say 'a'..'c' X~ 'a'..'c'; # OUTPUT: «(aa ab ac ba bb bc ca cb cc)␤»
 
 
 =head1 List prefix precedence

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -3113,16 +3113,7 @@ L<Junctions|/type/Junction>.
 
 The sequence operator invokes the generator with as many arguments as necessary.
 The arguments are taken from the initial elements and the already generated
-elements. The default generator is C<*.>L<succ|/routine/succ> or
-C<*.>L<pred|/routine/pred>, depending on how the end points compare:
-
-    say 1 ... 4;        # OUTPUT: «(1 2 3 4)␤»
-    say 4 ... 1;        # OUTPUT: «(4 3 2 1)␤»
-    say 1 ^... 4;       # OUTPUT: «(2 3 4)␤»
-    say 1 ...^ 4;       # OUTPUT: «(1 2 3)␤»
-    say 1 ^...^ 4;      # OUTPUT: «(2 3)␤»
-    say 'a' ... 'e';    # OUTPUT: «(a b c d e)␤»
-    say 'e' ... 'a';    # OUTPUT: «(e d c b a)␤»
+elements. 
 
 An endpoint of C<*> (L<Whatever|/type/Whatever>), C<Inf> or C<∞>
 generates on demand an infinite sequence, with a default generator of
@@ -3146,14 +3137,6 @@ Of course the generator can also take only one argument.
 There must be at least as many initial elements as arguments to the
 generator.
 
-Without a generator and with more than one initial element and all initial
-elements numeric, the sequence operator tries to deduce the generator. It
-knows about arithmetic and geometric sequences.
-
-    say 2, 4, 6 ... 12;     # OUTPUT: «(2 4 6 8 10 12)␤»
-    say 1, 2, 4 ... 32;     # OUTPUT: «(1 2 4 8 16 32)␤»
-    say 1, 2, 4 ^... 32;    # OUTPUT: «(2 4 8 16 32)␤»
-    say 1, 2, 4 ^...^ 32;   # OUTPUT: «(2 4 8 16)␤»
 
 If the endpoint is not C<*>, it's smartmatched against each generated
 element and the sequence is terminated when the smartmatch succeeded.
@@ -3173,6 +3156,40 @@ well, so they are also checked against the endpoint:
     my $end = 4;
     say 1, 2, 4, 8, 16 ... $end;
     # OUTPUT: «(1 2 4)␤»
+
+If you do not provide a generator, the sequence operator tries to deduce the
+sequence.  In most cases, this means using a default C<*.>L<succ|/routine/succ>
+or C<*.>L<pred|/routine/pred>, depending on how the end points compare:
+
+    say 1 ... 4;        # OUTPUT: «(1 2 3 4)␤»
+    say 4 ... 1;        # OUTPUT: «(4 3 2 1)␤»
+    say 1 ^... 4;       # OUTPUT: «(2 3 4)␤»
+    say 1 ...^ 4;       # OUTPUT: «(1 2 3)␤»
+    say 1 ^...^ 4;      # OUTPUT: «(2 3)␤»
+    say 'a' ... 'e';    # OUTPUT: «(a b c d e)␤»
+    say 'e' ... 'a';    # OUTPUT: «(e d c b a)␤»
+
+However, the sequence operator will deduce a different sequence in some special
+cases.
+
+If you provide more than one initial element and all initial elements are
+numeric, the sequence operator tries find an arithmetic or geometric sequence
+that fits the pattern in the initial elements:
+
+    say 2, 4, 6 ... 12;     # OUTPUT: «(2 4 6 8 10 12)␤»
+    say 1, 2, 4 ... 32;     # OUTPUT: «(1 2 4 8 16 32)␤»
+    say 1, 2, 4 ^... 32;    # OUTPUT: «(2 4 8 16 32)␤»
+    say 1, 2, 4 ^...^ 32;   # OUTPUT: «(2 4 8 16)␤»
+
+If you provide one C<Str> initial element and a C<Str> finial element with the
+same number of characters, then the sequence operator will deduce a sequence of
+all strings where each letter is C<le> the letter at the corresponding position
+in the final element:
+
+    say 'aa' … 'cc';          # OUTPUT: «(aa ab ac bb bc ca cb cc)␤»
+    # Which is the same as
+    say 'a'..'c' X~ 'a'..'c'; # OUTPUT: «(aa ab ac bb bc ca cb cc)␤»
+
 
 =head1 List prefix precedence
 

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -3181,7 +3181,7 @@ that fits the pattern in the initial elements:
     say 1, 2, 4 ^... 32;    # OUTPUT: «(2 4 8 16 32)␤»
     say 1, 2, 4 ^...^ 32;   # OUTPUT: «(2 4 8 16)␤»
 
-If you provide one C<Str> initial element and a C<Str> finial element with the
+If you provide one C<Str> initial element and a C<Str> final element with the
 same number of characters, then the sequence operator will deduce a sequence of
 all strings where each letter is C<le> the letter at the corresponding position
 in the final element:


### PR DESCRIPTION
The sequence `'aa'…'cc'` does not use a `*.succ` default generator  (and this is correct [per Roast](https://github.com/Raku/roast/blob/master/S03-sequence/nonnumeric.t#L58)).

See also [Can Raku range operator on strings mimic Perl's behaviour?](https://stackoverflow.com/questions/70239228/can-raku-range-operator-on-strings-mimic-perls-behaviour/70239585) and the links cited in the answers.
