### PR TITLE
State that isa-ok matches Roles

### DIFF
--- a/doc/Type/Test.pod6
+++ b/doc/Type/Test.pod6
@@ -428,6 +428,13 @@ isa-ok $womble, Womble, "Great Uncle Bulgaria is a womble";
 isa-ok $womble, 'Womble';     # equivalent
 =end code
 
+Note that, unlike C<isa>, C<isa-ok> also matches C<Roles>:
+
+=begin code :preamble<use Test;>
+say 42.isa(Numeric); # OUTPUT: «False␤»
+isa-ok 42, Numeric;  # OUTPUT: «ok 1 - The object is-a 'Numeric'␤»
+=end code
+
 =head2 sub can-ok
 
 Defined as:


### PR DESCRIPTION
`Mu.isa` explicitly does *not* match roles, so it seems worth calling out that `&isa-ok` behaves differently.
