### PR TITLE
sub-signatures demand a space before parenthesis

### DIFF
--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -1033,7 +1033,7 @@ X<|Language,sub-signature>
 To match against a compound parameter use a sub-signature following the argument
 name in parentheses.
 
-    sub foo(|c(Int, Str)){
+    sub foo(|c (Int, Str)){
        put "called with {c.raku}"
     };
     foo(42, "answer");


### PR DESCRIPTION
This makes the example compile.
