### PR TITLE
Update concurrency.pod6

### DIFF
--- a/doc/Language/concurrency.pod6
+++ b/doc/Language/concurrency.pod6
@@ -337,6 +337,10 @@ asynchronous event that it specifies - that could be a L<Supply|/type/Supply>, a
 L<Channel|/type/Channel>, a L<Promise|/type/Promise> or an
 L<Iterable|/type/Iterable>.
 
+Please note that one should keep the code inside the C<whenever> as small as
+possible, as only one C<whenever> block will be executed at any time.  One can
+use a C<start> block inside the C<whenever> block to run longer running code.
+
 In this example we are watching two supplies.
 
 =begin code
@@ -357,10 +361,6 @@ $vegetable-supplier.emit("Radish");   # OUTPUT: «We've got a vegetable: Radish�
 $bread-supplier.emit("Thick sliced"); # OUTPUT: «We've got bread: Thick sliced␤»
 $vegetable-supplier.emit("Lettuce");  # OUTPUT: «We've got a vegetable: Lettuce␤»
 =end code
-
-Please note that one should keep the code inside the C<whenever> as small as
-possible, as only one C<whenever> block will be executed at any time.  One can
-use a C<start> block inside the C<whenever> block to run longer running code.
 
 
 =head3 X<C<react>|Control flow,react>


### PR DESCRIPTION
Move the "only one whenever block will be executed at any time" part before the example: it's easy to miss at the bottom but represents a big caveat.