### PR TITLE
add link; lose my; change phrasing

### DIFF
--- a/doc/Type/Scalar.pod6
+++ b/doc/Type/Scalar.pod6
@@ -29,11 +29,11 @@ operations.
 =for code
 say |(1,2,$(3,4));       # OUTPUT: «12(3 4)␤»
 
-These C<Scalar> containers can also be created on the fly by assigning to a
-bare sigil:
+These C<Scalar> containers can also be created on the fly by assigning to an
+L<anonymous scalar variable|language/variables#index-entry-$_(variable)>:
 
 =for code
-say |(1,2,my $ = (3,4)); # OUTPUT: «12(3 4)␤»
+say |(1,2, $ = (3,4)); # OUTPUT: «12(3 4)␤»
 
 A C<$>-sigiled variable may be bound directly to a value with no
 intermediate C<Scalar> using the binding operator C<:=>. You can


### PR DESCRIPTION
In Type/Scalar.pod6,

- Add a link to anonymous scalar,
- Delete a `my` from example,
- Refer to `$` as 'anonymous scalar variable`