### PR TITLE
Consolidate supply from statement-prefixes.pod6 to control.pod6.

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -766,11 +766,18 @@ control exception thrown by C<take>, causing it to error out.
 
 =head1 X<supply/emit|Control flow,supply emit>
 
-Emits the invocant into the enclosing
+The keyword C<supply> creates a L<Supply object|/type/Supply> which is an
+L<on-demand supply|/language/concurrency#index-entry-supply_(on-demand)>
+that you can tap. It pairs with C<emit>, which can be used anywhere from within
+C<supply> prefixed code.
+
+Using the L<C<emit method>|type/Mu#/emit> or the
+L<C<emit routine>|/language/independent-routines#sub_emit> passes the invocant
+to the enclosing
 L<supply|/language/concurrency#index-entry-supply_(on-demand)>:
 
     my $supply = supply {
-        emit $_ for "foo", 42, .5;
+        .emit for "foo", 42, .5;
     }
     $supply.tap: {
         say "received {.^name} ($_)";
@@ -780,6 +787,8 @@ L<supply|/language/concurrency#index-entry-supply_(on-demand)>:
     # received Str (foo)
     # received Int (42)
     # received Rat (0.5)
+
+See also: L<C<tap>|/routine/tap> and L<C<Supplier>|/type/Supplier>.
 
 X<|Other languages,switch (given)>
 X<|Other languages,case statements (given)>

--- a/doc/Language/statement-prefixes.pod6
+++ b/doc/Language/statement-prefixes.pod6
@@ -225,33 +225,4 @@ await @sums;
 In this case C<react> prefixes C<whenever>, which makes a long sum with every
 number read from a channel.
 
-=head2 X<C<supply>|Syntax,supply (statement prefix)>
-
-The keyword C<supply> creates
-L<on-demand supplies|/language/concurrency#index-entry-supply_(on-demand)>
-that you can tap. It pairs with C<emit>, which can be used anywhere from within
-a C<supply> prefixed statement.
-
-=begin code
-my &cards = ->  {
-    my @cards = 1..10 X~ <♠ ♥ ♦ ♣>;
-    emit($_) for @cards.pick(@cards.elems);
-}
-my $supply = supply cards;
-
-$supply.tap( -> $v { say "Drawing: $v" });
-$supply.tap( -> $v { say "Drawing: $v" }, done => { say "No more cards" });
-# OUTPUT:
-# [...]
-# Drawing: 1♥
-# Drawing: 7♥
-# Drawing: 9♥
-# No more cards
-=end code
-
-In this example, C<supply> acts as prefix of the previously defined C<cards>
-routine. It would very well be defined as a block, but giving it a name in this
-case might increase legibility or simply give the responsibility of defining it
-to other module.
-
 =end pod


### PR DESCRIPTION
Part of the 'Consolidate' series of PRs which is about removing duplication between statement-prefixes.pod6 and control.pod6. The first in the series is PR #4151.
