### PR TITLE
Change supported Unicode version

### DIFF
--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -5,7 +5,7 @@
 =SUBTITLE Unicode support in Raku
 
 Raku has a high level of support of Unicode, with the latest version supporting
-Unicode 13.1. This document aims to be both an overview as well as description
+Unicode 15.0. This document aims to be both an overview as well as description
 of Unicode features which don't belong in the documentation for routines and
 methods.
 


### PR DESCRIPTION
It's kind-of dependent on the VM it's running on. Moar is up to Version 15.0 at least.

Interesting enough, the repository said 13.1, the [live site ](https://docs.raku.org/language/unicode) says 12.1. I would suspect that unicode.pod6 hasn't been regenned for a while. 

