### PR TITLE
Remove bot examples

### DIFF
--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -440,7 +440,7 @@ for you.
 A program that does automatic tasks on one or more L<#IRC> channels by
 acting like a regular user (as far as the IRC server is concerned) and
 performing some tasks that may involve answering to users requests.
-Examples are L<#camelia>, L<#dalek> and L<#yoleaux>.
+Examples can be found L<on the IRC page of raku.org|https://raku.org/community/irc>.
 
 =head2 X<Compilation unit or I<compunit>|Reference,compunit (glossary);Reference,compilation unit>
 

--- a/xt/pws/words.pws
+++ b/xt/pws/words.pws
@@ -287,7 +287,6 @@ cwd
 cx
 cygwin
 daenerys
-dalek
 dany
 dataflow
 datehash
@@ -1639,7 +1638,6 @@ xt
 xtest
 yada
 yay
-yoleaux
 yot
 youens
 yy


### PR DESCRIPTION
Relates to https://github.com/Raku/doc/issues/711.

These were the only mentions to IRC bots I found. It seems that their entries had been removed earlier. Now the description links to the irc page on raku.org.