### PR TITLE
Consolidate once from statement-prefixes.pod6 into control.pod6.

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -1141,11 +1141,12 @@ thrown instead of being returned as a C<Failure>.
 
 =head1 X<once|Control flow,once>
 
-A block prefix with C<once> will be executed exactly once, even if placed
-inside a loop or a recursive routine.
+A block or statement prefixed with C<once> will be executed exactly once,
+even if placed inside a loop or a recursive routine.
 
-    my $guard = 3;
+    my $guard;
     loop {
+        once $guard = 3;
         last if $guard-- <= 0;
         once { put 'once' };
         print 'many'

--- a/doc/Language/statement-prefixes.pod6
+++ b/doc/Language/statement-prefixes.pod6
@@ -149,15 +149,6 @@ for 1..^10 {
 In this case, we will know that the number has been found only when the
 C<try> block is not catching an exception.
 
-=head2 X<C<once>|Syntax,once (statement prefix)>
-
-Within a loop, runs the prefixed statement only once.
-
-=for code
-my $counter;
-my $result = do for ^5 { once $counter = 0; $counter++ };
-say $result; # OUTPUT: «(0 1 2 3 4)␤»
-
 =head2 X<C<gather>|Syntax,gather (statement prefix)>
 
 C<gather> can be used in front of a statement, receiving and gathering in a list


### PR DESCRIPTION
Part of the 'Consolidate' series of PRs which is about removing duplication between statement-prefixes.pod6 and control.pod6.  The first in the series is PR #4151.
