### PR TITLE
remove TM char for consistency

### DIFF
--- a/doc/Language/101-basics.pod6
+++ b/doc/Language/101-basics.pod6
@@ -1,6 +1,6 @@
 =begin pod :kind("Language") :subkind("Language") :category("beginning")
 
-=TITLE  Raku™ by example 101
+=TITLE  Raku by example 101
 
 =SUBTITLE A basic introductory example of a Raku program
 


### PR DESCRIPTION
This addresses issue #119 in doc-website, was in Raku/doc Either all references to Raku should have tm or none. My preference is for none as it is obvious

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
