### PR TITLE
Fix for #4089

### DIFF
--- a/lib/Pod/Convenience.rakumod
+++ b/lib/Pod/Convenience.rakumod
@@ -7,8 +7,14 @@ elements from a given file.
 
 =end overview
 
+# "File" class was deprecated; use the FileSystem if it's available, fall back to deprecated if not.
+# (should now work on both new and old rakudos, avoiding deprecation notice where possible
+my $class = ::("CompUnit::PrecompilationStore::FileSystem");
+if $class ~~ Failure {
+    $class = ::("CompUnit::PrecompilationStore::File");
+}
 
-my $precomp-store = CompUnit::PrecompilationStore::FileSystem.new(:prefix($?FILE.IO.parent(3).child(".pod-precomp")));
+my $precomp-store = $class.new(:prefix($?FILE.IO.parent(3).child(".pod-precomp")));
 my $precomp = CompUnit::PrecompilationRepository::Default.new(store => $precomp-store);
 
 sub extract-pod(IO() $file) is export {


### PR DESCRIPTION
Properly handle the deprecation notice for earlier rakudos. Original fix ONLY worked on
new compilers, died on old ones. This will work on both and avoid the deprecation warning on newer

