### PR TITLE
remove unneeded assignment to nameless state variable

### DIFF
--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -668,9 +668,9 @@ These are called "slurpy" because they slurp up any remaining arguments
 to a function, like someone slurping up noodles.
 
 =begin code
-$ = :($a, @b);  # exactly two arguments, where the second one must be Positional
-$ = :($a, *@b); # at least one argument, @b slurps up any beyond that
-$ = :(*%h);     # no positional arguments, but any number of named arguments
+:($a, @b);  # exactly two arguments, where the second one must be Positional
+:($a, *@b); # at least one argument, @b slurps up any beyond that
+:(*%h);     # no positional arguments, but any number of named arguments
 
 sub one-arg (@)  { }
 sub slurpy  (*@) { }

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -668,9 +668,10 @@ These are called "slurpy" because they slurp up any remaining arguments
 to a function, like someone slurping up noodles.
 
 =begin code
-:($a, @b);  # exactly two arguments, where the second one must be Positional
-:($a, *@b); # at least one argument, @b slurps up any beyond that
-:(*%h);     # no positional arguments, but any number of named arguments
+my $sig1 = :($a, @b);  # exactly two arguments, second must be Positional
+my $sig2 = :($a, *@b); # at least one argument, @b slurps up any beyond that
+my $sig3 = :(*%h);     # no positional arguments, but any number
+                       # of named arguments
 
 sub one-arg (@)  { }
 sub slurpy  (*@) { }
@@ -841,10 +842,10 @@ positional, except slurpy hash and arguments marked with a leading colon C<:>.
 The latter is called a L<colon-pair|/type/Pair>. Check the following signatures
 and what they denote:
 
-    $ = :($a);               # a positional argument
-    $ = :(:$a);              # a named argument of name 'a'
-    $ = :(*@a);              # a slurpy positional argument
-    $ = :(*%h);              # a slurpy named argument
+    $sig1 = :($a);               # a positional argument
+    $sig2 = :(:$a);              # a named argument of name 'a'
+    $sig3 = :(*@a);              # a slurpy positional argument
+    $sig4 = :(*%h);              # a slurpy named argument
 
 On the caller side, positional arguments are passed in the same order as the
 arguments are declared.
@@ -960,23 +961,23 @@ X<|optional argument>
 Positional parameters are mandatory by default, and can be made optional
 with a default value or a trailing question mark:
 
-    $ = :(Str $id);         # required parameter
-    $ = :($base = 10);      # optional parameter, default value 10
-    $ = :(Int $x?);         # optional parameter, default is the Int type object
+    $sig1 = :(Str $id);         # required parameter
+    $sig2 = :($base = 10);      # optional parameter, default value 10
+    $sig3 = :(Int $x?);         # optional parameter, default is the Int type object
 
 X<|mandatory named argument>
 Named parameters are optional by default, and can be made mandatory with a
 trailing exclamation mark:
 
-    $ = :(:%config);        # optional parameter
-    $ = :(:$debug = False); # optional parameter, defaults to False
-    $ = :(:$name!);         # mandatory 'name' named parameter
+    $sig1 = :(:%config);        # optional parameter
+    $sig2 = :(:$debug = False); # optional parameter, defaults to False
+    $sig3 = :(:$name!);         # mandatory 'name' named parameter
 
 Default values can depend on previous parameters, and are (at least
 notionally) computed anew for each call
 
-    $ = :($goal, $accuracy = $goal / 100);
-    $ = :(:$excludes = ['.', '..']);        # a new Array for every call
+    $sig1 = :($goal, $accuracy = $goal / 100);
+    $sig2 = :(:$excludes = ['.', '..']);        # a new Array for every call
 
 =head2 Dynamic variables
 


### PR DESCRIPTION
## The problem

In a code example to demonstrate slurping, a signature object get assigned to the nameless state variable. This assignment does not appear to be needed and may add confusion for readers.

## Solution provided

The code example removes the assignment.
