### PR TITLE
Largely rework the Object Tutorial 2nd try

### DIFF
--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -125,37 +125,6 @@ declarations. The example code includes attributes (state), introduced
 through the C<has> keyword, and behaviors, introduced through the C<method>
 keyword.
 
-X<|Tutorial,type object;Tutorial,DEFINITE>
-
-Declaring a class creates a new I<type object> which, by default, is installed
-into the current package (just like a variable declared with C<our> scope).
-This type object is an "empty instance" of the class. For example, types such as
-C<Int> and C<Str> refer to the type object of one of the Raku built-in
-classes. The example above uses the class name C<Task> so that other code can
-refer to it later, such as to create class instances by calling the C<new>
-method.
-
-You can use the C<.DEFINITE> method to find out if what you have is an instance
-or a type object:
-
-=begin code
-say Int.DEFINITE; # OUTPUT: «False␤» (type object)
-say 426.DEFINITE; # OUTPUT: «True␤»  (instance)
-
-class Foo {};
-say Foo.DEFINITE;     # OUTPUT: «False␤» (type object)
-say Foo.new.DEFINITE; # OUTPUT: «True␤»  (instance)
-=end code
-
-You can also use type "smileys" to only accept instances or type objects:
-
-=begin code
-multi foo (Int:U) { "It's a type object!" }
-multi foo (Int:D) { "It's an instance!"   }
-say foo Int; # OUTPUT: «It's a type object!␤»
-say foo 42;  # OUTPUT: «It's an instance!␤»
-=end code
-
 X<|Tutorial,attributes>
 X<|Tutorial,encapsulation>
 
@@ -669,6 +638,38 @@ buying food
 cleaning kitchen
 making dinner
 eating dinner. NOM!
+=end code
+
+
+=head2 X<A word on types|Tutorial,type object;Tutorial,DEFINITE>
+
+Declaring a class creates a new I<type object> which, by default, is installed
+into the current package (just like a variable declared with C<our> scope).
+This type object is an "empty instance" of the class. For example, types such as
+C<Int> and C<Str> refer to the type object of one of the Raku built-in
+classes. The example above uses the class name C<Task> so that other code can
+refer to it later, such as to create class instances by calling the C<new>
+method.
+
+You can use the C<.DEFINITE> method to find out if what you have is an instance
+or a type object:
+
+=begin code
+say Int.DEFINITE; # OUTPUT: «False␤» (type object)
+say 426.DEFINITE; # OUTPUT: «True␤»  (instance)
+
+class Foo {};
+say Foo.DEFINITE;     # OUTPUT: «False␤» (type object)
+say Foo.new.DEFINITE; # OUTPUT: «True␤»  (instance)
+=end code
+
+You can also use type "smileys" to only accept instances or type objects:
+
+=begin code
+multi foo (Int:U) { "It's a type object!" }
+multi foo (Int:D) { "It's an instance!"   }
+say foo Int; # OUTPUT: «It's a type object!␤»
+say foo 42;  # OUTPUT: «It's an instance!␤»
 =end code
 
 =head1 X<Inheritance|Tutorial,inheritance>

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -532,41 +532,28 @@ of the parameters are dependent C<Task> instances. The constructor captures
 these into the C<@dependencies> slurpy array and passes them as named
 parameters to C<bless> (note that C<:&callback> uses the name of the
 variable – minus the sigil – as the name of the parameter).
+One should refrain from putting logic other than reformulating the parameters in the constructor, because
+constructor methods are not recursively called for parent classes. This is different from e.g. Java.
 
-X<|Tutorial,BUILD>
-Private attributes really are private. This means that C<bless> is not
-allowed to bind things to C<&!callback> and C<@!dependencies> directly. To
-do this, we override the C<BUILD> submethod, which is called on the brand
-new object by C<bless>:
+Declaring C<new> as a C<method> and not as a C<multi method> prevents access to the default constructor.
++So if you intend to keep the default constructor available, use C<multi method new>.
 
-=begin code :preamble<has &.callback; has @.dependencies;>
-submethod BUILD(:&!callback, :@!dependencies) { }
-=end code
+=head2 X<C<TWEAK>|Tutorial,TWEAK>
 
-Since C<BUILD> runs in the context of the newly created C<Task> object, it
-is allowed to manipulate those private attributes. The trick here is that
-the private attributes (C<&!callback> and C<@!dependencies>) are being used
-as the bind targets for C<BUILD>'s parameters. Zero-boilerplate
-initialization! See L<objects|/language/objects#Object_construction> for
-more information.
+After C<bless> has initialized the classes attributes from the passed values, it will in turn call C<TWEAK>
+for each class in the inheritance hierarchy.
+C<TWEAK> gets passed all the arguments passed to bless.
+This is where custom initialization logic should go.
 
-The C<BUILD> method is responsible for initializing all attributes and must
-also handle default values:
+Remember to always make C<TWEAK> a C<submethod> and not a normal C<method>. If in a class hierarchy a class contains a C<TWEAK> method (declared as a C<method> instead of a C<submethod>) that method is inherited to its subclass and will thus be called twice during construction of the subclass!
 
-=begin code
-has &!callback;
-has @!dependencies;
-has Bool ($.done, $.ready);
-submethod BUILD(
-        :&!callback,
-        :@!dependencies,
-        :$!done = False,
-        :$!ready = not @!dependencies,
-    ) { }
-=end code
+=head2 X<C<BUILD>|Tutorial,BUILD>
 
-See L<Object Construction|/language/objects#Object_construction> for more
-options to influence object construction and attribute initialization.
+It is possible to disable the automatic attribute initialization and perform the initialization of
+attributes oneself. To do so one needs to write a custom C<BUILD> submethod. There are several edge cases one
+needs to be aware of and take into account though. This is detailed in the
+L<Object Construction Reference|/language/objects#Object_construction>. Because of the difficulty of using
+C<BUILD>, it is recommended to only make use of it when none of the other approaches described above suffices.
 
 X<|Tutorial,submethod DESTROY>
 =head1 X<Destruction|Tutorial,DESTROY>

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -194,6 +194,8 @@ has $.done is built(False);
 
 Above declaration makes sure one can't constuct finished tasks, but still allow users to look if a task is done.
 
+The C<is built> trait was introduced in Rakudo version 2020.01.
+
 =head2 C<is required> trait
 
 X<|traits,is required>

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -273,22 +273,22 @@ on how this works on the whole class.
 X<|Tutorial,class variables>
 =head1 Class variables
 
-A class declaration can also include I<class variables>, which are variables
+A class declaration can also include I<class variables>, declared with C<my> or C<our>, which are variables
 whose value is shared by all instances, and can be used for things like
-counting the number of instantiations or any other shared state.
-Class variables use the same syntax as the rest of the attributes, but are
-declared as C<my> or C<our>, both will be shared by subclasses.
+counting the number of instantiations or any other shared state. So I<class variables> act similar to
+I<static> variables known from other programming languages.
+They look the same as normal (non class) lexical variables (and in fact they are the same):
 
 =begin code
 class Str-with-ID is Str {
     my  $counter = 0;
-    our $hierarchy-counter = 0;
+    our $our-counter = 0;
     has Str $.string;
     has Int $.ID is built(False);
 
     submethod TWEAK() {
         $counter++;
-        $hierarchy-counter++;
+        $our-counter++;
         $!ID = $counter;
     }
 
@@ -301,18 +301,18 @@ class Str-with-ID-and-tag is Str-with-ID {
 say Str-with-ID.new(string => 'First').ID;  # OUTPUT: «1␤»
 say Str-with-ID.new(string => 'Second').ID; # OUTPUT: «2␤»
 say Str-with-ID-and-tag.new( string => 'Third', tag => 'Ordinal' ).ID; # OUTPUT: «3␤»
-say $Str-with-ID::hierarchy-counter;       # OUTPUT: «3␤»
+say $Str-with-ID::our-counter;        # OUTPUT: «3␤»
 =end code
 
-C<my> and C<our> are both I<class hierarchy> variables that are shared by all subclasses of
-C<Str-with-ID>. Additionally, class variables declared with package scope (C<our>) are
-visible via their fully qualified name (FQN), while lexically scoped class
-variables are "private".
+I<Class variables> are shared by all subclasses, in this case
+C<Str-with-ID-and-tag>. Additionally, when the package scope C<our> declarator
+is used, the variable is visible via their fully qualified name (FQN), while
+lexically scoped C<my> variables are "private". This is the exact behavior that
+C<my> and C<our> also show in non class context.
 
-=head1 Static fields?
-
-Raku has no B<static> keyword. Nevertheless, any class may declare anything
-that a module can, so making a scoped variable sounds like a good idea.
+X<|static>
+I<Class variables> act similar to I<static> variables in many other programming
+languages.
 
 =begin code
 class Singleton {
@@ -325,28 +325,25 @@ class Singleton {
 }
 =end code
 
-Class attributes defined by L<my|/syntax/my> or L<our|/syntax/our> may also be
-initialized when being declared, however we are implementing the Singleton
-pattern here and the object must be created during its first use. It is not 100%
-possible to predict the moment when attribute initialization will be executed,
-because it can take place during compilation, runtime or both, especially when
-importing the class using the L<use|/syntax/use> keyword.
+In this implementation of the I<Singleton> pattern a I<class variable> is used
+to save the instance.
 
-=begin code :preamble<class Foo {}; sub some_complicated_subroutine {}>
+=begin code>
 class HaveStaticAttr {
-    my Foo $.foo = some_complicated_subroutine;
+    my Int $.foo = 5;
 }
 =end code
 
 Class attributes may also be declared with a secondary sigil – in a similar
 manner to instance attributes – that will generate read-only accessors if the
 attribute is to be public.
+Default values behave as expected and are assigned only once.
 
 =head1 Methods
 
 X<|Tutorial,methods>
 
-While attributes give objects state, methods give objects behaviors. Let's
+While attributes give objects state, methods give objects behaviors. Back to our C<Task> example. Let's
 ignore the C<new> method temporarily; it's a special type of method.
 Consider the second method, C<add-dependency>, which adds a new task to a
 task's dependency list:

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -37,10 +37,11 @@ In the two classes, the default constructor is being used. This
 constructor will use named parameters in its invocation: C«Point.new(x =>
 0, y => 0)».
 
-The following, more elaborate example, shows how a dependency handler might look
-in Raku.  It showcases custom constructors, private and public attributes,
-L<Submethod|/type/Submethod>s, methods, and various aspects of signatures. It's
-not a lot of code, and yet the result is interesting and useful.
+=head1 The Task example
+
+The following piece of code implements a dependency handler. It showcases custom constructors, private and public attributes,
+L<Submethod|/type/Submethod>s, methods, and various aspects of signatures. It's not a lot of code, and yet the result is interesting and useful.
+It will be used as an example throughout the following sections.
 
 =begin code
 class Task {

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -46,12 +46,8 @@ example below:
 # Example taken from
 # https://medium.freecodecamp.org/a-short-overview-of-object-oriented-software-design-c7aa0a622c83
 class Hero {
-    has @!inventory;
+    has @!inventory is built;
     has Str $.name;
-    submethod BUILD( :$name, :@inventory ) {
-        $!name = $name;
-        @!inventory = @inventory
-    }
 
     method act {
         return @!inventory.pick;
@@ -64,7 +60,7 @@ say $hero.act;
 
 In this case, we I<encapsulate> the private attribute C<@!inventory>; but
 private instance variables cannot be set by the default constructor, which is
-why we add a C<BUILD> submethod that takes care of that.
+why we add the C<is built> trait to allow just that.
 
 The following, more elaborate example, shows how a dependency handler might look
 in Raku.  It showcases custom constructors, private and public attributes,
@@ -73,17 +69,14 @@ not a lot of code, and yet the result is interesting and useful.
 
 =begin code
 class Task {
-    has      &!callback;
-    has Task @!dependencies;
+    has      &!callback     is built;
+    has Task @!dependencies is built;
     has Bool $.done;
 
     # Normally doesn't need to be written
     method new(&callback, *@dependencies) {
         return self.bless(:&callback, :@dependencies);
     }
-
-    # BUILD is the equivalent of a constructor in other languages
-    submethod BUILD(:&!callback, :@!dependencies) { }
 
     method add-dependency(Task $dependency) {
         push @!dependencies, $dependency;
@@ -112,12 +105,8 @@ my $eat =
 $eat.perform();
 =end code
 
-In this case, C<BUILD> is needed since we have overridden the default
-C<new> constructor. C<bless> is eventually invoking it with the two named
-arguments that correspond to the two properties without a default value. With
-its signature, C<BUILD> converts the two positionals to the two attributes,
-C<&!callback> and C<@!dependencies>, and returns the object (or turns it in to
-the next phase, C<TWEAK>, if available).
+C<bless> is eventually invoking it with the two named
+arguments that correspond to the two properties without a default value.
 
 Declaring C<new> as a C<method> and not as a C<multi method> prevents us
 from using the default constructor; this implicit constructor uses the
@@ -362,9 +351,8 @@ say $Str-with-ID::hierarchy-counter;       # OUTPUT: «4␤»
 
 In this case, using C<new> might be the easiest way to initialize the C<$.ID>
 field and increment the value of the counter at the same time. C<new>, through
-C<bless>, will invoke the default C<BUILD>, assigning the values to their
-properties correctly. You can obtain the same effect using C<TWEAK>, which is
-considered a better practice by Raku experts. Please check L<the section on
+C<bless>, will invoke the default C<TWEAK>, assigning the values to their
+properties correctly. Please check L<the section on
 submethods|/language/classtut#index-entry-OOP> for an alternative example on how
 to do this. Since C<TWEAK> is called in every object instantiation, it's
 incremented twice when creating objects of class C<Str-with-ID-and-tag>; this is

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -656,7 +656,8 @@ say Foo.DEFINITE;     # OUTPUT: «False␤» (type object)
 say Foo.new.DEFINITE; # OUTPUT: «True␤»  (instance)
 =end code
 
-You can also use type "smileys" to only accept instances or type objects:
+In function signatures one can use so called type "smileys" to only accept instances
+or type objects:
 
 =begin code
 multi foo (Int:U) { "It's a type object!" }

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -295,7 +295,7 @@ class Singleton {
 In this implementation of the I<Singleton> pattern a I<class variable> is used
 to save the instance.
 
-=begin code>
+=begin code
 class HaveStaticAttr {
     my Int $.foo = 5;
 }

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -345,6 +345,8 @@ L<the C<is rw> trait on classes|/language/typesystem#trait_is_rw> for examples
 on how this works on the whole class.
 
 X<|Tutorial,class variables>
+=head1 Class variables
+
 A class declaration can also include I<class variables>, which are variables
 whose value is shared by all instances, and can be used for things like
 counting the number of instantiations or any other shared state.
@@ -595,6 +597,7 @@ method new(&callback, *@dependencies) {
 =end code
 
 X<|Tutorial,bless>
+=head2 bless
 
 The biggest difference between constructors in Raku and constructors in
 languages such as C# and Java is that rather than setting up state on a

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -43,9 +43,11 @@ It is rarely necessary to explicitly write a constructor. An automatically inher
 
 =head1 The Task example
 
-The following piece of code implements a dependency handler. It showcases custom constructors, private and public attributes,
-L<Submethod|/type/Submethod>s, methods, and various aspects of signatures. It's not a lot of code, and yet the result is interesting and useful.
-It will be used as an example throughout the following sections.
+As a more elaborate example the following piece of code implements a dependency
+handler. It showcases custom constructors, private and public attributes,
+methods, and various aspects of signatures. It's not a lot of code, and yet the
+result is interesting and useful. It will be used as an example throughout the
+following sections.
 
 =begin code
 class Task {

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -8,34 +8,35 @@ X<|Tutorial,OOP>
 
 Raku has a rich built-in syntax for defining and using classes.
 
-A default constructor allows the setting of attributes for the created
-object:
+A default constructor allows to set attributes via named parameters:
 
 =begin code
-class Point {
-    has Int $.x;
-    has Int $.y;
-}
-
 class Rectangle {
-    has Point $.lower;
-    has Point $.upper;
+    has Int $.a = 1;
+    has Int $.b = 1;
+
+    submethod TWEAK(:$log) {
+        say "Constructing Rectangle ($!a|$!b)" if $log;
+    }
 
     method area(--> Int) {
-        ($!upper.x - $!lower.x) * ( $!upper.y - $!lower.y);
+        return $!a * $!b;
     }
 }
 
-# Create a new Rectangle from two Points
-my $r = Rectangle.new(lower => Point.new(x => 0, y => 0),
-                      upper => Point.new(x => 10, y => 10));
+my $r1 = Rectangle.new(a => 2, b => 3);
+say $r1.area(); # OUTPUT: «6␤»
 
-say $r.area(); # OUTPUT: «100␤»
+my $r2 = Rectangle.new(b => 2, :log); # OUTPUT: «Constructing Rectangle (1|2)␤»
 =end code
 
-In the two classes, the default constructor is being used. This
-constructor will use named parameters in its invocation: C«Point.new(x =>
-0, y => 0)».
+We define a new I<Rectangle> class using the L<class|/language/objects#Classes> keyword. It has two I<attributes>, C<$!a> and C<$!b> introduced with the C<has> keyword. Both default to C<1>. Read only accessor methods are automatically generated. (Note the C<.> instead of C<!> in the declaration, which triggers the generation. Mnemonic: C<!> resembles a closed door, C<.> an open one.) 
+
+The L<method|/language/objects#Methods> named C<area> will return the area of the rectangle.
+
+Using the C<TWEAK> submethod, which is automatically called in the construction process we optionally log that a rectangle was created.
+
+It is rarely necessary to explicitly write a constructor. An automatically inherited default constructor called L<new|/language/objects#Object_construction> will automatically initialize attributes from named parameters passed to the constructor.
 
 =head1 The Task example
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -37,10 +37,7 @@ In the two classes, the default constructor is being used. This
 constructor will use named parameters in its invocation: C«Point.new(x =>
 0, y => 0)».
 
-You can also provide your own constructor and C<BUILD> implementation.
-You need to do it for cases in which there are private attributes that
-might need to be populated during object construction, as in the
-example below:
+To populate private attributes use the C<is built> trait:
 
 =begin code
 # Example taken from

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -550,6 +550,10 @@ namespace, the pseudo package C<GLOBAL> can be used.
 
 =head1 X<Constructors|Tutorial,Constructor>
 
+The object construction mechanisms described up to now suffice for most use cases. But if one actually needs
+to tweak object construction more than said mechanisms allow, it's good to understand how object construction
+works in more detail.
+
 Raku is rather more liberal than many languages in the area of
 constructors. A constructor is anything that returns an instance of the
 class. Furthermore, constructors are ordinary methods. You inherit a

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -5,10 +5,13 @@
 =SUBTITLE A tutorial about creating and using classes in Raku
 
 X<|Tutorial,OOP>
+Raku provides a rich built-in syntax for defining and using classes. It makes writing classes
+expressive and short for most cases, but also provides mechanisms to cover
+the rare corner cases.
 
-Raku has a rich built-in syntax for defining and using classes.
+=head1 A quick overview
 
-A default constructor allows to set attributes via named parameters:
+Let's start with an example to give an overview:
 
 =begin code
 class Rectangle {

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -554,7 +554,7 @@ Raku is rather more liberal than many languages in the area of
 constructors. A constructor is anything that returns an instance of the
 class. Furthermore, constructors are ordinary methods. You inherit a
 default constructor named C<new> from the base class C<Mu>, but you are
-free to override C<new>, as this example does:
+free to override C<new>, as the Task example does:
 
 =begin code
 method new(&callback, *@dependencies) {
@@ -567,13 +567,13 @@ X<|Tutorial,bless>
 The biggest difference between constructors in Raku and constructors in
 languages such as C# and Java is that rather than setting up state on a
 somehow already magically created object, Raku constructors create the
-object themselves. The easiest way to do this is by calling the
+object themselves. They do this is by calling the
 L<bless|/routine/bless> method, also inherited from L<Mu|/type/Mu>.
 The C<bless> method expects a set of named parameters to provide the initial
 values for each attribute.
 
 The example's constructor turns positional arguments into named arguments,
-so that the class can provide a nice constructor for its users. The first
+so that the class can provide a nicer constructor for its users. The first
 parameter is the callback (the thing which will execute the task). The rest
 of the parameters are dependent C<Task> instances. The constructor captures
 these into the C<@dependencies> slurpy array and passes them as named
@@ -928,7 +928,7 @@ which it can find out via introspection.
 =head2 X<Overriding default gist method|Reference,Overriding default gist method>
 
 Some classes might need their own version of C<gist>, which overrides the terse
-way it is printed when called to provide a default representation of the class.
+way they are printed when called to provide a default representation of the class.
 For instance, L<exceptions|/language/exceptions#Uncaught_exceptions> might want
 to write just the C<payload> and not the full object so that it is clearer what
 to see what's happened. However, this isn't limited to exceptions; you can

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -285,6 +285,37 @@ has Bool $.done is rw;
 The C<is rw> trait causes the generated accessor method to return a container
 so external code can modify the value of the attribute.
 
+=head2 C<is built> trait
+
+=for code
+has &!callback is built;
+
+X<|traits,is built>
+By default private attributes are not automatically set by the default constructor. (They are private after
+all.) In the above example we want to allow the user to provide the initial value but keep the attribute
+otherwise private. The C<is built> trait allows to do just that.
+
+One can also use it to do the opposite for public attributes, i.e. prevent them to be automatically
+initialized with a user provided value, but still generate the accessor method:
+
+=for code
+has $.done is built(False);
+
+Above declaration makes sure one can't constuct finished tasks, but still allow users to look if a task is done.
+
+=head2 C<is required> trait
+
+X<|traits,is required>
+Providing a value for an attribute during initialization is optional by default. Which in the task example
+makes sense for all three, the C<&!callback>, the C<@!dependencies> and the C<$.done> attribute. But lets say
+we want to add another attribute, C<$.name>, that holds a tasks name and we want to force the user to
+provide a value on initialization. We can do that as follows:
+
+=for code
+has $.name is required;
+
+=head2 Default values
+
 You can also supply default values to attributes (which works equally for
 those with and without accessors):
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -132,24 +132,24 @@ keyword.
 X<|Tutorial,attributes>
 X<|Tutorial,encapsulation>
 
-=head1 State
+=head1 Attributes
 
 In the C<Task> class, the first three lines inside the block all
 declare attributes (called I<fields> or I<instance storage> in other
-languages). Just as a C<my> variable cannot be accessed from outside its
-declared scope, attributes are not accessible outside of the class.
-This I<encapsulation> is one of the key principles of object oriented design.
+languages) using the C<has> declarator. Just as a C<my> variable cannot be
+accessed from outside its declared scope, attributes are never directly
+accessible from outside of the class (this is in contrast to many other
+languages). This I<encapsulation> is one of the key principles of object
+oriented design.
 
-The first declaration specifies instance storage for a callback (i.e.,
+=head2 X<Twigil C<$!>|Tutorial,twigils;Tutorial,!;Tutorial,&>
+
+The first declaration specifies instance storage for a callback (i.e.
 a bit of code to invoke in order to perform the task that an object
 represents):
 
 =for code
 has &!callback is built;
-
-X<|Tutorial,&>
-X<|Tutorial,twigils>
-X<|Tutorial,!>
 
 The C<&> sigil indicates that this attribute represents something invocable.
 The C<!> character is a I<twigil>, or secondary sigil. A twigil forms part
@@ -169,14 +169,15 @@ the present one is completed. Furthermore, the type declaration on this
 attribute indicates that the array may only hold instances of the C<Task>
 class (or some subclass of it).
 
+X<|Tutorial,.>
+X<|Tutorial,accessors>
+X<|Tutorial,accessor methods>
+=head2 Twigil C<$.>
+
 The third attribute represents the state of completion of a task:
 
 =for code
 has Bool $.done;
-
-X<|Tutorial,.>
-X<|Tutorial,accessors>
-X<|Tutorial,accessor methods>
 
 This scalar attribute (with the C<$> sigil) has a type of C<Bool>. Instead
 of the C<!> twigil, the C<.> twigil is used. While Raku does enforce
@@ -197,7 +198,8 @@ without having to write the method by hand. You are free instead to write
 your own accessor method, if at some future point you need to do something
 more complex than returning the value.
 
-X<|Tutorial,is rw>
+=head2 X<C<is rw> trait|Tutorial,is rw>
+
 Note that using the C<.> twigil has created a method that will provide
 read-only access to the attribute. If instead the users of this object
 should be able to reset a task's completion state (perhaps to perform it
@@ -497,7 +499,7 @@ Trust relationships are not subject to inheritance. To trust the global
 namespace, the pseudo package C<GLOBAL> can be used.
 
 
-=head1 X<Constructors|Tutorial,Constructor>
+=head1 X<Construction|Tutorial,Constructor>
 
 The object construction mechanisms described up to now suffice for most use cases. But if one actually needs
 to tweak object construction more than said mechanisms allow, it's good to understand how object construction

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -15,19 +15,19 @@ Let's start with an example to give an overview:
 
 =begin code
 class Rectangle {
-    has Int $.a = 1;
-    has Int $.b = 1;
+    has Int $.length = 1;
+    has Int $.width = 1;
 
     method area(--> Int) {
-        return $!a * $!b;
+        return $!length * $!width;
     }
 }
 
-my $r1 = Rectangle.new(a => 2, b => 3);
+my $r1 = Rectangle.new(length => 2, width => 3);
 say $r1.area(); # OUTPUT: «6␤»
 =end code
 
-We define a new I<Rectangle> class using the L<class|/language/objects#Classes> keyword. It has two I<attributes>, C<$!a> and C<$!b> introduced with the C<has> keyword. Both default to C<1>. Read only accessor methods are automatically generated. (Note the C<.> instead of C<!> in the declaration, which triggers the generation. Mnemonic: C<!> resembles a closed door, C<.> an open one.) 
+We define a new I<Rectangle> class using the L<class|/language/objects#Classes> keyword. It has two I<attributes>, C<$!length> and C<$!width> introduced with the C<has> keyword. Both default to C<1>. Read only accessor methods are automatically generated. (Note the C<.> instead of C<!> in the declaration, which triggers the generation. Mnemonic: C<!> resembles a closed door, C<.> an open one.)
 
 The L<method|/language/objects#Methods> named C<area> will return the area of the rectangle.
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -601,7 +601,7 @@ X<|Tutorial,bless>
 The biggest difference between constructors in Raku and constructors in
 languages such as C# and Java is that rather than setting up state on a
 somehow already magically created object, Raku constructors create the
-object themselves. They do this is by calling the
+object themselves. They do this by calling the
 L<bless|/routine/bless> method, also inherited from L<Mu|/type/Mu>.
 The C<bless> method expects a set of named parameters to provide the initial
 values for each attribute.

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -86,7 +86,8 @@ my $eat =
 $eat.perform();
 =end code
 
-=head1 X<Starting with class|Tutorial,class;Tutorial,state;Tutorial,has>
+X<|classes,state>
+=head1 X<Class|Tutorial,class;Tutorial,state>
 
 Raku, like many other languages, uses the C<class> keyword to define a
 class. The block that follows may contain arbitrary code, just as with
@@ -95,10 +96,8 @@ declarations. The example code includes attributes (state), introduced
 through the C<has> keyword, and behaviors, introduced through the C<method>
 keyword.
 
-X<|Tutorial,attributes>
-X<|Tutorial,encapsulation>
 
-=head1 Attributes
+=head1 X<Attributes|Tutorial,attributes;Tutorial,encapsulation;Tutorial,has>
 
 In the C<Task> class, the first three lines inside the block all
 declare attributes (called I<fields> or I<instance storage> in other

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -27,7 +27,7 @@ my $r1 = Rectangle.new(length => 2, width => 3);
 say $r1.area(); # OUTPUT: «6␤»
 =end code
 
-We define a new I<Rectangle> class using the L<class|/language/objects#Classes> keyword. It has two I<attributes>, C<$!length> and C<$!width> introduced with the C<has> keyword. Both default to C<1>. Read only accessor methods are automatically generated. (Note the C<.> instead of C<!> in the declaration, which triggers the generation. Mnemonic: C<!> resembles a closed door, C<.> an open one.)
+We define a new I<Rectangle> class using the L<class|/language/objects#Classes> keyword. It has two L<attributes|Attributes>, C<$!length> and C<$!width> introduced with the L<has> keyword. Both default to C<1>. Read only accessor methods are automatically generated. (Note the C<.> instead of C<!> in the declaration, which triggers the generation. Mnemonic: C<!> resembles a closed door, C<.> an open one.)
 
 The L<method|/language/objects#Methods> named C<area> will return the area of the rectangle.
 
@@ -504,7 +504,7 @@ for each class in the inheritance hierarchy.
 C<TWEAK> gets passed all the arguments passed to bless.
 This is where custom initialization logic should go.
 
-Remember to always make C<TWEAK> a C<submethod> and not a normal C<method>. If in a class hierarchy a class contains a C<TWEAK> method (declared as a C<method> instead of a C<submethod>) that method is inherited to its subclass and will thus be called twice during construction of the subclass!
+Remember to always make C<TWEAK> a L<submethod|Submethod> and not a normal C<method>. If in a class hierarchy a class contains a C<TWEAK> method (declared as a C<method> instead of a C<submethod>) that method is inherited to its subclass and will thus be called twice during construction of the subclass!
 
 =head2 X<C<BUILD>|Tutorial,BUILD>
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -558,12 +558,14 @@ C<BUILD>, it is recommended to only make use of it when none of the other approa
 X<|Tutorial,submethod DESTROY>
 =head1 X<Destruction|Tutorial,DESTROY>
 
-C<DESTROY> is the submethod that gets called when an object is garbage
-collected. That is going to happen only if the runtime needs the memory, so we
-can't rely on when it's going to happen. In particular, it could happen in the
-middle of some running code in a thread, so we must take special care to not
-assume any context during that event. We can use it to close any kind of handles
-or supplies or delete temporary files that are no longer going to be used.
+Raku is a garbage collecting language. This means that one usually doesn't need to care about cleaning up objects,
+because Raku does so automatically. Raku does not give any guarentees as to when it will
+clean up a given object though. It usually does a cleanup run only if the runtime needs the memory, so we
+can't rely on when it's going to happen.
+
+To run custom code when an object is cleaned up one can use the C<DESTROY> submethod. It can for example be used to close handles or supplies or delete temporary files that are no longer g
+oing to be used. As garbage collection can happen at arbitrary points during the runtime of our program, even in the middle of some totally unrelated piece of code in a different thread, we
+ must make sure to not assume any context in our C<DESTROY> submethod.
 
 =begin code
 my $in_destructor = 0;
@@ -580,9 +582,11 @@ for 1 .. 6000 {
 say "DESTROY called $in_destructor times";
 =end code
 
-This might print something like C<DESTROY called 5701 times>, but it only kicks
-in after we have stomped over former instances of C<Foo> 6000 times. We can't
-rely, however, on the order of destruction, for instance.
+This might print something like C<DESTROY called 5701 times> and possibly only kicks
+in after we have stomped over former instances of C<Foo> a few thousand times. We also can't
+rely, on the order of destruction.
+
+Same as C<TWEAK>: Make sure to always declare C<DESTROY> as a C<submethod>.
 
 =head1 Consuming our class
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -321,19 +321,19 @@ A class declaration can also include I<class variables>, which are variables
 whose value is shared by all instances, and can be used for things like
 counting the number of instantiations or any other shared state.
 Class variables use the same syntax as the rest of the attributes, but are
-declared as C<my> or C<our>, depending on the scope; C<our> variables will be
-shared by subclasses, since they have package scope.
+declared as C<my> or C<our>, both will be shared by subclasses.
 
 =begin code
 class Str-with-ID is Str {
-    my $counter = 0;
+    my  $counter = 0;
     our $hierarchy-counter = 0;
     has Str $.string;
-    has Int $.ID;
+    has Int $.ID is built(False);
 
-    method TWEAK() {
-        $!ID = $counter++;
+    submethod TWEAK() {
+        $counter++;
         $hierarchy-counter++;
+        $!ID = $counter;
     }
 
 }
@@ -342,11 +342,10 @@ class Str-with-ID-and-tag is Str-with-ID {
     has Str $.tag;
 }
 
-say Str-with-ID.new(string => 'First').ID;  # OUTPUT: «0␤»
-say Str-with-ID.new(string => 'Second').ID; # OUTPUT: «1␤»
-say Str-with-ID-and-tag.new( string => 'Third', tag => 'Ordinal' ).ID;
-# OUTPUT: «2␤»
-say $Str-with-ID::hierarchy-counter;       # OUTPUT: «4␤»
+say Str-with-ID.new(string => 'First').ID;  # OUTPUT: «1␤»
+say Str-with-ID.new(string => 'Second').ID; # OUTPUT: «2␤»
+say Str-with-ID-and-tag.new( string => 'Third', tag => 'Ordinal' ).ID; # OUTPUT: «3␤»
+say $Str-with-ID::hierarchy-counter;       # OUTPUT: «3␤»
 =end code
 
 In this case, using C<new> might be the easiest way to initialize the C<$.ID>
@@ -354,10 +353,8 @@ field and increment the value of the counter at the same time. C<new>, through
 C<bless>, will invoke the default C<TWEAK>, assigning the values to their
 properties correctly. Please check L<the section on
 submethods|/language/classtut#index-entry-OOP> for an alternative example on how
-to do this. Since C<TWEAK> is called in every object instantiation, it's
-incremented twice when creating objects of class C<Str-with-ID-and-tag>; this is
-a I<class hierarchy> variable that is shared by all subclasses of
-C<Str-with-ID>. Additionally, class variables declared with package scope are
+to do this. C<my> and C<our> are both I<class hierarchy> variables that are shared by all subclasses of
+C<Str-with-ID>. Additionally, class variables declared with package scope (C<our>) are
 visible via their fully qualified name (FQN), while lexically scoped class
 variables are "private".
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -70,7 +70,6 @@ class Task {
     has Task @!dependencies is built;
     has Bool $.done;
 
-    # Normally doesn't need to be written
     method new(&callback, *@dependencies) {
         return self.bless(:&callback, :@dependencies);
     }

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -116,35 +116,6 @@ the counter at the same time. Please check also
 L<this section on C<TWEAK> in the Object Orientation (OO) document|/language/objects#index-entry-TWEAK>
 for the mechanics of object construction.
 
-X<|Tutorial,DESTROY>
-X<|Tutorial,submethod DESTROY>
-
-C<DESTROY> is the submethod that gets called when an object is garbage
-collected. That is going to happen only if the runtime needs the memory, so we
-can't rely on when it's going to happen. In particular, it could happen in the
-middle of some running code in a thread, so we must take special care to not
-assume any context during that event. We can use it to close any kind of handles
-or supplies or delete temporary files that are no longer going to be used.
-
-=begin code
-my $in_destructor = 0;
-
-class Foo {
-    submethod DESTROY { $in_destructor++ }
-}
-
-my $foo;
-for 1 .. 6000 {
-    $foo = Foo.new();
-}
-
-say "DESTROY called $in_destructor times";
-=end code
-
-This might print something like C<DESTROY called 5701 times>, but it only kicks
-in after we have stomped over former instances of C<Foo> 6000 times. We can't
-rely, however, on the order of destruction, for instance.
-
 =head1 X<Starting with class|Tutorial,class;Tutorial,state;Tutorial,has>
 
 Raku, like many other languages, uses the C<class> keyword to define a
@@ -629,6 +600,35 @@ submethod BUILD(
 
 See L<Object Construction|/language/objects#Object_construction> for more
 options to influence object construction and attribute initialization.
+
+X<|Tutorial,submethod DESTROY>
+=head1 X<Destruction|Tutorial,DESTROY>
+
+C<DESTROY> is the submethod that gets called when an object is garbage
+collected. That is going to happen only if the runtime needs the memory, so we
+can't rely on when it's going to happen. In particular, it could happen in the
+middle of some running code in a thread, so we must take special care to not
+assume any context during that event. We can use it to close any kind of handles
+or supplies or delete temporary files that are no longer going to be used.
+
+=begin code
+my $in_destructor = 0;
+
+class Foo {
+    submethod DESTROY { $in_destructor++ }
+}
+
+my $foo;
+for 1 .. 6000 {
+    $foo = Foo.new();
+}
+
+say "DESTROY called $in_destructor times";
+=end code
+
+This might print something like C<DESTROY called 5701 times>, but it only kicks
+in after we have stomped over former instances of C<Foo> 6000 times. We can't
+rely, however, on the order of destruction, for instance.
 
 =head1 Consuming our class
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -329,12 +329,7 @@ say Str-with-ID-and-tag.new( string => 'Third', tag => 'Ordinal' ).ID; # OUTPUT:
 say $Str-with-ID::hierarchy-counter;       # OUTPUT: «3␤»
 =end code
 
-In this case, using C<new> might be the easiest way to initialize the C<$.ID>
-field and increment the value of the counter at the same time. C<new>, through
-C<bless>, will invoke the default C<TWEAK>, assigning the values to their
-properties correctly. Please check L<the section on
-submethods|/language/classtut#index-entry-OOP> for an alternative example on how
-to do this. C<my> and C<our> are both I<class hierarchy> variables that are shared by all subclasses of
+C<my> and C<our> are both I<class hierarchy> variables that are shared by all subclasses of
 C<Str-with-ID>. Additionally, class variables declared with package scope (C<our>) are
 visible via their fully qualified name (FQN), while lexically scoped class
 variables are "private".

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -37,28 +37,6 @@ In the two classes, the default constructor is being used. This
 constructor will use named parameters in its invocation: C«Point.new(x =>
 0, y => 0)».
 
-To populate private attributes use the C<is built> trait:
-
-=begin code
-# Example taken from
-# https://medium.freecodecamp.org/a-short-overview-of-object-oriented-software-design-c7aa0a622c83
-class Hero {
-    has @!inventory is built;
-    has Str $.name;
-
-    method act {
-        return @!inventory.pick;
-    }
-}
-my $hero = Hero.new(:name('Þor'),
-                    :inventory(['Mjölnir','Chariot','Bilskirnir']));
-say $hero.act;
-=end code
-
-In this case, we I<encapsulate> the private attribute C<@!inventory>; but
-private instance variables cannot be set by the default constructor, which is
-why we add the C<is built> trait to allow just that.
-
 The following, more elaborate example, shows how a dependency handler might look
 in Raku.  It showcases custom constructors, private and public attributes,
 L<Submethod|/type/Submethod>s, methods, and various aspects of signatures. It's
@@ -222,7 +200,7 @@ a bit of code to invoke in order to perform the task that an object
 represents):
 
 =for code
-has &!callback;
+has &!callback is built;
 
 X<|Tutorial,&>
 X<|Tutorial,twigils>
@@ -231,7 +209,9 @@ X<|Tutorial,!>
 The C<&> sigil indicates that this attribute represents something invocable.
 The C<!> character is a I<twigil>, or secondary sigil. A twigil forms part
 of the name of the variable. In this case, the C<!> twigil emphasizes that
-this attribute is private to the class.
+this attribute is private to the class. The attribute is I<encapsulated>.
+Private attributes will not be set by the default constructor by default, which is
+why we add the C<is built> trait to allow just that.
 
 The second declaration also uses the private twigil:
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -18,10 +18,6 @@ class Rectangle {
     has Int $.a = 1;
     has Int $.b = 1;
 
-    submethod TWEAK(:$log) {
-        say "Constructing Rectangle ($!a|$!b)" if $log;
-    }
-
     method area(--> Int) {
         return $!a * $!b;
     }
@@ -29,15 +25,11 @@ class Rectangle {
 
 my $r1 = Rectangle.new(a => 2, b => 3);
 say $r1.area(); # OUTPUT: «6␤»
-
-my $r2 = Rectangle.new(b => 2, :log); # OUTPUT: «Constructing Rectangle (1|2)␤»
 =end code
 
 We define a new I<Rectangle> class using the L<class|/language/objects#Classes> keyword. It has two I<attributes>, C<$!a> and C<$!b> introduced with the C<has> keyword. Both default to C<1>. Read only accessor methods are automatically generated. (Note the C<.> instead of C<!> in the declaration, which triggers the generation. Mnemonic: C<!> resembles a closed door, C<.> an open one.) 
 
 The L<method|/language/objects#Methods> named C<area> will return the area of the rectangle.
-
-Using the C<TWEAK> submethod, which is automatically called in the construction process we optionally log that a rectangle was created.
 
 It is rarely necessary to explicitly write a constructor. An automatically inherited default constructor called L<new|/language/objects#Object_construction> will automatically initialize attributes from named parameters passed to the constructor.
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -156,12 +156,12 @@ The C<!> character is a I<twigil>, or secondary sigil. A twigil forms part
 of the name of the variable. In this case, the C<!> twigil emphasizes that
 this attribute is private to the class. The attribute is I<encapsulated>.
 Private attributes will not be set by the default constructor by default, which is
-why we add the C<is built> trait to allow just that.
+why we add the C<is built> trait to allow just that. Mnemonic: C<!> looks like a closed door.
 
 The second declaration also uses the private twigil:
 
 =for code :preamble<class Task {}>
-has Task @!dependencies;
+has Task @!dependencies is built;
 
 However, this attribute represents an array of items, so it requires the
 C<@> sigil. These items each specify a task that must be completed before

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -84,42 +84,6 @@ my $eat =
 $eat.perform();
 =end code
 
-C<bless> is eventually invoking it with the two named
-arguments that correspond to the two properties without a default value.
-
-Declaring C<new> as a C<method> and not as a C<multi method> prevents us
-from using the default constructor; this implicit constructor uses the
-attributes as named parameters. This is one of the reasons why using
-C<new> as a method's name is discouraged. If you need to declare it anyway,
-use C<multi method new> if you do not want to disable the default constructor.
-
-C<TWEAK> is the last submethod to be called, and it has the
-advantage of having the object properties available without needing to
-use the metaobject protocol. It can be used, for instance, to assign
-values to instance variables based on the values of other attributes or
-instance variables:
-
-=begin code
-class Str-with-ID is Str {
-    my $counter = 0;
-    has Str $.string;
-    has Int $.ID;
-
-    submethod TWEAK() {
-        $!ID = $counter++;
-    }
-}
-
-say Str-with-ID.new(string => 'First').ID;  # OUTPUT: «0»
-say Str-with-ID.new(string => 'Second').ID; # OUTPUT: «1»
-=end code
-
-In this case, we need to compute C<$.ID> from the value of a counter that is a
-class variable, C<$counter>, thus we simply assign a value to it and increment
-the counter at the same time. Please check also
-L<this section on C<TWEAK> in the Object Orientation (OO) document|/language/objects#index-entry-TWEAK>
-for the mechanics of object construction.
-
 =head1 X<Starting with class|Tutorial,class;Tutorial,state;Tutorial,has>
 
 Raku, like many other languages, uses the C<class> keyword to define a

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -641,9 +641,8 @@ Declaring a class creates a new I<type object> which, by default, is installed
 into the current package (just like a variable declared with C<our> scope).
 This type object is an "empty instance" of the class. For example, types such as
 C<Int> and C<Str> refer to the type object of one of the Raku built-in
-classes. The example above uses the class name C<Task> so that other code can
-refer to it later, such as to create class instances by calling the C<new>
-method.
+classes. One can call methods on these type objects. So there is nothing special
+with calling the C<new> method on a type object.
 
 You can use the C<.DEFINITE> method to find out if what you have is an instance
 or a type object:


### PR DESCRIPTION
This is a reworked version of https://github.com/Raku/doc/pull/3794. The changes are largely the same, for the largest part only pulled apart into many separate commits.

With the advent of `is built` all the common use-cases of object
construction are now covered by our attribute syntax. This means that the
need to fall back to using `BUILD` has lessened enormously. Given that
`BUILD` has a number of behaviours that are non-obvious and require
knowing and understanding them, it makes sense to consider `BUILD` the
last resort mechanism to use when all else fails and recommend using
automatic attribute initialization and `TWEAK` for everything else.
Communicating this clearly in our object tutorial is very valuable, it
shows newcomers the sane default first. We do not want to send them off in
the wrong direction as `BUILD` has proven to be a stumbling block for new
users numerous times.

List of Changes:

- Try to be more structured by reordering things.
- Add more headings for easier navigation.
- Explain `is built`.
- Rework examples to not use `BUILD` anymore.
- Remove wrong explanation of the `Task` example stating one would need a
  `BUILD` when custom constructors are used.
- Remove in-depth explanation of `BUILD`. Add respective documentation for
  `TWEAK`. `BUILD` is still explained in detail in the Object Reference.
- State that `BUILD` is only intended for advanced use-cases.
- Remove `Hero` example which is made obsolete by `is built`.
- Simplify the `Str-with-ID` example and remove bits promoting making
  `TWEAK` a `method` instead of a `submethod`.
- Remove the second duplicate `Str-with-ID` example.
- Rename `Static Fields?` heading to `Class variables`
- Fix the `our` / `my` example to show what Raku actually does.