### PR TITLE
Fix foreign key reference in profile SQL query

### DIFF
--- a/doc/Language/performance.pod6
+++ b/doc/Language/performance.pod6
@@ -102,7 +102,7 @@ opening in SQLite.
         where
           c.routine_id = r.id
         group by
-          c.id
+          r.id
         order by
           inclusive_time desc
         limit 30;

--- a/doc/Language/performance.pod6
+++ b/doc/Language/performance.pod6
@@ -100,7 +100,7 @@ opening in SQLite.
           calls c,
           routines r
         where
-          c.id = r.id
+          c.routine_id = r.id
         group by
           c.id
         order by


### PR DESCRIPTION
## The problem

The example query would produce results with a few rows with high `inclusive_time` and then lots of small `inclusive_time`, each of which appeared to only happen once.

## Solution provided

Use the foreign key when joining, rather than joining two tables by their own primary keys.
