### PR TITLE
Minor cleanup for section "Getting started"

### DIFF
--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -38,12 +38,12 @@ L<the native types page|/language/nativetypes> for more information.
 Except in the case you are using your own compiled libraries, or any other
 kind of bundled library, shared libraries are versioned, i.e., they will be
 in a file C<libfoo.so.x.y.z>, and this shared library will be symlinked to
-C<libxxx.so.x>. By default, Raku will pick up that file if it's the only
-existing one. This is why it safer, and advisable, to always include a
+C<libfoo.so.x>. By default, Raku will pick up that file if it's the only
+existing one. This is why it's safer, and advisable, to always include a
 version, this way:
 
 =for code :skip-test<simple snippet>
-sub some_argless_function() is native('foo',v1.2.3) { * }
+sub some_argless_function() is native('foo', v1.2.3) { * }
 
 Please check the
 L<section on the ABI/API version|/language/nativecall#ABI/API_version> for


### PR DESCRIPTION
## The problems
1. The description of versioned shared libraries mixes libfoo and libxxx -- most likely this was a typo.
2. The last sentence before the second code example seems to be missing a word.
3. Usually we add a space after the comma in parameter lists. 

## Solution provided
1. Unify on ```libfoo```. That's what we have in the section "ABI/API version" as well.
2. and 3. are fixed in the obvious way.