### PR TITLE
link-checker: Check for the existence of directories as well as pod6 files

### DIFF
--- a/xt/link-checker.rakutest
+++ b/xt/link-checker.rakutest
@@ -49,9 +49,9 @@ sub is-valid-link($links) {
 
             # Look in doc/ folder for this rakudoc file.
             @path.unshift: 'doc';
-            my $path = @path.join('/') ~ '.pod6';
+            my $path = @path.join('/');
 
-            ok $path.IO.e, "$link exists (primary)";
+            ok ($path.IO.d or ($path ~ '.pod6').IO.e), "$link exists (primary)";
         }
     }
 }


### PR DESCRIPTION
This is useful for links to the `/language` index, for example.