### PR TITLE
Declare `v6.e.PREVIEW` in the preamble for examples that require 6.e

### DIFF
--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -1446,12 +1446,13 @@ be a list of matchers: as soon as a "snip" was made, will it start checking
 using the next matcher.  The rest of the C<Iterable> will be produced if
 there are no matchers left.
 
-    .say for snip * < 10, 2, 5, 13, 9, 6;      # OUTPUT: «(2 5)␤(13 9 6)␤»
-    .say for snip (* < 10, * < 20), 5, 13, 29; # OUTPUT: «(5)␤(13)␤(29)␤»
-    .say for snip Int, 2, 5, 5, "a", "b";      # OUTPUT: «(2 5 5)␤(a b)␤»
-    .say for (2, 5, 13, 9, 6).snip(* < 10);    # OUTPUT: «(2 5)␤(13 9 6)␤»
-    .say for (5, 13,29).snip(* < 10, * < 20);  # OUTPUT: «(5)␤(13)␤(29)␤»
-    .say for (2, 5, 5, "a", "b").snip: Int;    # OUTPUT: «(2 5 5)␤(a b)␤»
+=for code :solo :preamble<use v6.e.PREVIEW;>
+.say for snip * < 10, 2, 5, 13, 9, 6;      # OUTPUT: «(2 5)␤(13 9 6)␤»
+.say for snip (* < 10, * < 20), 5, 13, 29; # OUTPUT: «(5)␤(13)␤(29)␤»
+.say for snip Int, 2, 5, 5, "a", "b";      # OUTPUT: «(2 5 5)␤(a b)␤»
+.say for (2, 5, 13, 9, 6).snip(* < 10);    # OUTPUT: «(2 5)␤(13 9 6)␤»
+.say for (5, 13,29).snip(* < 10, * < 20);  # OUTPUT: «(5)␤(13)␤(29)␤»
+.say for (2, 5, 5, "a", "b").snip: Int;    # OUTPUT: «(2 5 5)␤(a b)␤»
 
 =head2 routine snitch
 

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -1447,24 +1447,26 @@ By default, it will L<note|/routine/note> the invocant / argument, but
 this can be overridden by specifying a C<Callable> that is expected to
 take the invocant / argument as its only argument.
 
-    (my $a = 42).snitch = 666; say $a;  # OUTPUT: «42␤666␤»
-    (1..5).snitch;                      # OUTPUT: «1..5␤»
-    (1..5).Seq.snitch;                  # OUTPUT: «(1 2 3 4 5)␤»
-    (1..5).Seq.snitch(&dd);             # OUTPUT: «(1, 2, 3, 4, 5).Seq␤»
-    (1..5).map(*+1).snitch;             # OUTPUT: «(2 3 4 5 6)␤»
-    say (1..3).Seq.snitch.map(*+2);     # OUTPUT: «(1 2 3)␤(3 4 5)␤»
+=for code :solo :preamble<use v6.e.PREVIEW;>
+(my $a = 42).snitch = 666; say $a;  # OUTPUT: «42␤666␤»
+(1..5).snitch;                      # OUTPUT: «1..5␤»
+(1..5).Seq.snitch;                  # OUTPUT: «(1 2 3 4 5)␤»
+(1..5).Seq.snitch(&dd);             # OUTPUT: «(1, 2, 3, 4, 5).Seq␤»
+(1..5).map(*+1).snitch;             # OUTPUT: «(2 3 4 5 6)␤»
+say (1..3).Seq.snitch.map(*+2);     # OUTPUT: «(1 2 3)␤(3 4 5)␤»
 
 The same, using the feed operator:
 
-    (1..3).Seq ==> snitch() ==> map(*+2) ==> say();  # OUTPUT: «(1 2 3)␤(3 4 5)␤»
+=for code :solo :preamble<use v6.e.PREVIEW;>
+(1..3).Seq ==> snitch() ==> map(*+2) ==> say();  # OUTPUT: «(1 2 3)␤(3 4 5)␤»
 
 Using a custom logger:
 
-=begin code :lang<raku>
-    my @snitched;
-    my @result = (1..3).Seq.snitch({ @snitched.push($_) }).map(*+2);
-    say @snitched;  # OUTPUT: «[(1 2 3)]␤»
-    say @result;    # OUTPUT: «[3 4 5]␤»
+=begin code :solo :lang<raku> :preamble<use v6.e.PREVIEW;>
+my @snitched;
+my @result = (1..3).Seq.snitch({ @snitched.push($_) }).map(*+2);
+say @snitched;  # OUTPUT: «[(1 2 3)]␤»
+say @result;    # OUTPUT: «[3 4 5]␤»
 =end code
 
 =end pod


### PR DESCRIPTION
`use v6.e.PREVIEW` for `snip` and `snitch` examples.