### PR TITLE
Remove formatting codes from various examples

### DIFF
--- a/doc/Language/functions.rakudoc
+++ b/doc/Language/functions.rakudoc
@@ -54,8 +54,8 @@ This will become more useful once macros are added to Raku.
 To have the subroutine take arguments, a L<signature|/type/Signature> goes
 between the subroutine's name and its body, in parentheses:
 
-=for code :allow<B L>
-sub exclaim B<($phrase)> {
+=for code
+sub exclaim ($phrase) {
     say $phrase ~ "!!!!"
 }
 exclaim "Howdy, World";
@@ -132,9 +132,9 @@ type.
 
 The parameters that a function accepts are described in its I<signature>.
 
-=for code :allow<B>
-sub formatB<(Str $s)> { ... }
--> B<$a, $b> { ... }
+=for code
+sub format(Str $s) { ... }
+-> $a, $b { ... }
 
 Details about the syntax and use of signatures can be found in the
 L<documentation on the C<Signature> class|/type/Signature>.

--- a/doc/Language/modules.rakudoc
+++ b/doc/Language/modules.rakudoc
@@ -109,8 +109,8 @@ use MyModule;
 
 This is equivalent to:
 
-=begin code :allow<L> :skip-test<needs dummy module>
-L<need|/language/modules#need> MyModule;
+=begin code :skip-test<needs dummy module>
+need MyModule;
 import MyModule;
 =end code
 

--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -2810,7 +2810,7 @@ In effect, the left-hand argument is the "start" condition and the
 right-hand is the "stop" condition. This construct is typically used to
 pick up only a certain section of lines. For example:
 
-=begin code :allow<B V>
+=begin code :allow<V>
 my $excerpt = q:to/END/;
 Here's some unimportant text.
 V<=>begin code
@@ -2821,7 +2821,7 @@ More unimportant text.
 END
 
 my @codelines = gather for $excerpt.lines {
-    take $_ if B<"=begin code" ff "=end code">
+    take $_ if "=begin code" ff "=end code"
 }
 # this will print four lines, starting with "=begin code" and ending with
 # "=end code"

--- a/doc/Language/pragmas.rakudoc
+++ b/doc/Language/pragmas.rakudoc
@@ -78,8 +78,8 @@ in the pragma's lexical scope. The effect can be restricted to a subset of
 variables by listing their names as arguments. By default applies to I<all>
 variables.
 
-=begin code :allow<C>
-# Apply C<is dynamic> only to $x, but not to $y
+=begin code
+# Apply `is dynamic` only to $x, but not to $y
 use dynamic-scope <$x>;
 
 sub poke {

--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -18,12 +18,12 @@ described in more detail in the following sections.
 
 =head2 X<Literal strings: Q|Syntax,Q;Syntax,｢ ｣>
 
-=for code :allow<B> :skip-test<listing>
-B<Q[>A literal stringB<]>
-B<｢>More plainly.B<｣>
-B<Q ^>Almost any non-word character can be a delimiter!B<^>
-B<Q ｢｢>Delimiters can be repeated/nested if they are adjacent.B<｣｣>
-B<Q｟Quoting with fancy unicode pairs｠>
+=for code :skip-test<listing>
+Q[A literal string]
+｢More plainly.｣
+Q^Almost any non-word character can be a delimiter!^
+Q｢｢Delimiters can be repeated/nested if they are adjacent.｣｣
+Q｟Quoting with fancy unicode pairs｠
 
 Delimiters can be nested, but in the plain C<Q> form, backslash escapes
 aren't allowed. In other words, basic C<Q> strings are as literal as
@@ -39,17 +39,17 @@ with a space. Please note that some natural languages use a left delimiting
 quote on the right side of a string. C<Q> will not support those as it relies
 on unicode properties to tell left and right delimiters apart.
 
-=for code :allow<B> :skip-test<listing>
-B<Q'>this will not work!B<'>
-B<Q(>this won't work either!B<)>
+=for code :skip-test<listing>
+Q'this will not work!'
+Q(this won't work either!)
 
 The examples above will produce an error. However, this will work
 
-=for code :allow<B> :skip-test<listing>
-B<Q (>this is fine, because of space after QB<)>
-B<Q '>and so is thisB<'>
-Q<Make sure you B«<»matchB«>» opening and closing delimiters>
-Q{This is still a closing curly brace → B<\>}
+=for code :skip-test<listing>
+Q (this is fine, because of space after Q)
+Q 'and so is this'
+Q<Make sure you <match> opening and closing delimiters>
+Q{This is still a closing curly brace → \}
 
 These examples produce:
 
@@ -149,7 +149,7 @@ delimiter, but it's also available as an adverb on C<Q>, as in the fifth and
 last example above.
 
 These examples produce:
-=for code :allow<B> :lang<text>
+=for code :lang<text>
 Very plain
 This back\slash stays
 This back\slash stays
@@ -170,13 +170,9 @@ in your strings, to avoid interpretation of angle brackets as hash keys:
 
 =head2 X<Interpolation: qq|Syntax,qq;Syntax," ">
 
-=begin code :allow<B L>
+=begin code
 my $color = 'blue';
-L<say|/routine/say> B<">My favorite color is B<$color>!B<">
-=end code
-
-=begin code :lang<text>
-My favorite color is blue!
+say "My favorite color is $color!"; # OUTPUT: «My favorite color is blue!␤»
 =end code
 
 X<|Syntax,\ (quoting)>
@@ -201,25 +197,19 @@ C<"documentation@raku.org"> without interpolating the C<@raku> variable.
 To interpolate an Array (or other L<Positional|/type/Positional> variable),
 append a C<[]> to the variable name:
 
-=begin code :allow<B>
+=begin code
 my @neighbors = "Felix", "Danielle", "Lucinda";
-say "@neighborsB<[]> and I try our best to coexist peacefully."
-=end code
-
-=begin code :lang<text>
-Felix Danielle Lucinda and I try our best to coexist peacefully.
+say "@neighbors[] and I try our best to coexist peacefully."
+# OUTPUT: «Felix Danielle Lucinda and I try our best to coexist peacefully.␤»
 =end code
 
 Alternatively, rather than using C<[]>, you can interpolate the Array by
 following it with a method call with parentheses after the method name. Thus the
 following code will work:
 
-=begin code :allow<B L> :preamble<my @neighbors = "Felix", "Danielle", "Lucinda">
-say "@neighborsB<.L<join|/routine/join>(', ')> and I try our best to coexist peacefully."
-=end code
-
-=begin code :lang<text>
-Felix, Danielle, Lucinda and I try our best to coexist peacefully.
+=begin code :preamble<my @neighbors = "Felix", "Danielle", "Lucinda">
+say "@neighbors.join(', ') and I try our best to coexist peacefully."
+# OUTPUT: «Felix, Danielle, Lucinda and I try our best to coexist peacefully.␤»
 =end code
 
 However, C<"@example.com"> produces C<@example.com>.
@@ -248,15 +238,10 @@ interpolations.
 Another feature of C<qq> is the ability to interpolate Raku code from
 within the string, using curly braces:
 
-=begin code :allow<B L>
+=begin code
 my ($x, $y, $z) = 4, 3.5, 3;
-say "This room is B<$x> m by B<$y> m by B<$z> m.";
-say "Therefore its volume should be B<{ $x * $y * $z }> m³!";
-=end code
-
-=begin code :lang<text>
-This room is 4 m by 3.5 m by 3 m.
-Therefore its volume should be 42 m³!
+say "This room is $x m by $y m by $z m.";                   # OUTPUT: «This room is 4 m by 3.5 m by 3 m.␤»
+say "Therefore its volume should be { $x * $y * $z } m³!";  # OUTPUT: «Therefore its volume should be 42 m³!␤»
 =end code
 
 This provides the same functionality as the C<q:closure>/C<q:c> quoting form.
@@ -266,7 +251,7 @@ This provides the same functionality as the C<q:closure>/C<q:c> quoting form.
 The C<qq> quoting form also interpolates backslash escape sequences.  Several of
 these print invisible/whitespace ASCII control codes or whitespace characters:
 
-=begin table :allow<L>
+=begin table
 Sequence    Hex Value       Character            Reference URL
 \0          \x0000          Nul                  https://util.unicode.org/UnicodeJsps/character.jsp?a=0000
 \a          \x0007          Bel                  https://util.unicode.org/UnicodeJsps/character.jsp?a=0007
@@ -311,12 +296,8 @@ provided by C<q:backslash>/C<q:b>.
 You can prevent any undesired interpolation in a
 C<qq>-quoted string by escaping the sigil or other initial character:
 
-=begin code :allow<B> :preamble<my $color = 'blue'>
-say B<">The B<\>$color variable contains the value '$color'B<">;
-=end code
-
-=begin code :lang<text>
-The $color variable contains the value 'blue'
+=begin code :preamble<my $color = 'blue'>
+say "The \$color variable contains the value '$color'"; # OUTPUT: «The $color variable contains the value 'blue'␤»
 =end code
 
 Interpolation of undefined values will raise a control exception that can be
@@ -335,9 +316,9 @@ CONTROL { .die };
 X<|Syntax,qw word quote>
 
 =for code :allow<B L>
-B<qw|>! @ # $ % ^ & * \| < > B<|> eqv '! @ # $ % ^ & * | < >'.words.list;
-B<q:w {> [ ] \{ \} B<}> eqv ('[', ']', '{', '}');
-B<Q:w |> [ ] { } B<|> eqv ('[', ']', '{', '}');
+qw|! @ # $ % ^ & * \| < > | eqv '! @ # $ % ^ & * | < >'.words.list;
+q:w { [ ] \{ \} }           eqv ('[', ']', '{', '}');
+Q:w | [ ] { } |             eqv ('[', ']', '{', '}');
 
 The C<:w> form, usually written as C<qw>, splits the string into
 "words". In this context, words are defined as sequences of non-whitespace
@@ -358,9 +339,9 @@ It's easier to write and to read this:
 =head2 Word quoting: C«< >»
 X«|Syntax,< > word quote»
 
-=for code :allow<B L>
-say B«<»a b cB«>» L<eqv|/routine/eqv> ('a', 'b', 'c');   # OUTPUT: «True␤»
-say B«<»a b 42B«>» L<eqv|/routine/eqv> ('a', 'b', '42'); # OUTPUT: «False␤», the 42 became an IntStr allomorph
+=for code
+say <a b c> eqv ('a', 'b', 'c');   # OUTPUT: «True␤»
+say <a b 42> eqv ('a', 'b', '42'); # OUTPUT: «False␤», the 42 became an IntStr allomorph
 say < 42 > ~~ Int; # OUTPUT: «True␤»
 say < 42 > ~~ Str; # OUTPUT: «True␤»
 

--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -2381,10 +2381,10 @@ ignored, to make regexes more readable by programmers.
 When C<:sigspace> is present, unquoted whitespace may be converted into
 C«<.ws>» subrule calls depending on where it occurs in the regex.
 
-    =begin code :allow<B>
-    say so "I used Photoshop®"   ~~ m:i/   photo shop /;      # OUTPUT: «True␤»
-    say so "I used a photo shop" ~~ m:iB<:s>/ photo shop /;   # OUTPUT: «True␤»
-    say so "I used Photoshop®"   ~~ m:iB<:s>/ photo shop /;   # OUTPUT: «False␤»
+    =begin code
+    say so "I used Photoshop®"   ~~ m:i/   photo shop /;  # OUTPUT: «True␤»
+    say so "I used a photo shop" ~~ m:i:s/ photo shop /;  # OUTPUT: «True␤»
+    say so "I used Photoshop®"   ~~ m:i:s/ photo shop /;  # OUTPUT: «False␤»
     =end code
 
 C<m:s/ photo shop /> acts the same as
@@ -2392,7 +2392,7 @@ C<m/ photo C«<.ws>» shop <.ws> />. By default, C«<.ws>» makes sure that
 words are separated, so C<a    b> and C<^&> will match C«<.ws>» in the
 middle, but C<ab> won't:
 
-    =begin code :allow<B>
+    =begin code
     say so "ab" ~~ m:s/a <.ws> b/;     # OUTPUT: «False␤»
     say so "a b" ~~ m:s/a <.ws> b/;    # OUTPUT: «True␤»
     say so "^&" ~~ m:s/'^' <.ws> '&'/; # OUTPUT: «True␤»
@@ -2415,7 +2415,7 @@ Z<ignore-code-ws>"C<foo+ >" becomes C«foo+ <.ws>».
 
 In all, this code:
 
-    =begin code :allow<B>
+    =begin code
     rx :s {
         ^^
         {
@@ -2435,21 +2435,21 @@ In all, this code:
 
 Becomes:
 
-    =begin code :allow<B>
+    =begin code
     rx {
-        ^^ B«<.ws>»
+        ^^ <.ws>
         {
             say "No space after this";
         }
-        <.assertion_and_then_ws> B«<.ws>»
-        characters_with_ws_after+ B«<.ws>»
-        [ws_separated_characters B«<.ws>»]* B«<.ws>»
+        <.assertion_and_then_ws> <.ws>
+        characters_with_ws_after+ <.ws>
+        [ws_separated_characters <.ws>]* <.ws>
         [
-        | some B«<.ws>» "stuff" B«<.ws>» .. B«<.ws>» . B«<.ws>»
-        | $$ B«<.ws>»
-        ] B«<.ws>»
+        | some <.ws> "stuff" <.ws> .. <.ws> . <.ws>
+        | $$ <.ws>
+        ] <.ws>
         :my $foo = "no ws after this";
-        $foo B«<.ws>»
+        $foo <.ws>
     }
     =end code
 

--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -850,7 +850,7 @@ arguments to parameters. If a fat arrow is used to construct a
 L<Pair|/type/Pair> only those with valid identifiers as keys are recognized as
 named arguments.
 
-=for code :allow<L>
+=for code
 sub named(:$x, :$y) { "x=$x y=$y" }
 named( y => 5, x => 4);             # OUTPUT: «x=4 y=5»
 

--- a/doc/Language/unicode_entry.rakudoc
+++ b/doc/Language/unicode_entry.rakudoc
@@ -610,11 +610,12 @@ Greek characters may be used as variable names.  For a list of Greek and
 Coptic characters and their unicode code points see the L<Greek in Unicode Wikipedia article|https://en.wikipedia.org/wiki/Greek_alphabet#Greek_in_Unicode>.
 
 For example, to assign the value 3 to π, enter the following in Vim
-(whitespace added to the compose sequences for clarity):
+(whitespace added to the compose sequences, listed in between « and », for
+clarity):
 
-    =begin code :allow<B> :lang<vim>
-    my $B<Ctrl-V u 03C0> = 3;  # same as: my $π = 3;
-    say $B<Ctrl-V u 03C0>;     # 3    same as: say $π;
+    =begin code :lang<vim>
+    my $«Ctrl-V u 03C0» = 3;  # same as: my $π = 3;
+    say $«Ctrl-V u 03C0»;     # same as: say $π;
     =end code
 
 =head2 Superscripts and subscripts
@@ -631,17 +632,17 @@ Thus, to write the L<Taylor series|https://en.wikipedia.org/wiki/Taylor_series>
 expansion around zero of the function C<exp(x)> one would input into e.g.
 vim the following:
 
-    =begin code :allow<B> :lang<vim>
-    exp(x) = 1 + x + xB<Ctrl-V u 00B2>/2! + xB<Ctrl-V u 00B3>/3!
-    + ... + xB<Ctrl-V u 207F>/n!
+    =begin code :lang<vim>
+    exp(x) = 1 + x + x«Ctrl-V u 00B2»/2! + x«Ctrl-V u 00B3»/3!
+    + ... + x«Ctrl-V u 207F»/n!
     # which would appear as
     exp(x) = 1 + x + x²/2! + x³/3! + ... + xⁿ/n!
     =end code
 
 Or to specify the elements in a list from C<1> up to C<k>:
 
-    =begin code :allow<B> :lang<vim>
-    AB<Ctrl-V u 2081>, AB<Ctrl-V u 2082>, ..., AB<Ctrl-V u 2096>
+    =begin code :lang<vim>
+    A«Ctrl-V u 2081», A«Ctrl-V u 2082», ..., A«Ctrl-V u 2096»
     # which would appear as
     A₁, A₂, ..., Aₖ
     =end code

--- a/doc/Type/IO/Handle.rakudoc
+++ b/doc/Type/IO/Handle.rakudoc
@@ -60,7 +60,7 @@ cause C<X::IO::BinaryAndEncoding> exception to be thrown.
 The open mode defaults to non-exclusive, read only (same as specifying
 C<:r>) and can be controlled by a mix of the following arguments:
 
-=begin code :lang<text> :allow< B R >
+=begin code :lang<text>
 :r      same as specifying   :mode<ro>  same as specifying nothing
 
 :w      same as specifying   :mode<wo>, :create, :truncate
@@ -84,7 +84,7 @@ to a handle opened in such unsupported modes as well.
 
 The mode details are:
 
-=begin code :lang<text> :allow< B R >
+=begin code :lang<text>
 :mode<ro>  means "read only"
 :mode<wo>  means "write only"
 :mode<rw>  means "read and write"

--- a/doc/Type/Routine.rakudoc
+++ b/doc/Type/Routine.rakudoc
@@ -261,9 +261,9 @@ from an C<is rw> routine, you have to use X<C<return-rw>|Reference,return-rw> in
 
 Marks a routine as exported to the rest of the world
 
-=begin code :allow<B>
+=begin code
 module Foo {
-    sub double($x) B<is export> {
+    sub double($x) is export {
         2 * $x
     }
 }

--- a/doc/Type/Variable.rakudoc
+++ b/doc/Type/Variable.rakudoc
@@ -56,32 +56,32 @@ my %hash is default( 'no-value-here' );
 Marks a variable as dynamic, that is, accessible from inner dynamic scopes
 without being in an inner lexical scope.
 
-=begin code :allow<B L>
+=begin code
 sub introspect() {
-    say B<$CALLER::x>;
+    say $CALLER::x;
 }
-my $x B<is dynamic> = 23;
+my $x is dynamic = 23;
 introspect;         # OUTPUT: «23␤»
 {
     # not dynamic
     my $x;
-    introspect()    # dies with an exception of L<type X::Caller::NotDynamic|/type/X::Caller::NotDynamic>
+    introspect()    # dies with an exception of X::Caller::NotDynamic
 }
 =end code
 
 The C<is dynamic> trait is a rather cumbersome way of creating and accessing
 dynamic variables.  A much easier way is to use the C<* twigil>:
 
-=begin code :allow<B L>
+=begin code
 sub introspect() {
-    say B<$*x>;
+    say $*x;
 }
 my $*x = 23;
 introspect;         # OUTPUT: «23␤»
 {
     # not dynamic
     my $x;
-    introspect()    # dies with an exception of L<type X::Dynamic::NotFound|/type/X::Dynamic::NotFound>
+    introspect()    # dies with an exception of X::Dynamic::NotFound
 }
 =end code
 


### PR DESCRIPTION
These don't currently render correctly on the [doc website](https://docs.raku.org), and in some cases make example source more difficult to read and maintain.  Output presentation has also been tidied.

Rendering of examples has been discussed in a few places recently,

- https://github.com/Raku/doc/discussions/4216
- https://github.com/Raku/doc-website/issues/124
- https://github.com/Raku/doc/issues/4250

While these changes doesn't resolve the overarching issue, they do improve the readability (and usability) of public facing documentation in the interim.

(If in future formatting codes are permitted in examples by the renderer, we could consider reverting this commit.) 