### PR TITLE
Methods in a class that `is hidden` don't get *%_

### DIFF
--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -490,9 +490,8 @@ L<re-dispatching|/language/functions#Re-dispatching>.
         method n { self.A::m }
     };
 
-    B.new.m;
-    B.new.n;
-    # OUTPUT: «i am hidden␤»
+    B.new.m;  # No output
+    B.new.n;  # OUTPUT: «i am hidden␤»
 
 The trait C<is hidden> allows a class to hide itself from
 L<re-dispatching|/language/functions#Re-dispatching>.
@@ -505,9 +504,15 @@ L<re-dispatching|/language/functions#Re-dispatching>.
         method n { self.A::m }
     }
 
-    B.new.m;
-    B.new.n;
-    # OUTPUT: «i am hidden␤»
+    B.new.m; # No output
+    B.new.n; # OUTPUT: «i am hidden␤»
+
+Classes declared with C<is hidden> also generate slightly different method
+signatures.  To facilitate re-dispatch, typical methods are automatically
+provided with an extra C<*%_> parameter that L<captures extra named
+arguments|/type/Method#index-entry-extra_named_arguments>.  Because classes
+declared with C<is hidden> don't participate in re-dispatch, their methods don't
+receive this extra parameter.
 
 =head3 trait C<trusts>
 

--- a/doc/Type/Method.pod6
+++ b/doc/Type/Method.pod6
@@ -39,7 +39,7 @@ without a class is the need to use `&` to invoke them in the latter case. In
 case any other sigil is used in the definition, as in the first example, that
 sigil can also be used.
 
-X<|extra named arguments>
+X<|extra named arguments>X<|*%_ (extra named arguments)>
 Methods automatically capture extra named arguments into the special variable C<%_>,
 where other types of C<Routine> will throw at runtime. So
 


### PR DESCRIPTION
This PR adds a note to the `is hidden` docs to explain that methods in a class declared with `is hidden` don't get the `*%_` parameter and explain why. See [this recent Stack Overflow answer](https://stackoverflow.com/a/71088429/) and the design docs [A12](https://raku.org/archive/doc/design/apo/A12.html#Interface%20Consistency) and [S12](https://design.raku.org/S12.html#Interface_Consistency).
