### PR TITLE
Correct META6.json `provides` snippet

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -611,7 +611,7 @@ use-ok 'MyModule';
 assuming inside C<META6.json> there is a line such as
 
 =for code :lang<json>
-depends: [ "MyModule": "lib/MyModule.rakumod" ],
+provides: { "MyModule": "lib/MyModule.rakumod" },
 
 It is also highly recommended to use the C<Test::META> C<meta-ok> test, which
 verifies the validity of the C<META6.json> file. If you wish to add a


### PR DESCRIPTION
To use a module of the own distribution, it must be listed
in the `provides` section, not the `depends` section.