### PR TITLE
Including :x adverb

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -2523,6 +2523,13 @@ In this case, one of them exists (1), so it returns True. Observe that we have
 used C<:st>. As said above, it's functionally equivalent, although obviously
 less legible than using C<:nth>, so this last form is advised.
 
+=head3 X<Counting|Adverbs,:x>
+
+The C<:x> counting adverb makes the expression match many times, like the C<:g>
+adverb, but only up to the limit given by the adverb expression, stopping once the
+specified number of matches has been reached. The value must be a
+L<Numeric|/type/Numeric> or a L<Range|/type/Range>.
+
 =head3 X<Continue|Adverbs,:continue;Adverbs,:c>
 
 The C<:continue> or short C<:c> adverb takes an argument. The argument is


### PR DESCRIPTION
## The problem

`Language/regexes` omitted the `:x` adverb, so this patch is just to add that.
