### PR TITLE
Rewrite the "make your own operator" example

### DIFF
--- a/doc/Language/js-nutshell.pod6
+++ b/doc/Language/js-nutshell.pod6
@@ -363,16 +363,16 @@ operator overloading natively! Since all operators are subroutines, you can
 define your own like so:
 
 =begin code
-multi sub infix:<||=>($a, $b) is equiv(&infix:<+=>) { $a || $b }
+# "distance operator": the distance of two numbers is the absolute value
+of their difference
+multi sub infix:<|-|>($a, $b) is equiv(&infix:<->) { abs $a - $b }
 
-my $foo = 0;
-$foo ||= 1;
-say $foo; # OUTPUT: 1
+say -1 |-| 3; # OUTPUT: 4
 =end code
 
 Operators can be defined as C<prefix>, C<infix>, or C<postfix>. The
 C<is tighter>, C<is equiv>, and C<is looser> traits optionally define the
-operator's precedence. In this case, C<||=> has the same precedence as C<+=>.
+operator's precedence. In this case, C<|-|> has the same precedence as C<->.
 
 Note how C<multi> is used when declaring the operator subroutines. This allows
 multiple subroutines with the same name to be declared while also having


### PR DESCRIPTION
Relates to https://github.com/rakudo/rakudo/issues/5221

This example got attention because of a related regression, however it was a severely problematic example:
- the implementation was incorrect
- hence the described output wasn't matched
- `||=` exists natively anyway so this example didn't illustrate what it claimed to

Here is a proposed alternative that does illustrate the point and the output is also correct.