### PR TITLE
Consolidate start from statement-prefixes.pod6 to control.pod6.

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -692,9 +692,9 @@ Unlike C<hyper>, C<race> does not preserve the order of elements.
 
 C<gather> is a statement or block prefix that returns a L<sequence|/type/Seq>
 of values. The values come from calls to L<take|/type/Mu#routine_take> in the
-dynamic scope of the C<gather> block. In the following example, we implement
+dynamic scope of the C<gather> code. In the following example, we implement
 a subroutine to compute the factors of an integer with C<gather> (note that the
-factors are not generated in a strictly increasing order):
+factors are not generated in order):
 
     sub factors( Int:D \n ) {
         my $k = 1;
@@ -714,10 +714,10 @@ factors are not generated in a strictly increasing order):
 
 The C<gather/take> combination can generate values lazily, depending on
 context.
+Binding to a scalar or sigilless container will force laziness.
 If you want to
 force lazy evaluation use the L<lazy|/type/Iterable#method_lazy> subroutine or
-method. Binding to a scalar or sigilless container will also force laziness.
-For example:
+method.  For example:
 
     my @vals = lazy gather {
         take 1;
@@ -733,7 +733,6 @@ For example:
     # between consumption of two values
     # Produced a value
     # 2
-
 
 C<gather/take> is scoped dynamically, so you can call C<take> from subs or
 methods that are called from within C<gather>:
@@ -752,12 +751,11 @@ methods that are called from within C<gather>:
 If values need to be mutable on the caller side, use
 L<take-rw|/type/Mu#routine_take-rw>.
 
-Note that C<gather/take> also work for hashes. The return value is
-still a C<Seq> but the assignment to a hash in the following example
-makes it a hash.
+Note that the C<Seq> created by C<gather/take> may be coerced to another type.
+An example with assignment to a hash:
 
     my %h = gather { take "foo" => 1; take "bar" => 2};
-    say %h;                                   # OUTPUT: «{bar => 2, foo => 1}␤»
+    say %h;                   # OUTPUT: «{bar => 2, foo => 1}␤»
 
 B<Note>: C<gather/take> must not be used to collect results from C<react/whenever>.
 The C<whenever> block is not run from the thread that runs the C<gather/react>, but

--- a/doc/Language/statement-prefixes.pod6
+++ b/doc/Language/statement-prefixes.pod6
@@ -158,25 +158,6 @@ my $counter;
 my $result = do for ^5 { once $counter = 0; $counter++ };
 say $result; # OUTPUT: «(0 1 2 3 4)␤»
 
-=head2 X<C<gather>|Syntax,gather (statement prefix)>
-
-C<gather> can be used in front of a statement, receiving and gathering in a list
-all data structures emitted from a C<take> run anywhere from that statement:
-
-=begin code
-proto sub fact( Int ) {*}
-multi sub fact( 1 --> 1 ) {}
-multi sub fact( $x ) { take $x * fact( $x-1 ) }
-
-my @factors = gather say fact(13); # OUTPUT: «6227020800»
-say @factors;
-# OUTPUT: «[2 6 24 120 720 5040 40320 362880 3628800 ...]»
-=end code
-
-In this example, C<gather> precedes C<say>, which prints the first result of the
-factorial; at the same time, it's harvesting the result from every call to
-C<fact>, which goes to C<@factor>.
-
 =head2 X<C<start>|Syntax,start (statement prefix)>
 
 As a statement prefix, C<start> behaves in the same way as L<in front of a


### PR DESCRIPTION
Miss titled, it is about **gather/take**.

Part of the 'Consolidate' series of PRs which is about removing duplication between statement-prefixes.pod6 and control.pod6. The first in the series is PR #4151.
