### PR TITLE
Simplify links and fix syntax

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -25,7 +25,7 @@ also be written as:
 
 Like many other languages, Raku uses C<blocks> enclosed by C<{> and C<}> to
 turn a sequence of statements into a
-[`Block`](https://docs.raku.org/type/Block) that acts as a single one. It is OK
+L<C<Block>|/type/Block> that acts as a single one. It is OK
 to omit the semicolon between the last statement in a block and the closing
 C<}>.
 

--- a/doc/Language/experimental.pod6
+++ b/doc/Language/experimental.pod6
@@ -167,6 +167,6 @@ first loop which prints these aliquot parts will be the only one that actually
 perform the computation.
 
 See also
-L<the description of the trait|https://docs.raku.org/routine/is%20cached> for additional information and examples.
+L<the description of the trait|/routine/is%20cached> for additional information and examples.
 
 =end pod

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -1005,7 +1005,7 @@ simultaneously.
 =item System administration simplified due to simpler update and upgrade policies.
 
 =item Simple numeric computation without precision loss because of
-L<Rat|https://docs.raku.org/type/Rat>s (rational numbers).
+L<Rat|/type/Rat>s (rational numbers).
 
 =item Extensible grammars for parsing data or code (which Raku uses to parse
 itself).

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -535,7 +535,7 @@ dot are ignored and symlinks are followed.
 It is important in this section to repeat the note at the beginning of this
 document, namely that there is a difference between a B<Raku> C<distribution>,
 which approximates a I<module> in other languages, and a B<Raku>
-L<module declaration|https://docs.raku.org/language/syntax#index-entry-declarator_unit-declarator_module-declarator_package-Package,_Module,_Class,_Role,_and_Grammar_declaration>.
+L<module declaration|/language/syntax#index-entry-declarator_unit-declarator_module-declarator_package-Package,_Module,_Class,_Role,_and_Grammar_declaration>.
 The reason for this is that a single file may contain a number of C<class>,
 C<module>, C<role> etc declarations, or these declarations may be spread between
 different files. In addition, when a C<distribution> is published (see

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -974,7 +974,7 @@ result, by applying a binary subroutine. It applies its argument (or first
 argument for the sub form) as an operator to all the elements in the object (or
 second argument for the sub form), producing a single result. The subroutine
 must be either an
-L<infix operator|https://docs.raku.org/language/operators#index-entry-infix_operator>
+L<infix operator|/language/operators#index-entry-infix_operator>
 or take two positional arguments. When using an infix operator, we must provide
 the code object of its subroutine version, i.e., the operator category, followed
 by a colon, then a list quote construct with the symbol(s) that make up the

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -122,7 +122,7 @@ assigning C<Nil> to a variable which has a default will restore that default.
 
 Methods such as C<BIND-POS>, C<ASSIGN-KEY>, C<ASSIGN-POS> will die;
 C<BIND-KEY> will produce a failure with an C<X::Bind> exception in it, and
-C<STORE> will produce an L<C<X::Assignment::RO>|https://docs.raku.org/type/X::Assignment::RO> exception.
+C<STORE> will produce an L<C<X::Assignment::RO>|/type/X::Assignment::RO> exception.
 
 =head1 Methods
 

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -654,7 +654,7 @@ X<|Language,slurpy argument>
 
 A function is X<variadic|Reference,variadic> if it can take a varying number of arguments; that is,
 its arity is not fixed. Therefore,
-L<optional|https://docs.raku.org/type/Signature#index-entry-optional_argument>,
+L<optional|/type/Signature#index-entry-optional_argument>,
 named, and slurpy parameters
 make routines that use them I<variadic>, and by extension are called variadic
 arguments. Here we will focus on slurpy parameters, or simply I<slurpies>.


### PR DESCRIPTION
## The problem

Some links are prefixed by https://docs.raku.org/, which is not needed. Also, one link is using wrong syntax for links.

## Solution provided

Links are simplified, and correct syntax are used.