### PR TITLE
Prefer OUTPUT: «…» in examples

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -49,8 +49,8 @@ This is as simple as:
 # the :from<Perl5> makes Raku load Inline::Perl5 first (if installed)
 # and then load the Scalar::Util module from Perl
 use Scalar::Util:from<Perl5> <looks_like_number>;
-say looks_like_number "foo";   # 0
-say looks_like_number "42";    # 1
+say looks_like_number "foo";   # OUTPUT: «0␤»
+say looks_like_number "42";    # OUTPUT: «1␤»
 
 A number of Perl modules have been ported to Raku, trying to maintain
 the API of these modules as much as possible, as part of the CPAN Butterfly

--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -263,7 +263,7 @@ more information in error messages, and for introspection.
     =begin code
     proto greeting ( Str \name --> Str ) {*}
 
-    say &greeting.signature;                  # (Str \name --> Str)
+    say &greeting.signature;                  # OUTPUT: «(Str \name --> Str)␤»
     =end code
 
 An interesting thing to note in the Raku code above is that passing values like C<'bub'> as a
@@ -465,23 +465,23 @@ associativity attached to the operator/subroutine.
     sub two-elem-list ( \a, \b ) { ( a, b ) }
 
     # you can use a subroutine as an infix operator
-    say 'a' [&two-elem-list] 'b'; # (a b)
+    say 'a' [&two-elem-list] 'b'; # OUTPUT: «(a b)␤»
 
     # as the reduction prefix metaoperator takes an infix operator, it will work there too;
-    [[&two-elem-list]] 1..5;           # ((((1 2) 3) 4) 5)
-    say (1..5).reduce: &two-elem-list; # ((((1 2) 3) 4) 5)
+    [[&two-elem-list]] 1..5;           # OUTPUT: «((((1 2) 3) 4) 5)␤»
+    say (1..5).reduce: &two-elem-list; # OUTPUT: «((((1 2) 3) 4) 5)␤»
 
     # right associative
     sub right-two-elem-list( \a, \b ) is assoc<right> { ( a, b ) }
-    say (1..5).reduce: &right-two-elem-list; # (1 (2 (3 (4 5))))
+    say (1..5).reduce: &right-two-elem-list; # OUTPUT: «(1 (2 (3 (4 5))))␤»
 
     # XXX there is possibly a bug here as this currently doesn't look at
     # XXX the associativity of &right-two-elem-list and just always does left assoc
     say [[&right-two-elem-list]] 1..5;
 
     # chaining
-    say [<] 1..5;            # True
-    say (1..5).reduce: &[<]; # True
+    say [<] 1..5;            # OUTPUT: «True␤»
+    say (1..5).reduce: &[<]; # OUTPUT: «True␤»
     =end code
 
 =head2 C<takeWhile>

--- a/doc/Language/math.pod6
+++ b/doc/Language/math.pod6
@@ -217,7 +217,7 @@ it will be coerced into such for the application of the inclusion operator.
 
 Raku includes a set of mathematical constants:
 
-    say π; # OUTPUT: «3.141592653589793»
+    say π; # OUTPUT: «3.141592653589793␤»
     say τ; # Equivalent to 2π; OUTPUT: «6.283185307179586»
     say 𝑒; # OUTPUT: «2.718281828459045␤»
 

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -656,7 +656,7 @@ L<C3 method resolution order|https://en.wikipedia.org/wiki/C3_linearization>.
 You can ask a type for its MRO through a call to its metaclass:
 
 =for code
-say List.^mro;      # ((List) (Cool) (Any) (Mu))
+say List.^mro;      # OUTPUT: «((List) (Cool) (Any) (Mu))␤»
 
 If a class does not specify a parent class, L<Any|/type/Any> is assumed
 by default. All classes directly or indirectly derive from L<Mu|/type/Mu>,
@@ -1053,8 +1053,8 @@ class Foo {
 
 my $o1 = Foo.new;
 my $o2 = $o1.clone: :bar(5000);
-say $o1; # Foo.new(foo => 42, bar => 100)
-say $o2; # Foo.new(foo => 42, bar => 5000)
+say $o1; # OUTPUT: «Foo.new(foo => 42, bar => 100)␤»
+say $o2; # OUTPUT: «Foo.new(foo => 42, bar => 5000)␤»
 =end code
 
 See document for L<clone|/routine/clone> for details on how non-scalar

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -2002,9 +2002,9 @@ Unlike the cmp operator which sorts according to codepoint, C<unicmp> and
 C<coll> sort according to how most users would expect, that is, disregarding
 aspects of the particular character like capitalization.
 
-    say 'a' unicmp 'Z'; # Less
-    say 'a' coll 'Z';   # Less
-    say 'a' cmp 'Z';    # More
+    say 'a' unicmp 'Z'; # OUTPUT: «Less␤»
+    say 'a' coll 'Z';   # OUTPUT: «Less␤»
+    say 'a' cmp 'Z';    # OUTPUT: «More␤»
 
 The main difference between C<coll> and C<unicmp> is that the behavior of the
 former can be changed by the

--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -49,9 +49,9 @@ contained in curly braces are interpolated.
 Raku
 
     my $planet = 'earth';
-    say "Hello, $planet";   # Hello, earth
-    say 'Hello, $planet';   # Hello, $planet
-    say "Hello, planet number { 1 + 2 }"; # Hello, planet number 3
+    say "Hello, $planet";                 # OUTPUT: «Hello, earth␤»
+    say 'Hello, $planet';                 # OUTPUT: «Hello, $planet␤»
+    say "Hello, planet number { 1 + 2 }"; # OUTPUT: «Hello, planet number 3␤»
 
 =head2 Statement separators
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -873,8 +873,8 @@ string. If you want match words delimited by commas, you might need to nest an
 ordinary and a modified quantifier:
 
     =begin code
-    say so 'abc,def' ~~ / ^ [\w+] ** 1 % ',' $ /;  # Output: «False»
-    say so 'abc,def' ~~ / ^ [\w+] ** 2 % ',' $ /;  # Output: «True»
+    say so 'abc,def' ~~ / ^ [\w+] ** 1 % ',' $ /;  # OUTPUT: «False␤»
+    say so 'abc,def' ~~ / ^ [\w+] ** 2 % ',' $ /;  # OUTPUT: «True␤»
     =end code
 
 =head2 Preventing backtracking: C<:>
@@ -994,10 +994,10 @@ Briefly, what C<|> does is this:
 
 =item1 First, select the branch which has the longest declarative prefix.
 
-    say "abc" ~~ /ab | a.* /;                 # Output: «⌜abc⌟␤»
-    say "abc" ~~ /ab | a {} .* /;             # Output: «⌜ab⌟␤»
-    say "if else" ~~ / if | if <.ws> else /;  # Output: «｢if｣␤»
-    say "if else" ~~ / if | if \s+   else /;  # Output: «｢if else｣␤»
+    say "abc" ~~ /ab | a.* /;                 # OUTPUT: «⌜abc⌟␤»
+    say "abc" ~~ /ab | a {} .* /;             # OUTPUT: «⌜ab⌟␤»
+    say "if else" ~~ / if | if <.ws> else /;  # OUTPUT: «｢if｣␤»
+    say "if else" ~~ / if | if \s+   else /;  # OUTPUT: «｢if else｣␤»
 
 As is shown above, C<a.*> is a declarative prefix, while C<a {} .*> terminates
 at C<{}>, then its declarative prefix is C<a>. Note that non-declarative atoms
@@ -1007,7 +1007,7 @@ terminates declarative prefix.
 
 =item1 If it's a tie, select the match with the highest specificity.
 
-    say "abc" ~~ /a. | ab { print "win" } /;  # Output: «win｢ab｣␤»
+    say "abc" ~~ /a. | ab { print "win" } /;  # OUTPUT: «win｢ab｣␤»
 
 When two alternatives match at the same length, the tie is broken by
 specificity. That is, C<ab>, as an exact match, counts as closer than C<a.>,
@@ -1015,7 +1015,7 @@ which uses character classes.
 
 =item1 If it's still a tie, use additional tie-breakers.
 
-    say "abc" ~~ /a\w| a. { print "lose" } /; # Output: «⌜ab⌟␤»
+    say "abc" ~~ /a\w| a. { print "lose" } /; # OUTPUT: «⌜ab⌟␤»
 
 If the tie breaker above doesn't work, then the textually earlier alternative
 takes precedence.

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -441,10 +441,10 @@ that is not how the behavior is defined.
 
 =for code
 my @a = <a b c d>;
-say @a.index(‘a’);    # 0
-say @a.index('c');    # 4 -- not 2!
-say @a.index('b c');  # 2 -- not undefined!
-say @a.index(<a b>);  # 0 -- not undefined!
+say @a.index(‘a’);    # OUTPUT: «0␤»
+say @a.index('c');    # OUTPUT: «4␤» -- not 2!
+say @a.index('b c');  # OUTPUT: «2␤» -- not undefined!
+say @a.index(<a b>);  # OUTPUT: «0␤» -- not undefined!
 
 These same caveats apply to L<.rindex|/type/Str#routine_rindex>.
 
@@ -455,11 +455,11 @@ elements in the list.
 
 =for code
 my @menu = <hamburger fries milkshake>;
-say @menu.contains('hamburger');            # True
-say @menu.contains('hot dog');              # False
-say @menu.contains('milk');                 # True!
-say @menu.contains('er fr');                # True!
-say @menu.contains(<es mi>);                # True!
+say @menu.contains('hamburger');            # OUTPUT: «True␤»
+say @menu.contains('hot dog');              # OUTPUT: «False␤»
+say @menu.contains('milk');                 # OUTPUT: «True␤»!
+say @menu.contains('er fr');                # OUTPUT: «True␤»!
+say @menu.contains(<es mi>);                # OUTPUT: «True␤»!
 
 If you actually want to check for the presence of an element, use the
 L<(cont)|/routine/(cont), infix ∋> operator for single elements, and the
@@ -468,10 +468,10 @@ operators for multiple elements.
 
 =for code
 my @menu = <hamburger fries milkshake>;
-say @menu (cont) 'fries';                   # True
-say @menu (cont) 'milk';                    # False
-say @menu (>) <hamburger fries>;            # True
-say @menu (>) <milkshake fries>;            # True (! NB: order doesn't matter)
+say @menu (cont) 'fries';                   # OUTPUT: «True␤»
+say @menu (cont) 'milk';                    # OUTPUT: «False␤»
+say @menu (>) <hamburger fries>;            # OUTPUT: «True␤»
+say @menu (>) <milkshake fries>;            # OUTPUT: «True␤» (! NB: order doesn't matter)
 
 If you are doing a lot of element testing, you may be better off using
 a L<Set|/type/Set>.
@@ -483,10 +483,10 @@ Numeric literals will be parsed into their numeric value before being
 coerced into a string, which may create nonintuitive results.
 
 =for code
-say 0xff.contains(55);      # True
-say 0xff.contains(0xf);     # False
-say 12_345.contains("23");  # True
-say 12_345.contains("2_");  # False
+say 0xff.contains(55);      # OUTPUT: «True␤»
+say 0xff.contains(0xf);     # OUTPUT: «False␤»
+say 12_345.contains("23");  # OUTPUT: «True␤»
+say 12_345.contains("2_");  # OUTPUT: «False␤»
 
 =head2 Getting a random item from a C<List>
 
@@ -499,11 +499,11 @@ and L<roll|/routine/roll>.
 
 =for code
 my @colors = <red orange yellow green blue indigo violet>;
-say @colors.rand;       # 2.21921955680514
-say @colors.pick;       # orange
-say @colors.roll;       # blue
-say @colors.pick(2);    # yellow violet  (cannot repeat)
-say @colors.roll(3);    # red green red  (can repeat)
+say @colors.rand;       # OUTPUT: «2.21921955680514␤»
+say @colors.pick;       # OUTPUT: «orange␤»
+say @colors.roll;       # OUTPUT: «blue␤»
+say @colors.pick(2);    # OUTPUT: «(yellow violet)␤»  (cannot repeat)
+say @colors.roll(3);    # OUTPUT: «(red green red)␤»  (can repeat)
 
 =head2 C<List>s numify to their number of elements in numeric context
 
@@ -954,7 +954,7 @@ But when the variable is changed to comprise regex metacharacters the outputs
 become different:
 
     my $variable = '#camelia';
-    say ‘I ♥ #camelia’ ~~ /  $variable  /;   # OUTPUT: ｢#camelia｣
+    say ‘I ♥ #camelia’ ~~ /  $variable  /;   # OUTPUT: «｢#camelia｣␤»
     say ‘I ♥ #camelia’ ~~ / <$variable> /;   # !! Error: malformed regex
 
 What happens here is that the string C<#camelia> contains the metacharacter
@@ -969,15 +969,15 @@ value of C<code> comprises only literals, there is no distinction between the
 two:
 
     my $variable = 'ailemac';
-    say ‘I ♥ camelia’ ~~ / $($variable.flip)   /;   # OUTPUT: ｢camelia｣
-    say ‘I ♥ camelia’ ~~ / <{$variable.flip}>  /;   # OUTPUT: ｢camelia｣
+    say ‘I ♥ camelia’ ~~ / $($variable.flip)   /;   # OUTPUT: «｢camelia｣␤»
+    say ‘I ♥ camelia’ ~~ / <{$variable.flip}>  /;   # OUTPUT: «｢camelia｣␤»
 
 But when the return value is changed to comprise regex metacharacters, the
 outputs diverge:
 
     my $variable = 'ailema.';
     say ‘I ♥ camelia’ ~~ / $($variable.flip)   /;   # OUTPUT: Nil
-    say ‘I ♥ camelia’ ~~ / <{$variable.flip}>  /;   # OUTPUT: ｢camelia｣
+    say ‘I ♥ camelia’ ~~ / <{$variable.flip}>  /;   # OUTPUT: «｢camelia｣␤»
 
 In this case the return value of the code is the string C<.amelia>, which
 contains the metacharacter C<.>. The above attempt by C«$(code)» to match the
@@ -1882,7 +1882,7 @@ create the transpose of a list-of-lists:
 =begin code
 my @matrix = <X Y>, <a b>, <1 2>;
 my @transpose = [Z] @matrix; # ← WRONG; but so far so good ↙
-say @transpose;              # [(X a 1) (Y b 2)]
+say @transpose;              # OUTPUT: «[(X a 1) (Y b 2)]␤»
 =end code
 
 And everything works fine, until you get an input @matrix with
@@ -1891,7 +1891,7 @@ I<exactly one> row (child list):
 =begin code
 my @matrix = <X Y>,;
 my @transpose = [Z] @matrix; # ← WRONG; ↙
-say @transpose;              # [(X Y)] – not the expected transpose [(X) (Y)]
+say @transpose;              # OUTPUT: «[(X Y)]␤» – not the expected transpose [(X) (Y)]
 =end code
 
 This happens partly because of the

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -431,8 +431,8 @@ my $d; # $d is Any
 say $d.hash; # OUTPUT: {}
 
 my %m is Map = a => 42, b => 666;
-say %m.hash;  # Map.new((a => 42, b => 666))
-say %m.Hash;  # {a => 42, b => 666}
+say %m.hash;  # OUTPUT: «Map.new((a => 42, b => 666))␤»
+say %m.Hash;  # OUTPUT: «{a => 42, b => 666}␤»
 =end code
 
 =head2 method Slip

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -135,8 +135,8 @@ I«public attribute» via C«.new» by passing it the Boolean value C«False».
     }
 
     my $foo = Foo.new(bar => 1, baz => 2);
-    say $foo.bar; # «1␤»
-    say $foo.baz; # «Any␤»
+    say $foo.bar; # OUTPUT: «1␤»
+    say $foo.baz; # OUTPUT: «Any␤»
 
 =head1 Methods
 

--- a/doc/Type/Bag.pod6
+++ b/doc/Type/Bag.pod6
@@ -93,16 +93,16 @@ of the C<Bag>, to specify which type of values are acceptable:
 Finally, you can create Bag masquerading as a hash by using the C<is> trait:
 
     my %b is Bag = <a b c>;
-    say %b<a>;  # True
-    say %b<d>;  # False
+    say %b<a>;  # OUTPUT: «True␤»
+    say %b<d>;  # OUTPUT: «False␤»
 
 Since 6.d (2019.03 and later), this syntax also allows you to specify the
 type of values you would like to allow:
 
     # limit to strings
     my %b is Bag[Str] = <a b c>;
-    say %b<a>;  # True
-    say %b<d>;  # False
+    say %b<a>;  # OUTPUT: «True␤»
+    say %b<d>;  # OUTPUT: «False␤»
 
     # limit to whole numbers
     my %b is Bag[Int] = <a b c>;

--- a/doc/Type/BagHash.pod6
+++ b/doc/Type/BagHash.pod6
@@ -83,8 +83,8 @@ the bag, and the (cumulative) values become the associated integer weights:
 You can also create C<BagHash> masquerading as a hash by using the C<is> trait:
 
     my %bh is BagHash = <a b b c c c>;
-    say %bh<b>;  # 2
-    say %bh<d>;  # 0
+    say %bh<b>;  # OUTPUT: «2␤»
+    say %bh<d>;  # OUTPUT: «0␤»
 
 Since 6.d (2019.03 and later) it is also possible to specify the type of values
 you would like to allow in a C<BagHash>.  This can either be done when calling
@@ -97,8 +97,8 @@ or using the masquerading syntax:
 
     # only allow strings
     my %bh is BagHash[Str] = <a b b c c c>;
-    say %bh<b>;  # 2
-    say %bh<d>;  # 0
+    say %bh<b>;  # OUTPUT: «2␤»
+    say %bh<d>;  # OUTPUT: «0␤»
 
     # only allow whole numbers
     my %bh is BagHash[Int] = <a b b c c c>;

--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -276,12 +276,12 @@ appropriate point in time, and cast to an C<Instant>.
 
 =for code
 my $instant = DateTime.new(
-    year => 2020,
+    year => 2023,
     month => 9,
     day => 1,
     hour => 22,
     minute => 5);
-say sleep-until $instant.Instant; # True (eventually...)
+say sleep-until $instant.Instant; # OUTPUT: «True␤» (eventually...)
 
 This could be used as a primitive kind of alarm clock.  For instance, say
 you need to get up at 7am on the 4th of September 2015, but for some reason

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -127,8 +127,8 @@ January. Thus, dates early in January often end up in the last week of the prior
 year, and similarly, the final few days of December may be placed in the first
 week of the next year.
 
-    say Date.new("2014-12-31").week-number;   # 1  (first week of 2015)
-    say Date.new("2016-01-02").week-number;   # 53 (last week of 2015)
+    say Date.new("2014-12-31").week-number;   # OUTPUT: «1␤»  (first week of 2015)
+    say Date.new("2016-01-02").week-number;   # OUTPUT: «53␤» (last week of 2015)
 
 =head2 method week-year
 
@@ -139,9 +139,9 @@ is equal to C<Date.year>. Note however that dates early in January often end up 
 the last week of the prior year, and similarly, the final few days of December
 may be placed in the first week of the next year.
 
-    say Date.new("2015-11-15").week-year;   # 2015
-    say Date.new("2014-12-31").week-year;   # 2015 (date belongs to the first week of 2015)
-    say Date.new("2016-01-02").week-year;   # 2015 (date belongs to the last week of 2015)
+    say Date.new("2015-11-15").week-year;   # OUTPUT: «2015␤»
+    say Date.new("2014-12-31").week-year;   # OUTPUT: «2015␤» (date belongs to the first week of 2015)
+    say Date.new("2016-01-02").week-year;   # OUTPUT: «2015␤» (date belongs to the last week of 2015)
 
 =head2 method weekday-of-month
 
@@ -150,7 +150,7 @@ may be placed in the first week of the next year.
 Returns a number (1..5) indicating the number of times a particular day-of-week
 has occurred so far during that month, the day itself included.
 
-    say Date.new("2003-06-09").weekday-of-month;  # 2  (second Monday of the month)
+    say Date.new("2003-06-09").weekday-of-month;  # OUTPUT: «2␤»  (second Monday of the month)
 
 =head2 method yyyy-mm-dd
 

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -424,14 +424,14 @@ hashes the type used in the declaration of the C<Hash> is returned.
     say %h1.keyof;                           # OUTPUT: «(Str(Any))␤»
 
     my %h2{Str} = 'oranges' => 7;            # (keys must be of type Str)
-    say %h2.keyof;                           # (Str)
+    say %h2.keyof;                           # OUTPUT: «(Str)␤»
     %h2{3} = 'apples';                       # throws exception
     CATCH { default { put .^name, ': ', .Str } };
     # OUTPUT: «X::TypeCheck::Binding: Type check failed in binding to key; expected Str but got Int (3)␤»
 
     my %h3{Int};                             # (this time, keys must be of type Int)
     %h3{42} = 4096;
-    say %h3.keyof;                           # (Int)
+    say %h3.keyof;                           # OUTPUT: «(Int)␤»
 
 =head2 method of
 

--- a/doc/Type/Mix.pod6
+++ b/doc/Type/Mix.pod6
@@ -85,8 +85,8 @@ or using the masquerading syntax:
 
     # only allow strings
     my %m is Mix[Str] = <a b b c c c>;
-    say %m<b>;  # 2
-    say %m<d>;  # 0
+    say %m<b>;  # OUTPUT: «2␤»
+    say %m<d>;  # OUTPUT: «0␤»
 
     # only allow whole numbers
     my %m is Mix[Int] = <a b b c c c>;

--- a/doc/Type/MixHash.pod6
+++ b/doc/Type/MixHash.pod6
@@ -81,8 +81,8 @@ or using the masquerading syntax:
 
     # only allow strings
     my %mh is MixHash[Str] = <a b b c c c>;
-    say %mh<b>;  # 2
-    say %mh<d>;  # 0
+    say %mh<b>;  # OUTPUT: «2␤»
+    say %mh<d>;  # OUTPUT: «0␤»
 
     # only allow whole numbers
     my %mh is MixHash[Int] = <a b b c c c>;

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -78,9 +78,9 @@ Returns C<True> if and only if the invocant conforms to type C<$type>.
 
 =for code
 my $d = Date.new('2016-06-03');
-say $d.does(Dateish);             # True    (Date does role Dateish)
-say $d.does(Any);                 # True    (Date is a subclass of Any)
-say $d.does(DateTime);            # False   (Date is not a subclass of DateTime)
+say $d.does(Dateish);             # OUTPUT: «True␤»    (Date does role Dateish)
+say $d.does(Any);                 # OUTPUT: «True␤»    (Date is a subclass of Any)
+say $d.does(DateTime);            # OUTPUT: «False␤»   (Date is not a subclass of DateTime)
 
 Unlike L<C<isa>|/routine/isa#(Mu)_routine_isa>, which
 returns C<True> only for superclasses, C<does> includes both superclasses and

--- a/doc/Type/Set.pod6
+++ b/doc/Type/Set.pod6
@@ -76,16 +76,16 @@ variable C<Associative> by using the corresponding sigil) by using the C<is>
 trait:
 
     my %s is Set = <a b c>;
-    say %s<a>;  # True
-    say %s<d>;  # False
+    say %s<a>;  # OUTPUT: «True␤»
+    say %s<d>;  # OUTPUT: «False␤»
 
 Since 6.d (2019.03 and later), this syntax also allows you to specify the
 type of values you would like to allow:
 
     # limit to strings
     my %s is Set[Str] = <a b c>;
-    say %s<a>;  # True
-    say %s<d>;  # False
+    say %s<a>;  # OUTPUT: «True␤»
+    say %s<d>;  # OUTPUT: «False␤»
 
     # limit to whole numbers
     my %s is Set[Int] = <a b c>;

--- a/doc/Type/SetHash.pod6
+++ b/doc/Type/SetHash.pod6
@@ -120,8 +120,8 @@ assignment:
 You can also create C<SetHash> masquerading as a hash by using the C<is> trait:
 
     my %sh is SetHash = <a b c>;
-    say %sh<a>;  # True
-    say %sh<d>;  # False
+    say %sh<a>;  # OUTPUT: «True␤»
+    say %sh<d>;  # OUTPUT: «False␤»
 
 Since 6.d (2019.03 and later) it is also possible to specify the type of values
 you would like to allow in a C<SetHash>.  This can either be done when calling
@@ -134,8 +134,8 @@ or using the masquerading syntax:
 
     # only allow strings
     my %sh is SetHash[Str] = <a b c>;
-    say %sh<a>;  # True
-    say %sh<d>;  # False
+    say %sh<a>;  # OUTPUT: «True␤»
+    say %sh<d>;  # OUTPUT: «False␤»
 
     # only allow whole numbers
     my %sh is SetHash[Int] = <a b c>;

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -481,10 +481,10 @@ so that even an instantiated C<Failure> acts as an undefined value:
 
     my $a = Failure;                # Initialize with type object
     my $b = Failure.new("foo");     # Initialize with object instance
-    say $a.DEFINITE;                # Output: «False␤» : indefinite type object
-    say $b.DEFINITE;                # Output: «True␤»  : definite object instance
-    say $a.defined;                 # Output: «False␤» : default response
-    say $b.defined;                 # Output: «False␤» : .defined override
+    say $a.DEFINITE;                # OUTPUT: «False␤» : indefinite type object
+    say $b.DEFINITE;                # OUTPUT: «True␤»  : definite object instance
+    say $a.defined;                 # OUTPUT: «False␤» : default response
+    say $b.defined;                 # OUTPUT: «False␤» : .defined override
 
 =head3 Constraining signatures of C<Callable>s
 


### PR DESCRIPTION
Also try to ensure consistent casing of `OUTPUT:` and add missing `␤`s.