### PR TITLE
Update modules-extra.pod6

### DIFF
--- a/doc/Language/modules-extra.pod6
+++ b/doc/Language/modules-extra.pod6
@@ -18,8 +18,6 @@ of a module distribution.
 =item L<App::Mi6|https://modules.raku.org/dist/App::Mi6>     Minimal authoring tool for Raku
 =item L<META6|https://modules.raku.org/dist/META6>        Do things with Raku C<META> files
 =item L<Module::Skeleton|https://bitbucket.org/rightfold/module-skeleton>        Generate a skeleton module
-=item L<p6doc|https://modules.raku.org/dist/p6doc>        Generate documentation end-products
-
 
 =head1 Tests
 


### PR DESCRIPTION
## The problem
p6doc no longer available on modules.raku.org

## Solution provided
Remove reference to it and link