### PR TITLE
Add scrollbar for navbar

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -395,6 +395,9 @@ td, th {
         float: left;
         position: sticky;
         top: 0;
+        height: 100vh;
+        overflow-y: scroll;
+        overflow-x: hidden;
     }
 
     table#TOC {


### PR DESCRIPTION
The navbar was made sticky in b2e1f85 to avoid situations where the user needs to scroll the main content up to use the ToC navbar pane (as described in #2138). However, this resulted in some portions of the ToC being unreachable when the ToC was long enough that it didn't fit on a single screen.

This PR fixes that by adding a scrollbar to the navbar.  Fixes #4176.
