### PR TITLE
Document MacOS quirk wrt DYLD_LIBRARY_PATH and SIP

### DIFF
--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -1246,6 +1246,28 @@ AF_INET6 SOCK_RAW
 2607:f8b0:4006:800::200e
 =end code
 
+=head1 Platform Specific Notes
+
+=head2 MacOS - DYLD_LIBRARY_PATH is ignored
+
+On MacOSX El Capitan and later the I<System Integrity Protection>, short SIP,
+prevents protected processes from passing through several environment
+variables, among them C<DYLD_LIBRARY_PATH>. The C<env> program, often used in
+I<shebang> lines, is one of those programs. This means that whenever C<env> is
+involved in calling a program the C<DYLD_LIBRARY_PATH> variable will be
+cleared. To work around this effect one has to either make sure no protected
+process is involved (this can be difficult) or disable SIP.
+
+This is usually not a problem when using popular installation methods such as
+I<Homebrew> or I<MacPorts>, tends to be more problematic when installing into
+non standard locations such as ones home directory and most definitely
+problematic when explicitly utilizing the C<DYLD_LIBRARY_PATH> variable.
+
+See L<Apples documentation on SIP|https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/RuntimeProtections/RuntimeProtections.html>
+for some more information.
+See L<Brian D Foys blogpost on the topic|https://briandfoy.github.io/macos-s-system-integrity-protection-sanitizes-your-environment/>
+for a more detailed explanation.
+
 =end pod
 
 # vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6


### PR DESCRIPTION
MacOS has some annoying behavior when dynamically loading C libs. Document those.
See https://github.com/Raku/App-Rakubrew/issues/9 for the very long story.