### PR TITLE
Modify embedded comments documentation

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -178,12 +178,10 @@ X<|Syntax,Embedded comments>
 =head3 Multi-line / embedded comments
 
 Multi-line and embedded comments start with a hash character, followed by a
-backtick, and then some opening bracketing character, and end with the matching
-closing bracketing character. Whitespace is not permitted between the backtick and the
-bracketing character; it will be treated as a single-line comment. Only the paired characters (), {}, [], and <> are
-valid for bounding comment blocks. (Unlike matches and substitutions, where pairs
-such as !!, || or @ may be used.) The content can not only span multiple lines,
-but can also be embedded inline.
+backtick, and then a Unicode Open Punctuation character, and end with the matching
+Close Punctuation character. Whitespace is not permitted between the backtick and the
+punctuation character; it will be treated as a single-line comment.
+The content can not only span multiple lines, but can also be embedded inline.
 
 =begin code
 if #`( why would I ever write an inline comment here? ) True {


### PR DESCRIPTION
The section describing the specific paired characters is incorrect e.g. ```#`｢...｣``` would work. Explicitly refer to Unicode Punctuation characters which I believe covers the valid set of characters.
