### PR TITLE
throws-like does not work correctly a string for the exception name

### DIFF
--- a/doc/Type/Test.pod6
+++ b/doc/Type/Test.pod6
@@ -573,8 +573,8 @@ eval-lives-ok q[my $daenerys-burns = False;
 
 Marks a test as passed if the given C<$code> throws the specific exception
 expected exception type C<$ex_type>. The code C<$code> may be specified as
-something C<Callable> or as a string to be C<EVAL>ed. The exception may be
-specified as a type object or as a string containing its type name.
+something C<Callable> or as a string to be C<EVAL>ed. The exception is
+specified as a type object.
 
 If an exception was thrown, it will also try to match the matcher hash,
 where the key is the name of the method to be called on the exception, and


### PR DESCRIPTION
## The problem

Documentation is incorrect for throws-like.  If the eval code throws an exception, a string containing the name of that exception will not match.  Example:

```
raku -MTest -e "throws-like 'Exception.new.throw', 'Exception'"
```

This outputs:
```
# Subtest: did we throws-like Str?
    1..2
    ok 1 - 'Exception.new.throw' died
    not ok 2 - right exception type (Str)
    # Failed test 'right exception type (Str)'
    # at SETTING::src/core.c/Exception.pm6 line 64
Stub code executed
  in block  at /home/jmaslak/.rakubrew/versions/moar-2022.12/install/share/perl6/core/sources/60CBD62BA814F88B5840C355CCC73B21A03D70B9 (Test) line 658
  in any  at /home/jmaslak/.rakubrew/versions/moar-2022.12/install/share/perl6/core/sources/60CBD62BA814F88B5840C355CCC73B21A03D70B9 (Test) line 642
  in block <unit> at EVAL_0 line 1
  in block  at /home/jmaslak/.rakubrew/versions/moar-2022.12/install/share/perl6/core/sources/60CBD62BA814F88B5840C355CCC73B21A03D70B9 (Test) line 638
  in sub subtest at /home/jmaslak/.rakubrew/versions/moar-2022.12/install/share/perl6/core/sources/60CBD62BA814F88B5840C355CCC73B21A03D70B9 (Test) line 437
  in sub throws-like at /home/jmaslak/.rakubrew/versions/moar-2022.12/install/share/perl6/core/sources/60CBD62BA814F88B5840C355CCC73B21A03D70B9 (Test) line 630
  in block <unit> at -e line 1
```

However, the following works as expected:
```
raku -MTest -e "throws-like 'Exception.new.throw', Exception"
```

## Solution provided

Solution is to remove the note that exception types can be specified by strings containing the exception name.