### PR TITLE
Add a practical example of class introspection

### DIFF
--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -234,7 +234,7 @@ X<|Tutorial,class variables>
 
 A class declaration can also include I<class variables>, declared with C<my> or C<our>, which are variables
 whose value is shared by all instances, and can be used for things like
-counting the number of instantiations or any other shared state. So I<class variables> act similar to
+counting the number of instantiations or any other shared state. So I<class variables> act similarly to
 I<static> variables known from other programming languages.
 They look the same as normal (non class) lexical variables (and in fact they are the same):
 
@@ -930,4 +930,77 @@ class instances; in this case, the class method uses the alembic symbol, and the
 instance method, defined below it, aggregates the data we have on the cook to show
 it in a narrative way.
 
+=head2 A practical introspection example
+
+When one creates a new class, it is somtimes useful to have
+informative (and safe) introspection accessible more easily as a
+public method. For example, the following class is used to hold
+attributes for a record row in a CSV spreadsheet with a header row
+defining its field (attribute) names.
+
+=begin code
+unit class CSV-Record;
+#| Field names and values for a CSV row
+has $last;
+has $first;
+#...more fields (attributes)...
+
+method fields(--> List) {
+    #| Return a list of the the attribute names (fields)
+    #| of the class instance
+    my @attributes = self.^attributes;
+    my @names;
+    for @attributes -> $a {
+        my $name = $a.name;
+        # The name is prefixed by its sigil and twigil
+        # which we don't want
+        $name ~~ s/\S\S//;
+        @names.push: $name;
+    }
+    @names
+}
+
+method values(--> List) {
+    #| Return a list of the values for the attributes
+    #| of the class instance
+    my @attributes = self.^attributes;
+    my @values;
+    for @attributes -> $a {
+        # Syntax is not obvious
+        my $value = $a.get_value: self;
+        @values.push: $value;
+    }
+    @values
+}
+=end code
+
+We use it with a simple CSV file with contents:
+
+=begin code
+last,   first #...more fields...
+Wall,   Larry
+Conway, Damon
+=end code
+
+Load the first record and show its contents:
+
+=begin code
+my $record = CSV-Record.new: :$last, :$first;
+say $record.fields.raku; # OUTPUT: «["last", "first"]␤»
+say $record.values.raku; # OUTPUT: «["Wall", "Larry"]␤»
+=end code
+
+Note that practically we would have designed the class so that it has
+the C<fields> list as a constant since its values are the same for all
+class objects:
+
+=begin code
+constant @fields = <last first>;
+method fields(--> List) {
+    @fields
+}
 =end pod
+
+Downsides of using the introspective method for attribute names
+include slightly more processing time and power and the probable need
+to remove the sigil and twigil for public presentation.

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -979,7 +979,7 @@ We use it with a simple CSV file with contents:
 =begin code
 last,   first #...more fields...
 Wall,   Larry
-Conway, Damon
+Conway, Damian
 =end code
 
 Load the first record and show its contents:


### PR DESCRIPTION
## The problem

The current docs do not show a practical, simple, and safe example of the use and implementation of class introspection. This PR attempts to rectify the problem.

## Solution provided

Text was added in a new `=head2` section to the end of the `classtut.pod6` file. The example was tested locally.
