### PR TITLE
Consolidate start from statement-prefixes.pod6 into control.pod6.

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -150,7 +150,7 @@ parenthesize a statement if it is the last thing in an expression:
 
 =head1 X<start|Control flow,start>
 
-The simplest way to run a block B<asynchronously> is by writing C<start>
+The simplest way to run a statement or block B<asynchronously> is by writing C<start>
 before it:
 
 =for code
@@ -159,8 +159,8 @@ say "working";
 # working, done
 
 Note that you need a space between the C<start> and the block. In the example
-above, the C<start> block is in sink context, since it's not assigned to a
-variable. From version 6.d, these kind of blocks have an exception handler
+above, the C<start> block is in sink context since it's not assigned to a
+variable. From version 6.d, these sunk blocks have an exception handler
 attached:
 
 =for code :skip-test<Illustrates exception>
@@ -184,15 +184,14 @@ returned promise. So:
 If the code inside the block has not finished, the call to C<.result> will
 wait until it is done.
 
-A C<start> may also be used on a bare statement (without curly braces).
-This is mainly useful when calling a subroutine / method on an object
-is the only thing to do asynchronously.
+A C<start> used on a bare statement is useful when the only thing to do
+asynchronously is a subroutine or method:
 
     sub get42 { 42 }
     my $promise = start get42;
     say $promise.result; # OUTPUT: «42␤»
 
-Note that code executed this way does not have access to the special
+Note that start code does not have access to the special
 variables L«C<$!>|/syntax/$!» and L«C<$/>|/syntax/$$SOLIDUS» of its outer
 block, but receives new ones, so every asynchronous task has its
 per-task state.

--- a/doc/Language/statement-prefixes.pod6
+++ b/doc/Language/statement-prefixes.pod6
@@ -149,6 +149,15 @@ for 1..^10 {
 In this case, we will know that the number has been found only when the
 C<try> block is not catching an exception.
 
+=head2 X<C<once>|Syntax,once (statement prefix)>
+
+Within a loop, runs the prefixed statement only once.
+
+=for code
+my $counter;
+my $result = do for ^5 { once $counter = 0; $counter++ };
+say $result; # OUTPUT: «(0 1 2 3 4)␤»
+
 =head2 X<C<gather>|Syntax,gather (statement prefix)>
 
 C<gather> can be used in front of a statement, receiving and gathering in a list

--- a/doc/Language/statement-prefixes.pod6
+++ b/doc/Language/statement-prefixes.pod6
@@ -149,16 +149,6 @@ for 1..^10 {
 In this case, we will know that the number has been found only when the
 C<try> block is not catching an exception.
 
-=head2 X<C<once>|Syntax,once (statement prefix)>
-
-Within a loop, runs the prefixed statement only once.
-
-=for code
-my $counter;
-my $result = do for ^5 { once $counter = 0; $counter++ };
-say $result; # OUTPUT: «(0 1 2 3 4)␤»
-
-<<<<<<< Updated upstream
 =head2 X<C<gather>|Syntax,gather (statement prefix)>
 
 C<gather> can be used in front of a statement, receiving and gathering in a list

--- a/doc/Language/statement-prefixes.pod6
+++ b/doc/Language/statement-prefixes.pod6
@@ -158,6 +158,7 @@ my $counter;
 my $result = do for ^5 { once $counter = 0; $counter++ };
 say $result; # OUTPUT: «(0 1 2 3 4)␤»
 
+<<<<<<< Updated upstream
 =head2 X<C<gather>|Syntax,gather (statement prefix)>
 
 C<gather> can be used in front of a statement, receiving and gathering in a list
@@ -176,29 +177,6 @@ say @factors;
 In this example, C<gather> precedes C<say>, which prints the first result of the
 factorial; at the same time, it's harvesting the result from every call to
 C<fact>, which goes to C<@factor>.
-
-=head2 X<C<start>|Syntax,start (statement prefix)>
-
-As a statement prefix, C<start> behaves in the same way as L<in front of a
-block|/language/control#start>, that is, it runs the statement
-asynchronously, and returns a promise.
-
-=begin code
-proto sub fact( Int ) {*}
-multi sub fact( 1 --> 1 ) {}
-multi sub fact( $x ) {  $x * fact( $x-1 ) }
-
-my @promises = gather {
-    for <3 4> {
-        take start fact( 10 ** $_ );
-    }
-}
-
-say await @promises;
-=end code
-
-The L<C<Promise>s|/type/Promise> created by start are gathered in an array,
-which returns the result of the operation once the promises have been fulfilled.
 
 =head2 X<C<react>|Syntax,react (statement prefix)>
 


### PR DESCRIPTION
Part of the 'Consolidate' series of PRs which is about removing duplication between statement-prefixes.pod6 and control.pod6.  The first in the series is PR #4151.
