### PR TITLE
Change metadata from unknown basic to fundamental

### DIFF
--- a/doc/Type/independent-routines.pod6
+++ b/doc/Type/independent-routines.pod6
@@ -1,4 +1,4 @@
-=begin pod :kind("Language") :subkind("Language") :category("basic")
+=begin pod :kind("Language") :subkind("Language") :category("fundamental")
 
 =TITLE Independent routines
 


### PR DESCRIPTION
This page should appear in the language page of the website, but is missed because the category metadata is 'basic' not 'fundamental'

## The problem
This page does not appear in the language index page.

## Solution provided
Change metadata 'basic' to 'fundamental'