### PR TITLE
Remove incorrect text & non-compiling example

### DIFF
--- a/doc/Language/containers.pod6
+++ b/doc/Language/containers.pod6
@@ -351,18 +351,6 @@ The constraint is a property of the variable, not the container.
 In this case, the type constraint is the (compile-type defined) subset
 C<Three-letter>.
 
-Variables may have no container in them, yet still offer the ability to
-re-bind and typecheck that rebind. The reason for that is in such cases the
-binding operator L<:=|/language/operators#infix_:=> performs the typecheck:
-
-    my Int \z = 42;
-    z := 100; # OK
-    z := "x"; # Typecheck failure
-
-The same isn't the case when, say, binding to a L<Hash|/type/Hash> key, as
-the binding is then handled by a method call (even though the syntax remains
-the same, using C<:=> operator).
-
 The default type constraint of a C<Scalar> container is L<Mu|/type/Mu>.
 Introspection of type constraints on containers is provided by C<.VAR.of>
 method, which for C<@> and C<%> sigiled variables gives the constraint for
@@ -383,6 +371,7 @@ declaration:
     my Int:D $def = 3;
     say $def;   # OUTPUT: «3␤»
     $def = Int; # Typecheck failure
+=comment ^^^ fails at runtime, so xt/example-compilation still passes
 
 You'll also need to initialize the variable in the declaration, it can't be
 left undefined after all.


### PR DESCRIPTION
This PR removes some text describing binding semantics that, after discussion, turned out to be the result of a bug rather than
intended behavior (the intended behavior is still under-documented, see Raku/doc#3961).  It also removes the accompanying test, which
failed to compile once the bug was fixed.

Finally, it adds a doc-comment clarifying that a nearby test fails at runtime even though it *looks* like it would throw a compile-time
error (and thus would need to be marked for xt/example-compilation to skip).

Resolves #4020 