### PR TITLE
Mention adverbial pair in 5to6

### DIFF
--- a/doc/Language/5to6-perlop.pod6
+++ b/doc/Language/5to6-perlop.pod6
@@ -245,9 +245,11 @@ method calls - see L<this page|/language/operators#infix_%3A>.
 
 The C<< => >> operator, or I<fat arrow>, works similarly to the Perl "fat
 comma" in that it allows an unquoted (ordinary) identifier on its left side, but
-in Raku constructs Pair objects, rather than just functioning as a separator.
+in Raku constructs L<Pair|/type/Pair> objects, rather than just functioning as a separator.
 If you are trying to just literally translate a line of Perl code to Raku,
-it should behave as expected.
+it should behave as expected.  To read Raku, take a look at
+L<Adverbial Pair|/language/glossary#Adverbial_pair> which will explain a new syntax.
+
 
 =head2 List operators (rightward)
 


### PR DESCRIPTION
Being slightly competent with Perl, I took the fat arrow description in 5to6-perlop as a disincentive to read about Pairs.  That was an efficient choice except for my later ignorance of adverbially constructed pair syntax.

Here, I have added a link to the type Pair and to the glossary entry for adverbial pair.
