### PR TITLE
Partially revert changes to `Distribution::Resource`

### DIFF
--- a/doc/Type/Distribution/Resource.pod6
+++ b/doc/Type/Distribution/Resource.pod6
@@ -90,13 +90,13 @@ However, if we install the distribution and run the installed script, what we
 will get is
 
 =for code :lang<text>
-"/home/jmerelo/.rakudobrew/versions/moar-2020.05/install/share/raku/site/resources/7127AA0E7F43E87DF309570E813E46A6E2C4D0B2.so".IO
+"/home/jmerelo/.rakudobrew/versions/moar-2020.05/install/share/perl6/site/resources/7127AA0E7F43E87DF309570E813E46A6E2C4D0B2.so".IO
 ---------->
 site
 (Str)
 1F8F9C004D7E952B297F30420DA07B354B3F2AA7
 libraries/whatever
-"/home/jmerelo/.rakudobrew/versions/moar-2020.05/install/share/raku/site/resources/D357F3E46256CB0DACD8975033D1CC7A17B4CF9F.csv".IO
+"/home/jmerelo/.rakudobrew/versions/moar-2020.05/install/share/perl6/site/resources/D357F3E46256CB0DACD8975033D1CC7A17B4CF9F.csv".IO
 ---------->
 site
 (Str)


### PR DESCRIPTION
Reverts two lines changed in 4118f0c: the directory name has yet to be changed from `perl6` to `raku`.