### PR TITLE
Document `handles(**)`

### DIFF
--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -686,8 +686,14 @@ of the I«delegatee»'s methods as its own.
 In Raku, delegation is specified by applying the L«handles|/language/typesystem#trait_handles»
 trait to an attribute. The arguments provided to the trait specify the methods
 the object and the I«delegatee» attribute will have in common. Instead of a
-list of method names, a C<Pair> (for renaming), a list of C<Pairs>, a C<Regex>
-or a C<Whatever> can be provided.
+list of method names, you can provide a C<Pair> (to rename; the key becomes the
+new name), a C<Regex> (to handle every method with a matching name), a C<Whatever>
+(to delegate all methods that the attribute L<can|type/Metamodel::ClassHOW#method_can>
+call), or a C<HyperWhatever> (to delegate all method calls, even ones that will lead to
+the attribute's L<FALLBACK|routine/FALLBACK> method).  You can also provide a C<List> providing
+any of those items to delegate multiple methods.  Note that the C<Regex>, C<Whatever>, and
+C<HyperWhatever> forms do not delegate any methods that the class has inherited (for example,
+from C<Any> or C<Mu>) but that explicitly naming the method does delegate it.
 
 =begin code
 class Book {


### PR DESCRIPTION
This PR explains that you can pass a `HyperWhatever` to the `handles` method and describes how that's different from passing a `Whatever` (specifically, the `HyperWhatever` delegates method calls that will end up in the attribute's `FALLBACK` method; the `Whatever` only delegates if the attribute `.^can` do a method of that name).
