### PR TITLE
fix cross-reference formats

### DIFF
--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -78,7 +78,7 @@ my $eat =
 $eat.perform();
 =end code
 
-X<|classes,state>
+X<|Tutorial,class;Tutorial,state>
 =head1 X<Class|Tutorial,class;Tutorial,state>
 
 Raku, like many other languages, uses the C<class> keyword to define a
@@ -173,7 +173,7 @@ so external code can modify the value of the attribute.
 =for code
 has &!callback is built;
 
-X<|traits,is built>
+X<|Types,traits;Types,is built>
 By default private attributes are not automatically set by the default constructor. (They are private after
 all.) In the above example we want to allow the user to provide the initial value but keep the attribute
 otherwise private. The C<is built> trait allows to do just that.
@@ -190,7 +190,7 @@ The C<is built> trait was introduced in Rakudo version 2020.01.
 
 =head2 C<is required> trait
 
-X<|traits,is required>
+X<|Types,traits;Types,is required>
 Providing a value for an attribute during initialization is optional by default. Which in the task example
 makes sense for all three, the C<&!callback>, the C<@!dependencies> and the C<$.done> attribute. But lets say
 we want to add another attribute, C<$.name>, that holds a tasks name and we want to force the user to
@@ -269,7 +269,7 @@ is used, the variable is visible via their fully qualified name (FQN), while
 lexically scoped C<my> variables are "private". This is the exact behavior that
 C<my> and C<our> also show in non class context.
 
-X<|static>
+X<|Types,static>
 I<Class variables> act similar to I<static> variables in many other programming
 languages.
 


### PR DESCRIPTION
## The problem

Several instances of cross-references are in the wrong format or have invalid categories.

## Solution provided

Fix the format, and use a valid (but possibly not the most appropriate) category.
