### PR TITLE
Add examples of obtaining path parts

### DIFF
--- a/doc/Language/io-guide.pod6
+++ b/doc/Language/io-guide.pod6
@@ -63,6 +63,22 @@ However, don't be in a rush to stringify anything. Pass paths around as
 L<IO::Path|/type/IO::Path> objects. All the routines that operate on paths
 can handle them, so there's no need to convert them.
 
+=head2 Path parts
+
+Given a local file name, it's very easy to get its components.
+For example, we have a file, "financial.data", in some
+directory, "/usr/local/data". Use Raku to analyze its path:
+
+=begin code
+my $fname = "financial.data";
+# Stringify the full path name
+my $f = $fname.IO.absolute; 
+say $f;                       # OUTPUT: «/usr/local/data/financial.data␤»
+# Stringify the path's parts:
+say $f.IO.dirname;            # OUTPUT: «/usr/local/data␤»
+say $f.IO.basename;           # OUTPUT: «financial.data␤»
+=end code
+
 =head2 Working with files
 
 =head3 Writing into files


### PR DESCRIPTION
## The problem

No good example of getting path parts exists.

## Solution provided

I added a new head2 section with some examples. (Note I ran "make xtest before this commit and saw no problems with my code.)

# UPDATE

Well, I obviously didn't look very carefully!