### PR TITLE
Making "our declaration" more accurately described

### DIFF
--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -611,8 +611,8 @@ C<sub x() {}> do exactly the same thing.
 
 =head2 The C<our> declarator
 
-C<our> variables work just like C<my> variables, except that they also
-introduce an alias into the symbol table.
+C<our> variables are created in the scope of the surrounding package. They also create
+an alias in the lexical scope, therefore they can be used like C<my> variables as well.
 
     module M {
         our $Var;


### PR DESCRIPTION
## The problem

As @niner pointed out, the docs had the "what is an alias of what" backwards.

## Solution provided

 This change brings the description closer to S04-control, which also seems more factual for this matter.