### PR TITLE
correct grammar

### DIFF
--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -234,7 +234,7 @@ X<|Tutorial,class variables>
 
 A class declaration can also include I<class variables>, declared with C<my> or C<our>, which are variables
 whose value is shared by all instances, and can be used for things like
-counting the number of instantiations or any other shared state. So I<class variables> act similar to
+counting the number of instantiations or any other shared state. So I<class variables> act similarly to
 I<static> variables known from other programming languages.
 They look the same as normal (non class) lexical variables (and in fact they are the same):
 
@@ -270,7 +270,7 @@ lexically scoped C<my> variables are "private". This is the exact behavior that
 C<my> and C<our> also show in non class context.
 
 X<|static>
-I<Class variables> act similar to I<static> variables in many other programming
+I<Class variables> act similarly to I<static> variables in many other programming
 languages.
 
 =begin code


### PR DESCRIPTION
## The problem

Two instances of the phrase "act similar" are not grammatically correct.

## Solution provided

Change to read "act similarly" in each instance.
