### PR TITLE
xt/rakudoc-c.rakutest: respect `Z<ignore-code-ws>`

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -2410,8 +2410,8 @@ it will turn into C«<.ws>».
 In addition, if whitespace comes after a term but I<before> a quantifier
 (C<+>, C<*>, or C<?>), C«<.ws>» will be matched after every match of the
 term. So, C<foo +> becomes C«[ foo <.ws> ]+». On the other hand, whitespace
-I<after> a quantifier acts as normal significant whitespace; e.g., "C<foo+ >"
-becomes C«foo+ <.ws>».
+I<after> a quantifier acts as normal significant whitespace; e.g.,
+Z<ignore-code-ws>"C<foo+ >" becomes C«foo+ <.ws>».
 
 In all, this code:
 
@@ -2807,10 +2807,11 @@ say $string ~~ / :r (.+)(SQL) (.+) $1/;  # OUTPUT: «Nil␤»
 =end code
 
 The fact is that, as shown in the I<iteration 1> output, the first match of the
-regular expression engine will be C<PostgreSQL is an >, C<SQL>, C< database>
-that does not leave out any room for matching another occurrence of the word
-I<SQL> (as C<$1> in the regular expression). Since the engine is not able to get
-backward and change the path to match, the regular expression fails.
+regular expression engine will be Z<ignore-code-ws>C<PostgreSQL is an >,
+C<SQL>, C< database> that does not leave out any room for matching another
+occurrence of the word I<SQL> (as C<$1> in the regular expression). Since the
+engine is not able to get backward and change the path to match, the regular
+expression fails.
 
 It is worth noting that disabling backtracking will not prevent the engine
 to try several ways to match the regular expression.

--- a/xt/rakudoc-c.rakutest
+++ b/xt/rakudoc-c.rakutest
@@ -27,11 +27,19 @@ sub is-valid-c($contents) {
 }
 
 sub walk-content($x) {
+    my $trailing-ok = False;
     for $x.contents -> $contents {
         next unless $contents;
         for @$contents -> $item {
+            if $item ~~ Pod::FormattingCode and $item.type eq 'Z' {
+                if $item.contents.lc ~~ 'ignore-code-ws' {
+                  # skip the validity check for the next C<>
+                  $trailing-ok = True;
+                }
+            }
             if $item ~~ Pod::FormattingCode and $item.type eq 'C' {
-                is-valid-c($item.contents);
+                is-valid-c($item.contents) unless $trailing-ok;
+                $trailing-ok = False;
             } elsif $item !~~ Str {
                 walk-content($item);
             }


### PR DESCRIPTION
`Z<ignore-code-ws>` indicates that the following whitespace check ought to be skipped.

A couple of these `Z<>`s have been added to `doc/Language/regexes.rakudoc`. 

Relates to #4251.