### PR TITLE
Update old `#index-entry-...` links

### DIFF
--- a/doc/Language/101-basics.rakudoc
+++ b/doc/Language/101-basics.rakudoc
@@ -415,7 +415,7 @@ Let's see an example of this now.
 
 In this example, you will see some special syntax that makes it easier
 to make a list of strings. This is the
-C«<...>» L<quote-words|/language/operators#index-entry-qw-quote-words-quote-words>
+C«<...>» L«quote-words|/language/operators#term_<_>»
 construct. When you put words in between the C«<» and C«>» they are all assumed
 to be strings, so you do not need to wrap them each in double quotes
 C«"..."».

--- a/doc/Language/5to6-nutshell.rakudoc
+++ b/doc/Language/5to6-nutshell.rakudoc
@@ -287,10 +287,10 @@ first $coderef, @values, :k;
 =begin item
 C<&foo;> I<and> C<goto &foo;> I<for re-using the caller's argument
 list / replacing the caller in the call stack>. Raku can use either
-L<C<callsame>|/language/functions#index-entry-dispatch_callsame> for
+L<C<callsame>|/language/functions#sub_callsame> for
 re-dispatching or
-L<C<nextsame>|/language/functions#index-entry-dispatch_nextsame> and
-L<C<nextwith>|/language/functions#index-entry-dispatch_nextwith>, which have no
+L<C<nextsame>|/language/functions#sub_nextsame> and
+L<C<nextwith>|/language/functions#sub_nextwith>, which have no
 exact equivalent in Perl.
 
 =for code :lang<perl>
@@ -310,7 +310,7 @@ multi foo ( Any $n ) {
 multi foo ( Int $n ) {
     say "Int"; callsame;
 };
-foo(3); # /language/functions#index-entry-dispatch_callsame
+foo(3); # /language/functions#sub_callsame
 =end code
 
 =end item
@@ -573,7 +573,7 @@ type of its arguments.
 While the operator has not changed, the rules for what exactly is matched
 depend on the types of both arguments, and those rules are far from
 identical in Perl and Raku. See L<~~|/routine/~~> and
-L<the smartmatch operator|/language/operators#index-entry-smartmatch_operator>
+L<the smartmatch operator|/language/operators#infix_~~>
 
 =head2 C<& | ^> String bitwise ops
 =head2 C<& | ^> Numeric bitwise ops
@@ -1585,7 +1585,7 @@ Rakudo supports this only for modules so far.
 
 =head2 AUTOLOAD
 
-The L«C<FALLBACK> method|/language/typesystem#index-entry-FALLBACK_(method)»
+The L«C<FALLBACK> method|/language/typesystem#Fallback_method»
 provides similar functionality.
 
 =head2 Importing specific functions from a module

--- a/doc/Language/5to6-perlfunc.rakudoc
+++ b/doc/Language/5to6-perlfunc.rakudoc
@@ -174,7 +174,7 @@ still be useful.
 
 It does not exist in Raku. For breaking out of C<given> blocks, you should
 probably take a look at
-L<C<proceed> and C<succeed>|/language/control#index-entry-control_flow__proceed-proceed>.
+L<C<proceed> and C<succeed>|/language/control#proceed_and_succeed>.
 
 =head2 X<caller|Other languages,caller - perlfunc>
 

--- a/doc/Language/5to6-perlop.rakudoc
+++ b/doc/Language/5to6-perlop.rakudoc
@@ -97,7 +97,7 @@ C<=~> and C<!~> have been replaced by C<~~> and C<!~~>, respectively.
 Those of you who consider smartmatching broken in Perl will be happy
 to hear that it works much better in Raku, as the stronger typing
 means less guesswork. See
-L<the smartmatch documentation|/language/operators#index-entry-smartmatch_operator> for a
+L<the smartmatch documentation|/language/operators#infix_~~> for a
 more extensive explanation of how smartmatch works in Raku.
 
 =head2 Multiplicative operators
@@ -146,11 +146,11 @@ of its arguments.
 
 C<~~> is the smartmatch operator as in Perl, but it's also I<just>
 the match operator in Raku, as noted above. For how smartmatching
-works in Raku, see L<the smartmatch documentation|/language/operators#index-entry-smartmatch_operator>.
+works in Raku, see L<the smartmatch documentation|/language/operators#infix_~~>.
 
 =head2 Smartmatch operator
 
-See L<the smartmatch documentation|/language/operators#index-entry-smartmatch_operator>
+See L<the smartmatch documentation|/language/operators#infix_~~>
 for a more extensive explanation of how smartmatch works in Raku.
 
 =head2 Bitwise And
@@ -291,7 +291,7 @@ get this behavior with single quotes.
 C<qq> allows interpolation of variables. However, by default, only
 scalar variables are interpolated. To get other variables to
 interpolate, you need to put square brackets after them (the so-called
-L<zen-slice|/language/subscripts#index-entry-Zen_slices>) to get them to
+L<zen-slice|/language/subscripts#Zen_slices>) to get them to
 interpolate. E.g. C«@a = <1 2 3>; say qq/@a[] example@example.com/;»
 results in "1 2 3 example@example.com". Hashes interpolate in the same
 manner: C«%a = 1 => 2, 3 => 4;say "%a{}";» results in a space

--- a/doc/Language/5to6-perlvar.rakudoc
+++ b/doc/Language/5to6-perlvar.rakudoc
@@ -407,7 +407,7 @@ for "foo".IO.lines.kv -> $n, $line {
 =end code
 
 For L<IO::CatHandle|/type/IO::CatHandle> types
-(of which L«C<$*ARGFILES>|/language/variables#index-entry-%24%2AARGFILES» is
+(of which L«C<$*ARGFILES>|/language/variables#$*ARGFILES» is
 one), you can use L«C<on-switch>|/type/IO::CatHandle#method_on-switch» hook
 to reset line number on handle switch, and increment it manually.
 See also L«C<IO::CatHandle::AutoLines>|https://raku.land/zef:raku-community-modules/IO::CatHandle::AutoLines»
@@ -443,7 +443,7 @@ There are no built-in formats in Raku.
 Because of how error variables have changed in Raku, they will not be detailed
 here individually.
 
-To quote the Raku L<docs|/language/variables#index-entry-%24!>, "$! is the error variable." That's it.
+To quote the Raku L<docs|/language/variables#The_$!_variable>, "$! is the error variable." That's it.
 All the error variables appear to have been eaten by $!. As with the rest of
 Raku, it's an object that will return various things depending on the type of error
 or L<exception|/type/Exception>.

--- a/doc/Language/community.rakudoc
+++ b/doc/Language/community.rakudoc
@@ -20,7 +20,7 @@ No, they pour new wine into new wineskins, and both are preserved.'" - Larry Wal
 
 =head2 Online communities
 
-L<IRC|/language/glossary#index-entry-IRC> communication has played an integral role in the Raku community for more than a decade. There are various channels for Raku-related activities on C<libera.chat>. There are several L<bots|/language/glossary#Bot> to make IRC activity more convenient and fun. You can read about IRC content L<here|https://raku.org/community/irc/> in greater details.
+L<IRC|/language/glossary#IRC> communication has played an integral role in the Raku community for more than a decade. There are various channels for Raku-related activities on C<libera.chat>. There are several L<bots|/language/glossary#Bot> to make IRC activity more convenient and fun. You can read about IRC content L<here|https://raku.org/community/irc/> in greater details.
 
 L<The Raku Discord server|https://discord.gg/VzYpdQ6> serves a similar purpose. Thanks to the bridges written by fellow Raku members, it integrates well with the main IRC channels.
 

--- a/doc/Language/control.rakudoc
+++ b/doc/Language/control.rakudoc
@@ -134,7 +134,7 @@ the expression it is contained in is evaluated:
     my $f = "."; say do { $f ~= "." } X~ 1, 2, 3;
 
 In other words, it follows the same
-L<reification|/language/glossary#index-entry-Reify> rules as everything else.
+L<reification|/language/glossary#Reify> rules as everything else.
 
 Technically, C<do> is a loop which runs exactly one iteration.
 
@@ -626,7 +626,7 @@ assign them to an array:
     my @b = (for 1, 2, 3 { $_ * 2 }); @b.say;  # OUTPUT: «[2 4 6]␤»
 
 This implies that, if the results of the loop are not assigned, they will be
-in a L<sink context|/language/contexts#index-entry-sink_context>:
+in a L<sink context|/language/contexts#Sink>:
 
 =for code
 class Sunk {
@@ -764,14 +764,14 @@ control exception thrown by C<take>, causing it to error out.
 =head1 X<supply/emit|Control flow,supply emit>
 
 The keyword C<supply> creates a L<Supply object|/type/Supply> which is an
-L<on-demand supply|/language/concurrency#index-entry-supply_(on-demand)>
+L<on-demand supply|/language/concurrency#index-entry-Reference_supply_(on-demand)>
 that you can tap. It pairs with C<emit>, which can be used anywhere from within
 C<supply> prefixed code.
 
 Using the L<C<emit method>|/type/Mu#method_emit> or the
 L<C<emit routine>|/language/independent-routines#sub_emit> passes the invocant
 to the enclosing
-L<supply|/language/concurrency#index-entry-supply_(on-demand)>:
+L<supply|/language/concurrency#Supplies>:
 
     my $supply = supply {
         .emit for "foo", 42, .5;
@@ -1259,7 +1259,7 @@ print @x.map: -> $x {
 
 prints "1 2 42 4 5".
 
-In a L<whenever|/language/concurrency#index-entry-whenever>
+In a L<whenever|/language/concurrency#whenever>
 block, C<next> immediately exits the block for the current value:
 
     react {

--- a/doc/Language/create-cli.rakudoc
+++ b/doc/Language/create-cli.rakudoc
@@ -11,14 +11,14 @@ The default command line interface of Raku scripts consists of three parts:
 
 =head2 Parsing the command line parameters into a L<capture|/type/Capture>
 
-This looks at the values in L<@*ARGS|/language/variables#index-entry-@*ARGS>,
+This looks at the values in L<@*ARGS|/language/variables#@*ARGS>,
 interprets these according to some policy, and creates a L<Capture|/type/Capture>
 object out of that. An alternative way of parsing may be provided by the developer
 or installed using a module.
 
 =head2 Calling a provided C<MAIN> subroutine using that capture
 
-Standard L<multi dispatch|/language/functions#index-entry-declarator_multi-Multi-dispatch>
+Standard L<multi dispatch|/language/functions#Multi-dispatch>
 is used to call the C<MAIN> subroutine with the generated C<Capture> object.
 This means that your C<MAIN> subroutine may be a C<multi sub>, each candidate
 of which is responsible for some part of processing the given command line
@@ -38,7 +38,7 @@ X<|Programs,MAIN>
 
 The sub with the special name C<MAIN> will be executed after all relevant entry
 phasers (C<BEGIN>, C<CHECK>, C<INIT>, C<PRE>, C<ENTER>) have been run and
-the L<mainline|/language/glossary#index-entry-Mainline> of the script has been
+the L<mainline|/language/glossary#Mainline> of the script has been
 executed. No error will occur if there is no C<MAIN> sub: your script will
 then just have to do the work, such as argument parsing, in the mainline of
 the script.
@@ -55,7 +55,7 @@ called.
 
 The signature of (the candidates of the multi) sub C<MAIN> determines which
 candidate will actually be called using the standard
-L<multi dispatch|/language/glossary#index-entry-Multi-Dispatch> semantics.
+L<multi dispatch|/language/glossary#Multi-dispatch> semantics.
 
 A simple example:
 

--- a/doc/Language/faq.rakudoc
+++ b/doc/Language/faq.rakudoc
@@ -461,7 +461,7 @@ say $bar; # OUTPUT: «70␤»
 =end code
 
 To test whether a variable has any defined values, see
-L<DEFINITE|/language/classtut#index-entry-.DEFINITE> and L<defined|/routine/defined>
+L<DEFINITE|/language/classtut#A_word_on_types> and L<defined|/routine/defined>
 routines. Several other constructs exist that test for definiteness, such as
 L«C<with>, C<orwith>, and C<without>|/syntax/with orwith without»
 statements, L«C<//>|/routine/$SOLIDUS$SOLIDUS», L<andthen|/routine/andthen>,

--- a/doc/Language/glossary.rakudoc
+++ b/doc/Language/glossary.rakudoc
@@ -314,7 +314,7 @@ X<|Reference,forward declaration>
 
 Declare the scope and/or type of a functional entity (class or routine)
 without actually declaring its code by using
-the L<"stub" operator|/language/operators#index-entry-..._operators>; code
+the L<"stub" operator|/language/operators#listop_...>; code
 will be declared later on in the same file.
 
 =for code
@@ -820,7 +820,7 @@ is its usual acronym.
 =head1 X<property|Reference,property>
 
 In this context, it either refers to an
-L<object property|/language/objects#index-entry-Property>,
+L<object property|/language/objects#Attributes>,
 which is the value of an instance variable, or an
 L<Unicode property|/language/regexes#Unicode_properties>
 which are codepoint features that
@@ -892,7 +892,7 @@ actual implementation is deferred to the class that uses that Role.
 
 Roles are part of Raku's L<object system|/language/objects>, and are
 declared using the
-L<role|/language/objects#index-entry-declarator_role-Roles> keyword and
+L<role|/language/objects#Roles> keyword and
 used in class declaration via L<does|/routine/does>.
 
 =head1 X<rvalue|Reference,rvalue>
@@ -929,7 +929,7 @@ such a variable.
 
 =head1 X<Sigilless variable|Reference,Sigilless Variable>
 
-L<Sigilless variables|/language/variables#index-entry-\_(sigilless_variables)>
+L<Sigilless variables|/language/variables#Sigilless_variables>
 are actually aliases to the value it is assigned to them, since they are not
 containers. Once you assign a sigilless variable (using the escape
 C<\>), its value cannot be changed.
@@ -1011,7 +1011,7 @@ scope.
 =head1 X<Tight and loose precedence|Reference,Tight;Reference,Loose>
 
 In this context, tight or tighter refers to
-L<precedence rules|/language/functions#index-entry-is_tighter>
+L<precedence rules|/language/functions#Precedence>
 and is the opposite of C<looser>. Precedence rules for new terms are
 always expressed in relationship with other terms, so C<is tighter>
 implies that operands with that operator will be grouped before operands
@@ -1051,7 +1051,7 @@ one simple string.>
 =head1 X<Type objects|Reference,Type Objects>
 
 A
-L<type object|/language/classtut#index-entry-type_object>
+L<type object|/language/classtut#A_word_on_types>
 is an object that is used to represent a type or a class. Since in
 object oriented programming everything is an object, classes are
 objects too, and they inherit from L<Mu|/type/Mu>.

--- a/doc/Language/hashmap.rakudoc
+++ b/doc/Language/hashmap.rakudoc
@@ -285,7 +285,7 @@ non-string keys, use a colon prefix:
 
 Note that with objects as keys, you often cannot use the C«<...>» construct
 for key lookup, as it creates only strings and
-L<allomorphs|/language/glossary#index-entry-Allomorph>. Use the C«{...}»
+L<allomorphs|/language/glossary#Allomorph>. Use the C«{...}»
 instead:
 
     :{  0  => 42 }<0>.say;   # Int    as key, IntStr in lookup; OUTPUT: «(Any)␤»

--- a/doc/Language/io-guide.rakudoc
+++ b/doc/Language/io-guide.rakudoc
@@ -191,7 +191,7 @@ loading it entirely:
 
 Note that we did this by passing a limit argument to
 L«C<.words>|/type/IO::Path#method_words» instead of, say, using
-L<a list indexing operation|/language/operators#index-entry-array_indexing_operator-array_subscript_operator-array_indexing_operator>.
+L<a list indexing operation|/language/operators#postcircumfix_[_]>.
 The reason for that is there's still a filehandle in use under the hood, and
 until you fully consume the returned L<Seq|/type/Seq>, the handle will remain open.
 If nothing references the L<Seq|/type/Seq>, eventually the handle will get closed, during
@@ -200,7 +200,7 @@ it's best to ensure all the handles get closed right away. So, you should
 always ensure the L<Seq|/type/Seq> from L<IO::Path|/type/IO::Path>'s
 L«C<.words>|/type/IO::Path#method_words» and
 L«C<.lines>|/type/IO::Path#method_lines» methods is
-L<fully reified|/language/glossary#index-entry-Reify>; and the limit argument
+L<fully reified|/language/glossary#Reify>; and the limit argument
 is there to help you with that.
 
 =head4 Using IO::Handle
@@ -235,7 +235,7 @@ Unlike some languages, the handle won't get automatically closed when the
 scope it's defined in is left. Instead, it'll remain open until it's garbage
 collected. To make the closing business easier, some of the methods let you
 specify a C<:close> argument, you can also use the
-L«C<will leave> trait|/language/phasers#index-entry-Phasers__will_trait», or the
+L«C<will leave> trait|/language/phasers#index-entry-Phasers_will_trait», or the
 C<does auto-close> trait provided by the
 L«C<Trait::IO>|https://raku.land/zef:raku-community-modules/Trait::IO» module.
 

--- a/doc/Language/iterating.rakudoc
+++ b/doc/Language/iterating.rakudoc
@@ -106,13 +106,13 @@ build a class that fulfills the iterator and iterable roles.
 =head1 How to iterate: contextualizing and topic variables
 
 C<for> and other loops place the item produced in every iteration into the
-L<topic variable C<$_>|/language/variables#index-entry-topic_variable>, or
+L<topic variable C<$_>|/language/variables#The_$__variable>, or
 capture them into the variables that are declared along with the block. These
 variables can be directly used inside the loop, without needing to declare them,
 by using the
 L<C<^> twigil|/syntax/$CIRCUMFLEX_ACCENT#(Traps_to_avoid)_twigil_^>.
 
-Implicit iteration occurs when using the L<sequence operator|/language/operators#index-entry-..._operators>.
+Implicit iteration occurs when using the L<sequence operator|/language/operators#infix_...>.
 
     say 1,1,1, { $^a²+2*$^b+$^c } … * > 300; # OUTPUT: «(1 1 1 4 7 16 46 127 475)
 

--- a/doc/Language/list.rakudoc
+++ b/doc/Language/list.rakudoc
@@ -406,7 +406,7 @@ memory:
     });
     say @divisors; # OUTPUT: «[2 5 7]␤»
 
-The L<C<gather> statement|/language/control#index-entry-lazy_list_gather>
+The L<C<gather> statement|/language/control#gather/take>
 creates a lazy list, which is eagerly evaluated when assigned to C<@divisors>.
 
 =head2 Flattening "context"
@@ -689,7 +689,7 @@ As the third statement shows, you can assign directly to an element in a shaped
 array too. B<Note>: the second statement works only from version 2018.09.
 
 Since version 6.d,
-L<C<enum>s|/language/typesystem#index-entry-Enumeration-_Enums-_enum> can be
+L<C<enum>s|/language/typesystem#enum> can be
 used also as shape parameters:
 
 =for code

--- a/doc/Language/math.rakudoc
+++ b/doc/Language/math.rakudoc
@@ -50,7 +50,7 @@ say "Identity with ∅ ", so @id-empty.all;       # OUTPUT: «Identity with ∅ 
 
 In this code, which uses the L<empty set|/language/setbagmix#term_%E2%88%85>
 which is already defined by Raku, not only do we check if the equalities in the
-algebra of sets hold, we also use, via L<sigilless variables|/language/variables#index-entry-\_(sigilless_variables)> and the
+algebra of sets hold, we also use, via L<sigilless variables|/language/variables#Sigilless_variables> and the
 Unicode form of the set operators, expressions that are as close as possible to
 the original form; C<A ∪ U === U>, for example, except for the use of the
 L<value identity operator C<===>|/routine/===> is very close to the actual

--- a/doc/Language/modules-core.rakudoc
+++ b/doc/Language/modules-core.rakudoc
@@ -30,7 +30,7 @@ to be used (at least until version 6.c) by the final user.
 =item L«C<Pod::To::Text>|https://github.com/rakudo/rakudo/blob/master/lib/Pod/To/Text.rakumod»    Used by several external modules
 =item L«C<Test>|/type/Test»    Test routines (see L<tutorial|/language/testing>)
 =item L«C<experimental>|https://github.com/rakudo/rakudo/blob/master/lib/experimental.rakumod»
-(L<documentation|/language/pragmas#index-entry-experimental__pragma>)
+(L<documentation|/language/pragmas#experimental>)
 =item L«C<newline>|https://github.com/rakudo/rakudo/blob/master/lib/newline.rakumod»
 
 =end pod

--- a/doc/Language/modules.rakudoc
+++ b/doc/Language/modules.rakudoc
@@ -133,7 +133,7 @@ indirect lookup.
 
 The symbols provided by the loaded module will not be imported into the
 current scope. You may use
-L<dynamic lookup|/language/packages#index-entry-::()> or
+L<dynamic lookup|/language/packages#Interpolating_into_names> or
 L<dynamic subsets|/language/typesystem#subset> to use them by providing
 the fully qualified name of a symbol, for instance:
 
@@ -513,7 +513,7 @@ zef --force install .
 X<|Syntax,use lib>
 A user may have a collection of modules not found in the normal ecosystem,
 maintained by a module or package manager, but needed regularly.  Instead of
-using the C<use lib> L<pragma|/language/pragmas#index-entry-lib__pragma> one
+using the C<use lib> L<pragma|/language/pragmas#lib> one
 can use the C<RAKULIB> environment variable to point to module locations.
 For example:
 
@@ -535,7 +535,7 @@ L<here|/language/traps#Filesystem_repositories> for more information.
 It is important in this section to repeat the note at the beginning of this
 document, namely that there is a difference between a B<Raku> C<distribution>,
 which approximates a I<module> in other languages, and a B<Raku>
-L<module declaration|/language/syntax#index-entry-declarator_unit-declarator_module-declarator_package-Package,_Module,_Class,_Role,_and_Grammar_declaration>.
+L<module declaration|/language/syntax#Package,_Module,_Class,_Role,_and_Grammar_declaration>.
 The reason for this is that a single file may contain a number of C<class>,
 C<module>, C<role> etc declarations, or these declarations may be spread between
 different files. In addition, when a C<distribution> is published (see
@@ -766,7 +766,7 @@ language name change.>
 L<markdown-formatted|https://help.github.com/articles/markdown-basics/>
 text file, which will later be automatically rendered as HTML by GitHub/GitLab for modules kept
 in those ecosystems or by L<raku.land|https://raku.land> website for modules
-kept on L<CPAN|/language/faq#index-entry-CPAN_(FAQ)>.
+kept on L<CPAN|/language/faq#Is_there_a_repository_of_third_party_library_modules_for_Raku?>.
 
 =item Regarding the C<LICENSE> file, if you have no other preference,
 you might just use the same one that Rakudo Raku uses. Just
@@ -987,7 +987,7 @@ zef install ./your-module-folder
 
 Note that doing so precompiles and installs your module. If you make changes to
 the source, you'll need to re-install the module.
-(See C<use lib> L<pragma|/language/pragmas#index-entry-lib__pragma>, C<-I>
+(See C<use lib> L<pragma|/language/pragmas#lib>, C<-I>
 command line switch, or C<RAKULIB> env variable, to include a path to your
 module source while developing it, so you don't have to install it at all).
 

--- a/doc/Language/nativetypes.rakudoc
+++ b/doc/Language/nativetypes.rakudoc
@@ -62,9 +62,9 @@ native candidate, but you cannot differentiate different sizes or
 signedness of the same native type.  That is, you can have an
 L<Int|/type/Int> and L<int|/type/int> candidates, but there would be an
 ambiguity between, for instance L<int|/type/int>,
-L<uint|/language/nativetypes#index-entry-uint>,
+L<uint|/language/nativetypes#Types_with_native_representation_and_size>,
 L<atomicint|/type/atomicint> or
-L<int64|/language/nativetypes#index-entry-int64> candidates.
+L<int64|/language/nativetypes#Types_with_native_representation_and_size> candidates.
 
 They cannot be bound either; trying to do C<my num $numillo := 3.5> will
 raise the exception C<Cannot bind to natively typed variable
@@ -176,7 +176,7 @@ say $for-malloc.raku;
 =end code
 
 As the example shows, it's represented by a parameterized
-L<C<Pointer> role|/language/nativecall#index-entry-Pointer>,
+L<C<Pointer> role|/language/nativecall#Basic_use_of_pointers>,
 using as parameter whatever the original pointer is pointing to (in this
 case, C<void>). This role represents native pointers, and can be used
 wherever they need to be represented in a Raku program.

--- a/doc/Language/numerics.rakudoc
+++ b/doc/Language/numerics.rakudoc
@@ -343,7 +343,7 @@ say 0/0;
 
 =head1 Allomorphs
 
-L<Allomorphs|/language/glossary#index-entry-Allomorph> are subclasses of two
+L<Allomorphs|/language/glossary#Allomorph> are subclasses of two
 types that can behave as either of them. For example, the allomorph L<IntStr|/type/IntStr> is
 the subclass of L<Int|/type/Int> and L<Str|/type/Str> types and will be accepted by any type
 constraint that requires an L<Int|/type/Int> or L<Str|/type/Str> object.

--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -886,7 +886,7 @@ was found, it throws a L<X::Method::NotFound|/type/X::Method::NotFound> exceptio
 X«|Syntax,methodop .*»
 =head2 methodop C«.*»
 
-C<$foo.*meth> walks the L<MRO|/language/objects#MRO> and calls all the methods called C<meth> and
+C<$foo.*meth> walks the L<MRO|/language/objects#Inheritance> and calls all the methods called C<meth> and
 submethods called C<meth> if the type is the same as type of C<$foo>. Those
 methods might be multis, in which case the matching candidate would be called.
 

--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -648,7 +648,7 @@ literal or a C<Pair> literal, it's converted to the appropriate number.
 
 The X<grouping operator|Terms,grouping operator>.
 
-An empty group C<()> creates an L<empty list|/type/List#index-entry-()_empty_list>.
+An empty group C<()> creates an L<empty list|/type/List#index-entry-Syntax_()_(empty_list)>.
 Parentheses around non-empty expressions simply structure the expression, but do
 not have additional semantics.
 
@@ -689,7 +689,7 @@ in list context. Check this:
 
 This array is itemized, in the sense that every element constitutes an item, as
 shown by the C<$> preceding the last element of the array, the
-L<(list) item contextualizer|/type/Any#index-entry-%24_%28item_contextualizer%29>.
+L<(list) item contextualizer|/type/Any#sub_item>.
 
 =head1 Terms
 
@@ -862,7 +862,7 @@ Technically, not a real operator; it's syntax special-cased in the compiler.
 X«|Syntax,methodop .+»
 =head2 methodop C«.+»
 
-C<$foo.+meth> walks the L<MRO|/language/objects#index-entry-MRO> and calls all the methods called C<meth> and
+C<$foo.+meth> walks the L<MRO|/language/objects#Inheritance> and calls all the methods called C<meth> and
 submethods called C<meth> if the type is the same as type of C<$foo>. Those
 methods might be multis, in which case the matching candidate would be called.
 
@@ -886,7 +886,7 @@ was found, it throws a L<X::Method::NotFound|/type/X::Method::NotFound> exceptio
 X«|Syntax,methodop .*»
 =head2 methodop C«.*»
 
-C<$foo.*meth> walks the L<MRO|/language/objects#index-entry-MRO> and calls all the methods called C<meth> and
+C<$foo.*meth> walks the L<MRO|/language/objects#MRO> and calls all the methods called C<meth> and
 submethods called C<meth> if the type is the same as type of C<$foo>. Those
 methods might be multis, in which case the matching candidate would be called.
 
@@ -2020,7 +2020,7 @@ aspects of the particular character like capitalization.
 
 The main difference between C<coll> and C<unicmp> is that the behavior of the
 former can be changed by the
-L<C<$*COLLATION>|/language/variables#index-entry-%24*COLLATION> dynamic
+L<C<$*COLLATION>|/language/variables#%24*COLLATION> dynamic
 variable.
 
 B<NOTE:> These are not yet implemented in the JVM.
@@ -3179,7 +3179,7 @@ The generator can also take only one argument.
     say 5, { $_ * 2 } ... 40;                # OUTPUT: «5 10 20 40␤»
 
 Or it can use the L<anonymous state variable
-C<$>|/language/variables#index-entry-$_(variable)> to skip one position in
+C<$>|/language/variables#The_$_variable> to skip one position in
 the sequence when computing the next one:
 
     say (1, 1, 1, -> $a, $b, $ { $a + $b } … ∞)[3..10];

--- a/doc/Language/performance.rakudoc
+++ b/doc/Language/performance.rakudoc
@@ -41,7 +41,7 @@ This file will open to the "Overview" section, which gives some overall data
 about how the program ran, e.g., total runtime, time spent doing garbage
 collection. One important piece of information you'll get here is percentage of
 the total call frames (i.e., blocks) that were interpreted (slowest, in red),
-L<speshed|/language/glossary#index-entry-Spesh> (faster, in orange), and jitted
+L<speshed|/language/glossary#Spesh> (faster, in orange), and jitted
 (fastest, in green).
 
 The next section, "Routines", is probably where you'll spend the most time. It

--- a/doc/Language/pragmas.rakudoc
+++ b/doc/Language/pragmas.rakudoc
@@ -131,7 +131,7 @@ only affects the lexical block it was used in:
         CATCH { default { say "Caught {.^name}" } }
     } # OUTPUT: «Caught X::Str::Numeric␤»
 
-Inside L«C<try> blocks|/language/exceptions#index-entry-try_blocks», the
+Inside L«C<try> blocks|/language/exceptions#try_blocks», the
 C<fatal> pragma is enabled by default, and you can I<disable> it with C<no
 fatal>:
 
@@ -241,7 +241,7 @@ entire compilation unit (usually a file) from being precompiled.
 
 =head2 X<soft|Pragmas,soft>
 
-L<Re-dispatching|/language/functions#Re-dispatching>, L<inlining|/language/functions#index-entry-use_soft_(pragma)>
+L<Re-dispatching|/language/functions#Re-dispatching>, L<inlining|/language/functions#index-entry-Language_use_soft_(pragma)>
 
 =head2 X<strict|Pragmas,strict>
 

--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -346,7 +346,7 @@ say < 42 > ~~ Int; # OUTPUT: «True␤»
 say < 42 > ~~ Str; # OUTPUT: «True␤»
 
 The angle brackets quoting is like C<qw>, but with extra feature that lets you
-construct L<allomorphs|/language/glossary#index-entry-Allomorph> or literals
+construct L<allomorphs|/language/glossary#Allomorph> or literals
 of certain numbers:
 
     say <42 4/2 1e6 1+1i abc>.raku;
@@ -435,8 +435,8 @@ just literal quote characters:
 =head2 X<<<Word quoting with interpolation and quote protection: « »|Syntax,<< >>;Syntax,« »>>>
 
 This style of quoting is like C<qqww>, but with the added benefit of
-constructing L<allomorphs|/language/glossary#index-entry-Allomorph> (making it
-functionally equivalent to L<qq:ww:v|#index-entry-:val_(quoting_adverb)>). The
+constructing L<allomorphs|/language/glossary#Allomorph> (making it
+functionally equivalent to L<qq:ww:v|#:val_(quoting_adverb)>). The
 ASCII equivalent to C<« »> are double angle brackets C«<< >>».
 
     # Allomorph Construction

--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -436,7 +436,7 @@ just literal quote characters:
 
 This style of quoting is like C<qqww>, but with the added benefit of
 constructing L<allomorphs|/language/glossary#Allomorph> (making it
-functionally equivalent to L<qq:ww:v|#:val_(quoting_adverb)>). The
+functionally equivalent to L<qq:ww:v|#index-entry-Adverbs_:v_(quoting_adverb)>). The
 ASCII equivalent to C<« »> are double angle brackets C«<< >>».
 
     # Allomorph Construction

--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -198,7 +198,7 @@ against a named regex C<R> include the following:
 =begin item
 I«Smartmatch: "string" ~~ /pattern/, or "string" ~~ /<R>/»
 
-L<Smartmatching|/language/operators#index-entry-smartmatch_operator> a string
+L<Smartmatching|/language/operators#infix_~~> a string
 against a C<Regex> performs a regex match of the string against the C<Regex>:
 
     say "Go ahead, make my day." ~~ / \w+ /;   # OUTPUT: «｢Go｣␤»
@@ -218,7 +218,7 @@ object, while the smartmatch against the named C<Regex> as such does not.
 I«Explicit topic match: m/pattern/, or m/<R>/»
 
 The match operator C<m/ /> immediately matches the topic variable
-L<C<$_>|/language/variables#index-entry-topic_variable> against the regex
+L<C<$_>|/language/variables#The_$__variable> against the regex
 following the C<m>.
 
 As with the C<rx/ /> syntax for regex definitions, the match operator may be
@@ -243,7 +243,7 @@ I«Implicit topic match in sink and Boolean contexts»
 
 In case a C<Regex> object is used in sink context, or in a context in which it
 is coerced to L<C<Bool>|/type/Bool>, the topic variable
-L<C<$_>|/language/variables#index-entry-topic_variable> is automatically matched
+L<C<$_>|/language/variables#The_$__variable> is automatically matched
 against it:
 
   $_ = "dummy string";        # Set the topic explicitly

--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -174,7 +174,7 @@ sub abbrev($arg where Str|List|Hash) {...} # throws if $arg is not one of those 
 X<|Language,anonymous arguments>
 Anonymous arguments are fine too, if you don't actually need to refer to a
 parameter by name, for instance to distinguish between different signatures in a
-L<multi|/language/functions#index-entry-declarator_multi-Multi-dispatch> or to
+L<multi|/language/functions#Multi-dispatch> or to
 check the signature of a L<Callable|/type/Callable>.
 
 =for code :preamble<my $sig;>
@@ -931,7 +931,7 @@ say alias-named(color => "white", class => "C");
 
 You can create named arguments that do not create any variables by
 making the argument an alias for an
-L<anonymous argument|#index-entry-anonymous_arguments>. This can be
+L<anonymous argument|#index-entry-Language_anonymous_arguments>. This can be
 useful when using named arguments solely as a means of selecting a
 C<multi> candidate, which is often the case with traits, for instance:
 

--- a/doc/Language/structures.rakudoc
+++ b/doc/Language/structures.rakudoc
@@ -21,7 +21,7 @@ value to variables declared with the C<$> sigil.
     say $just-a-number.VAR.^name; # OUTPUT: «Scalar␤»
 
 Any complex data structure can be I<scalarized> by using the L<item
-contextualizer C<$>|/type/Any#index-entry-%24_(item_contextualizer)>:
+contextualizer C<$>|/type/Any#sub_item>:
 
     (1, 2, 3, $(4, 5))[3].VAR.^name.say; # OUTPUT: «Scalar␤»
 
@@ -341,7 +341,7 @@ say @fibonacci[14]; # OUTPUT: «987␤»
 =end code
 
 Above we were reifying a L<Seq|/type/Seq> we created with the L<sequence
-operator|/language/operators#index-entry-%E2%80%A6_operators>, but other data
+operator|/language/operators#infix_...>, but other data
 structures use the concept as well. For example, an un-reified
 L<Range|/type/Range> is just the two end points. In some languages, calculating
 the sum of a huge range is a lengthy and memory-consuming process, but Raku

--- a/doc/Language/subscripts.rakudoc
+++ b/doc/Language/subscripts.rakudoc
@@ -247,7 +247,7 @@ In particular the I<type> can be any of the following:
 
 The notable difference between C<*> and Zen slice (empty) is that the
 L<Whatever|/type/Whatever> star will cause full
-L<reification|/language/glossary#index-entry-Reify> or itemization, while Zen
+L<reification|/language/glossary#Reify> or itemization, while Zen
 slice won't. Both versions also
 L<de-cont|https://perl6advent.wordpress.com/2017/12/02/perl-6-sigils-variables-and-containers/#decont>.
 
@@ -337,11 +337,11 @@ object) or an empty list (which returns an empty slice):
     say %bag{*};   # OUTPUT: «(1 3)␤»
     say %bag{()};  # OUTPUT: «()␤»
 
-Zen slicing does not L<reify|/language/glossary#index-entry-Reify> or
+Zen slicing does not L<reify|/language/glossary#Reify> or
 L<cache|/routine/cache> (not even C<Seq>s) and merely returns the invocant. It
 is usually used to
 L<interpolate|/language/quoting#Interpolation:_qq> entire arrays / hashes into
-strings or to L<decont|/language/glossary#index-entry-decont>.
+strings or to L<decont|/language/glossary#decont>.
 
     my @words = "cruel", "world";
     say "Hello, @words[]!";  # OUTPUT: «Hello, cruel world!␤»

--- a/doc/Language/traps.rakudoc
+++ b/doc/Language/traps.rakudoc
@@ -263,9 +263,9 @@ say A.new(x => 42).x;       # OUTPUT: «Any␤»
 leaves C<$!x> uninitialized, because the custom C<BUILD> doesn't
 initialize it.
 
-B<Note:> Consider using L<TWEAK|/language/objects#index-entry-TWEAK>
+B<Note:> Consider using L<TWEAK|/language/objects#index-entry-Methods_TWEAK>
 instead. L<Rakudo|/language/glossary#Rakudo> supports
-L<TWEAK|/language/objects#index-entry-TWEAK> method since release
+L<TWEAK|/language/objects#TWEAK> method since release
 2016.11.
 
 One possible remedy is to explicitly initialize the attribute in
@@ -693,7 +693,7 @@ to any filehandles.
 =head2 Allomorphs generally follow numeric semantics
 
 L<Str|/type/Str> C<"0"> is C<True>, while L<Numeric|/type/Numeric> is C<False>. So what's the L<Bool|/type/Bool> value of
-L<allomorph|/language/glossary#index-entry-Allomorph> C«<0>»?
+L<allomorph|/language/glossary#Allomorph> C«<0>»?
 
 In general, allomorphs follow L<Numeric|/type/Numeric> semantics, so the ones that I<numerically> evaluate
 to zero are C<False>:
@@ -1278,7 +1278,7 @@ say doesn't-return-ret;
 # BAD: outputs «Nil» and a warning «Useless use of constant string "ret" in sink context (line 13)»
 =end code
 
-Code for C<returns-ret> and C<doesn't-return-ret> might look exactly the same, since in principle it does not matter where the L<C<CATCH>|/language/phasers#index-entry-Phasers__CATCH-CATCH> block goes. However, a block is an object and the last object in a C<sub> will be returned, so the C<doesn't-return-ret> will return C<Nil>, and, besides, since "ret" will be now in sink context, it will issue a warning. In case you want to place phasers last for conventional reasons, use the explicit form of C<return>.
+Code for C<returns-ret> and C<doesn't-return-ret> might look exactly the same, since in principle it does not matter where the L<C<CATCH>|/language/phasers#CATCH> block goes. However, a block is an object and the last object in a C<sub> will be returned, so the C<doesn't-return-ret> will return C<Nil>, and, besides, since "ret" will be now in sink context, it will issue a warning. In case you want to place phasers last for conventional reasons, use the explicit form of C<return>.
 
 =begin code
 sub explicitly-return-ret () {
@@ -1292,7 +1292,7 @@ sub explicitly-return-ret () {
 =head2 C<LEAVE> needs explicit return from a sub to run
 
 As the documentation for the
-L<C<LEAVE> phaser indicates|/language/phasers#index-entry-Phasers__LEAVE-LEAVE>
+L<C<LEAVE> phaser indicates|/language/phasers#LEAVE>
 C<LEAVE> runs when a block is exited, "... except when the program exits
 abruptly". That is, unlike C<END>, it's going to be invoked only if the block
 actually returns in an orderly way. This is why:
@@ -1465,7 +1465,7 @@ Died with the exception:
 
 Resolving this is easy because C<.print> returns a promise that you
 can await on. The solution is even more beautiful if you are
-working in a L<react|/language/concurrency#index-entry-react> block:
+working in a L<react|/language/concurrency#react> block:
 
 =begin code :skip-test<$proc needs a complex initialization>
 whenever $proc.print: “one\ntwo\nthree\nfour” {
@@ -1967,7 +1967,7 @@ kind of action in the map code block:
     <þor oðin loki>.map: *.codes.say; # OUTPUT: «3␤4␤4␤»
 
 The problem might arise when maps are nested and L<in a sink
-context|/language/contexts#index-entry-sink_context>.
+context|/language/contexts#Sink>.
 
     <foo bar ber>.map: { $^a.comb.map: { $^b.say}}; # OUTPUT: «»
 
@@ -1999,7 +1999,7 @@ as it will be saving the two nested sequences from void context:
 =head1 Smartmatching
 
 The
-L<smartmatch operator|/language/operators#index-entry-smartmatch_operator>
+L<smartmatch operator|/language/operators#infix_~~>
 shortcuts to the right hand side I<accepting> the left hand side. This
 may cause some confusion.
 

--- a/doc/Language/typesystem.rakudoc
+++ b/doc/Language/typesystem.rakudoc
@@ -37,10 +37,10 @@ type constraint may change in this case.
 =head2 Type objects
 
 To test if an object is a type object, use
-L<smartmatch|/language/operators#index-entry-smartmatch_operator>
+L<smartmatch|/language/operators#infix_~~>
 against a type constrained with a
 L<type smiley|/language/signatures#Constraining_argument_definiteness> or
-L«C<.DEFINITE>|/language/mop#index-entry-syntax_DEFINITE-DEFINITE» method:
+L«C<.DEFINITE>|/language/mop#DEFINITE» method:
 
 =begin code :ok-test<WHAT>
 my $a = Int;
@@ -130,7 +130,7 @@ automatically if no such scope exists already.
 
 X«|Syntax,... (forward declaration)»
 X«Forward declarations|Language,Forward declarations» can be provided with a block containing only C<...>,
-the L<"stub" operator|/language/operators#index-entry-..._operators>. The
+the L<"stub" operator|/language/operators#listop_...>. The
 compiler will check at the end of the current scope if the type is defined.
 
     class C {...}
@@ -503,7 +503,7 @@ L<re-dispatching|/language/functions#Re-dispatching>.
 Classes declared with C<is hidden> also generate slightly different method
 signatures.  To facilitate re-dispatch, typical methods are automatically
 provided with an extra C<*%_> parameter that L<captures extra named
-arguments|/type/Method#index-entry-extra_named_arguments>.  Because classes
+arguments|/type/Method#index-entry-Syntax_*%___(extra_named_arguments)>.  Because classes
 declared with C<is hidden> don't participate in re-dispatch, their methods don't
 receive this extra parameter.
 
@@ -909,7 +909,7 @@ For a full explanation see L<Grammars|/language/grammars>.
 =head2 C<subset>
 
 A X<C<subset>|Syntax,subset> declares a new type that will re-dispatch to its base
-type. If a L<C<where>|/language/signatures#index-entry-where_clause> clause is supplied any assignment
+type. If a L<C<where>|/language/signatures#Type_constraints> clause is supplied any assignment
 will be checked against the given code object.
 
     subset Positive of Int where * > -1;
@@ -962,7 +962,7 @@ and/or API number of a type can be applied via the adverbs C«:ver<>»,
 C«:auth<>», and C«:api<>» respectively. All of them take a string as argument;
 for C<:ver> the string is converted to a L«C«Version»|/type/Version» object, and
 for C<:api> the string is converted into an
-L<allomorph|/language/glossary#index-entry-Allomorph>
+L<allomorph|/language/glossary#Allomorph>
 L«C«IntStr»|/type/IntStr» object. C<:auth> generally takes the form
 C<hosting:ID>, as in C<github:github-user> or C<gitlab:gitlab-user>.
 

--- a/doc/Language/variables.rakudoc
+++ b/doc/Language/variables.rakudoc
@@ -147,7 +147,7 @@ The last two examples above are simple I<destructuring assignments> that select
 the first item of the right-hand side list. See for a more elaborate discussion
 of destructuring assignments in the context of variable declarations the section
 on L<declaring a list of variables with lexical or package
-scope|/language/variables#index-entry-declaring_a_list_of_variables>.
+scope|/language/variables#Declaring_a_list_of_variables_with_lexical_(my)_or_package_(our)_scope>.
 
 Chained assignments are parsed having regard to the precedence of the assignment
 operators and, where applicable, their right associativity. For instance, in the
@@ -565,7 +565,7 @@ sentence surround the variables with parentheses:
 
    my ( $foo, $bar );
 
-see also L<Declaring a list of variables with lexical or package scope|/language/variables#index-entry-declaring_a_list_of_variables>.
+see also L<Declaring a list of variables with lexical or package scope|/language/variables#Declaring_a_list_of_variables_with_lexical_(my)_or_package_(our)_scope>.
 
 Additionally, lexical scoping means that variables can be temporarily
 redefined in a new scope:
@@ -626,7 +626,7 @@ at the same time, surround the variables with parentheses:
 
    our ( $foo, $bar );
 
-see also L<the section on declaring a list of variables with lexical or package scope|/language/variables#index-entry-declaring_a_list_of_variables>.
+see also L<the section on declaring a list of variables with lexical or package scope|/language/variables#Declaring_a_list_of_variables_with_lexical_(my)_or_package_(our)_scope>.
 
 X<|Language,declaring a list of variables>
 =head2 Declaring a list of variables with lexical (C<my>) or package (C<our>) scope
@@ -1080,7 +1080,7 @@ re-applied by assigning C<Nil> to it:
 =head2 Default defined variables pragma
 
 To force all variables to have a
-L<definiteness|/language/mop#index-entry-syntax_DEFINITE-DEFINITE> constraint,
+L<definiteness|/language/mop#DEFINITE> constraint,
 use the pragma C<use variables :D>. The pragma is lexically scoped and can be
 switched off with C<use variables :_>.
 
@@ -1420,7 +1420,7 @@ sub do-work {
 do-work;
 =end code
 
-Note that, in a L<C«multi»|/language/functions#index-entry-declarator_multi-Multi-dispatch>,
+Note that, in a L<C«multi»|/language/functions#Multi-dispatch>,
 C<&?ROUTINE> refers to the current candidate, I<not> the C<multi>
 as a whole.
 
@@ -1543,7 +1543,7 @@ X<|Variables,%*ENV>
 =head4  C<%*ENV>
 
 Operating system environment variables. Numeric values are provided
-as L<allomorphs|/language/glossary#index-entry-Allomorph>.
+as L<allomorphs|/language/glossary#Allomorph>.
 
 X<|Variables,$*REPO>
 =head4 C<$*REPO>

--- a/doc/Type/Allomorph.rakudoc
+++ b/doc/Type/Allomorph.rakudoc
@@ -54,7 +54,7 @@ complete description on how to work with these allomorphs.
     multi method ACCEPTS(Allomorph:D: Any:D \a)
 
 If the C<a> parameter is L<Numeric|/type/Numeric> (including
-another L<allomorph|/language/glossary#index-entry-Allomorph>),
+another L<allomorph|/language/glossary#Allomorph>),
 checks if invocant's L<Numeric|/type/Numeric> value
 L<ACCEPTS|/type/Numeric#method_ACCEPTS> C<a>.
 If the C<a> parameter is L<Str|/type/Str>, checks if invocant's

--- a/doc/Type/Any.rakudoc
+++ b/doc/Type/Any.rakudoc
@@ -996,7 +996,7 @@ result, by applying a binary subroutine. It applies its argument (or first
 argument for the sub form) as an operator to all the elements in the object (or
 second argument for the sub form), producing a single result. The subroutine
 must be either an
-L<infix operator|/language/operators#index-entry-infix_operator>
+L<infix operator|/language/operators#index-entry-Language_infix_operator>
 or take two positional arguments. When using an infix operator, we must provide
 the code object of its subroutine version, i.e., the operator category, followed
 by a colon, then a list quote construct with the symbol(s) that make up the
@@ -1365,7 +1365,7 @@ say %hash.collate; # (aa => value Za => second);
 =end code
 
 This method is affected by the
-L<C<$*COLLATION>|/language/variables#index-entry-$*COLLATION> variable, which
+L<C<$*COLLATION>|/language/variables#$*COLLATION> variable, which
 configures the four X<collation levels|Language,collation levels>. While Primary, Secondary and
 Tertiary mean different things for different scripts, for the Latin script used
 in English they mostly correspond with Primary being Alphabetic, Secondary being

--- a/doc/Type/Block.rakudoc
+++ b/doc/Type/Block.rakudoc
@@ -12,7 +12,7 @@ creating an empty block is C<{;}>.
 
 Without an explicit signature or placeholder arguments, a block has C<$_>
 as a positional argument, which defaults to the outer scope's C<$_>. Thus it
-will inherit the L<topic|/language/variables#index-entry-topic_variable> if there is any.
+will inherit the L<topic|/language/variables#The_$__variable> if there is any.
 
     my $block = { uc $_; };
     say $block.^name;           # OUTPUT: «Block␤»

--- a/doc/Type/Callable.rakudoc
+++ b/doc/Type/Callable.rakudoc
@@ -31,7 +31,7 @@ of such a container is C<Callable>.
     method CALL-ME(Callable:D $self: |arguments)
 
 This method is required for the L«C<( )> postcircumfix operator|/language/operators#postcircumfix_(_)»
-and the L«C<.( )> postcircumfix operator|/language/operators#index-entry-.(_)». It's what makes
+and the L«C<.( )> postcircumfix operator|/language/operators#methodop_.postfix_/_.postcircumfix». It's what makes
 an object actually call-able and needs to be overloaded to let a given object
 act like a routine. If the object needs to be stored in a C<&>-sigiled
 container, it has to implement Callable.

--- a/doc/Type/Channel.rakudoc
+++ b/doc/Type/Channel.rakudoc
@@ -94,7 +94,7 @@ C<.receive> may still drain any remaining items that were previously sent, but i
 the queue is empty, will throw an L<X::Channel::ReceiveOnClosed|/type/X::Channel::ReceiveOnClosed>
 exception.  Since you can produce a C<Seq> from a Channel by contextualizing to array with C<@()>
 or by calling the C<.list> method, these methods will not terminate until the channel has been
-closed. A L<whenever|/language/concurrency#index-entry-whenever>-block will also
+closed. A L<whenever|/language/concurrency#whenever>-block will also
 terminate properly on a closed channel.
 
 =for code

--- a/doc/Type/Collation.rakudoc
+++ b/doc/Type/Collation.rakudoc
@@ -9,7 +9,7 @@ class Collation { }
 
 C<Collation> is the class that allows proper sorting, taking into account all
 Unicode characteristics. It's the class the object
-L<C<$*COLLATION>|/language/variables#index-entry-%24*COLLATION> is instantiated
+L<C<$*COLLATION>|/language/variables#%24*COLLATION> is instantiated
 to, and thus includes I<collation levels>, that is, what kind of features should
 be looked up when comparing two strings and in which order.
 

--- a/doc/Type/DateTime.rakudoc
+++ b/doc/Type/DateTime.rakudoc
@@ -111,7 +111,7 @@ Since Rakudo release 2022.07, it is also possible to just specify a
 Creates a new C<DateTime> object from the current system time. A custom
 L<formatter|/routine/formatter> and L<timezone|/routine/timezone> can be provided. The C<:$timezone> is
 the offset B<in seconds> from L<GMT|https://en.wikipedia.org/wiki/Greenwich_Mean_Time>
-and defaults to the value of L«C<$*TZ> variable|/language/variables#index-entry-%24*TZ».
+and defaults to the value of L«C<$*TZ> variable|/language/variables#%24*TZ».
 
     say DateTime.now; # OUTPUT: «2018-01-08T13:05:32.703292-06:00␤»
 
@@ -390,7 +390,7 @@ not respect local time and always occur at the end of the I<UTC> day:
     method local(DateTime:D: --> DateTime:D)
 
 Returns a DateTime object for the same time, but in the local time zone
-(L«C<$*TZ>|/language/variables#index-entry-%24*TZ»).
+(L«C<$*TZ>|/language/variables#%24*TZ»).
 
     my $*TZ = -3600;
     say DateTime.new('2015-12-24T12:23:00+0200').local; # OUTPUT: «2015-12-24T09:23:00-0100␤»

--- a/doc/Type/Distro.rakudoc
+++ b/doc/Type/Distro.rakudoc
@@ -7,7 +7,7 @@
     class Distro does Systemic { }
 
 Built-in class for providing distribution related information.  Usually accessed
-through the L<$*DISTRO|/language/variables#index-entry-%24*DISTRO> dynamic
+through the L<$*DISTRO|/language/variables#%24*DISTRO> dynamic
 variable.
 
 =head1 Methods

--- a/doc/Type/Exception.rakudoc
+++ b/doc/Type/Exception.rakudoc
@@ -138,14 +138,14 @@ Coerces the C<Exception> into a L<Failure|/type/Failure> object.
 
 Throws a fatal L<Exception|/type/Exception>. The default exception handler prints each
 element of the list to
-L«C<$*ERR>|/language/variables#index-entry-%24%2AERR» (STDERR).
+L«C<$*ERR>|/language/variables#Special_filehandles:_STDIN,_STDOUT_and_STDERR» (STDERR).
 
 =for code
 die "Important reason";
 
 If the subroutine form is called without arguments, the value of
 L«C<$!> variable|/syntax/$!» is checked. If it is set to a
-L«C<.DEFINITE>|/language/mop#index-entry-syntax_DEFINITE-DEFINITE»
+L«C<.DEFINITE>|/language/mop#DEFINITE»
 value, its value will be used as the L<Exception|/type/Exception> to throw if it's of
 type L<Exception|/type/Exception>, otherwise, it will be used as payload of
 L<X::AdHoc|/type/X::AdHoc> exception. If C<$!> is not C<.DEFINITE>,

--- a/doc/Type/Failure.rakudoc
+++ b/doc/Type/Failure.rakudoc
@@ -83,7 +83,7 @@ Returns C<True> for handled failures, C<False> otherwise.
     sub f() { fail }; my $v = f; say $v.handled; # OUTPUT: «False␤»
 
 The C<handled> method is an
-L<lvalue|/language/glossary#index-entry-lvalue>, see L«routine trait
+L<lvalue|/language/glossary#lvalue>, see L«routine trait
 C<is rw>|/type/Routine#trait_is_rw», which means you can also use it
 to set the handled state:
 

--- a/doc/Type/IO/ArgFiles.rakudoc
+++ b/doc/Type/IO/ArgFiles.rakudoc
@@ -28,7 +28,7 @@ my $argfiles = IO::CatHandle.new(@*ARGS);
 
 This class is the magic behind the C<$*ARGFILES> variable, which provides a way
 to iterate over files passed in to the program on the command line (i.e.
-elements of L<C«@*ARGS»|/language/variables#index-entry-%40%2AARGS>). Thus the
+elements of L<C«@*ARGS»|/language/variables#%40%2AARGS>). Thus the
 examples above can be simplified like so:
 
     .say for $*ARGFILES.lines;
@@ -88,7 +88,7 @@ for $*ARGFILES.handles -> $fh {
 
 That code will fail if any of the arguments is not the valid name of a file. You
 will have to deal with that case at another level, checking that
-L<C<@*ARGS>|/language/variables#index-entry-%40*ARGS> contains valid file names,
+L<C<@*ARGS>|/language/variables#%40*ARGS> contains valid file names,
 for instance.
 
 =end pod

--- a/doc/Type/IO/CatHandle.rakudoc
+++ b/doc/Type/IO/CatHandle.rakudoc
@@ -256,7 +256,7 @@ want to treat each filehandle separately:
 
 It I<is> acceptable to call this method multiple times; C<.handles.head> is a
 valid idiom for obtaining the currently-active handle. If, between
-L<reification|/language/glossary#index-entry-Reify> of the elements of the
+L<reification|/language/glossary#Reify> of the elements of the
 returned L<Seq|/type/Seq> the handles get switched by some other means, the next
 element produced by the L<Seq|/type/Seq> would be the next handle of the
 invocant, not the handle that would've been produced if no switching occurred:

--- a/doc/Type/IO/Handle.rakudoc
+++ b/doc/Type/IO/Handle.rakudoc
@@ -159,7 +159,7 @@ Reads a single line of input from the handle, removing the trailing newline
 characters (as set by L«C<.nl-in>|/routine/nl-in») if the handle's C<.chomp>
 attribute is set to C<True>. Returns C<Nil>, if no more input is available. The
 subroutine form defaults to
-L«C<$*ARGFILES>|/language/variables#index-entry-%24%2AARGFILES» if no handle is
+L«C<$*ARGFILES>|/language/variables#%24%2AARGFILES» if no handle is
 given.
 
 Attempting to call this method when the handle is
@@ -184,7 +184,7 @@ say get;                   # Read one line from $*ARGFILES
 Reads a single character from the input stream. Attempting to call this method
 when the handle is L<in binary mode|/type/IO::Handle#method_encoding> will
 result in C<X::IO::BinaryMode> exception being thrown. The subroutine form
-defaults to L«C<$*ARGFILES>|/language/variables#index-entry-%24%2AARGFILES» if
+defaults to L«C<$*ARGFILES>|/language/variables#%24%2AARGFILES» if
 no handle is given. Returns C<Nil>, if no more input is available, otherwise
 operation will block, waiting for at least one character to be available; these
 caveats apply:
@@ -361,7 +361,7 @@ Reads up to C<$limit> lines, where C<$limit> can be a non-negative L<Int|/type/I
 C<Inf>, or L<Whatever|/type/Whatever> (which is interpreted to mean C<Inf>). If C<:$close> is
 set to C<True>, will close the handle when the file ends or C<$limit> is
 reached. Subroutine form defaults to
-L«C<$*ARGFILES>|/language/variables#index-entry-%24%2AARGFILES», if no
+L«C<$*ARGFILES>|/language/variables#%24%2AARGFILES», if no
 handle is provided.
 
 Attempting to call this method when the handle is
@@ -369,7 +369,7 @@ L<in binary mode|/type/IO::Handle#method_encoding> will result in
 C<X::IO::BinaryMode> exception being thrown.
 
 B<NOTE:> the lines are read lazily, so ensure the returned L<Seq|/type/Seq> is either
-L<fully reified|/language/glossary#index-entry-Reify> or is no longer needed
+L<fully reified|/language/glossary#Reify> or is no longer needed
 when you close the handle or attempt to use any other method that changes the
 file position.
 
@@ -445,7 +445,7 @@ C<$limit> argument that can be a non-negative L<Int|/type/Int>, C<Inf>, or L<Wha
 must be returned. If L<Bool|/type/Bool> C<:$close> named argument is set to C<True>,
 will automatically close the handle when the returned L<Seq|/type/Seq> is exhausted.
 Subroutine form defaults to
-L«C<$*ARGFILES>|/language/variables#index-entry-%24%2AARGFILES», if no handle
+L«C<$*ARGFILES>|/language/variables#%24%2AARGFILES», if no handle
 is provided.
 
 Attempting to call this method when the handle is
@@ -501,7 +501,7 @@ mode is undefined.
 Writes the given C<@text> to the handle, coercing any non-L<Str|/type/Str>
 objects to L<Str|/type/Str> by calling L«C<.Str>|/routine/Str» method on them.
 L<Junction|/type/Junction> arguments
-L<autothread|/language/glossary#index-entry-Autothreading> and the order of
+L<autothread|/language/glossary#Autothreading> and the order of
 printed strings is not guaranteed. See L<write|/routine/write> to write bytes.
 
 Attempting to call this method when the handle is
@@ -582,7 +582,7 @@ given 'foo'.IO.open: :w, :1000out-buffer {
 Writes the given C<@text> to the handle, coercing any non-L<Str|/type/Str> objects to
 L<Str|/type/Str> by calling L«C<.Str>|/routine/Str» method on them, and appending the
 value of L«C<.nl-out>|/type/IO::Handle#method_nl-out» at the end. L<Junction|/type/Junction>
-arguments L<autothread|/language/glossary#index-entry-Autothreading> and the
+arguments L<autothread|/language/glossary#Autothreading> and the
 order of printed strings is not guaranteed.
 
 Attempting to call this method when the handle is
@@ -738,9 +738,9 @@ mode.
 
 For a handle opened on a file this returns the L<IO::Path|/type/IO::Path> that
 represents the file. For the standard I/O handles
-L«C<$*IN>|/language/variables#index-entry-%24%2AIN»,
-L«C<$*OUT>|/language/variables#index-entry-%24%2AOUT», and
-L«C<$*ERR>|/language/variables#index-entry-%24%2AERR» it returns an
+L«C<$*IN>|/language/variables#Special_filehandles:_STDIN,_STDOUT_and_STDERR»,
+L«C<$*OUT>|/language/variables#Special_filehandles:_STDIN,_STDOUT_and_STDERR», and
+L«C<$*ERR>|/language/variables#Special_filehandles:_STDIN,_STDOUT_and_STDERR» it returns an
 L<IO::Special|/type/IO::Special> object.
 
 =head2 method IO

--- a/doc/Type/IO/Path.rakudoc
+++ b/doc/Type/IO/Path.rakudoc
@@ -702,7 +702,7 @@ L<Seq|/type/Seq>.
 
 B<NOTE:> words are lazily read. The handle used under the hood is not closed
 until the returned L<Seq|/type/Seq> is
-L<fully reified|/language/glossary#index-entry-Reify>, and this could lead to
+L<fully reified|/language/glossary#Reify>, and this could lead to
 leaking open filehandles. It is possible to avoid leaking open filehandles using
 the L«C<$limit> argument|/type/IO::Handle#routine_words» to cut down the C<Seq>
 of words to be generated.
@@ -726,7 +726,7 @@ L<Seq|/type/Seq>.
 
 B<NOTE:> the lines are ready lazily and the handle used under the hood won't
 get closed until the returned L<Seq|/type/Seq> is
-L<fully reified|/language/glossary#index-entry-Reify>, so ensure it is,
+L<fully reified|/language/glossary#Reify>, so ensure it is,
 or you'll be leaking open filehandles. (TIP: use the
 L«C<$limit> argument|/type/IO::Handle#routine_lines»)
 

--- a/doc/Type/Iterable.rakudoc
+++ b/doc/Type/Iterable.rakudoc
@@ -72,7 +72,7 @@ itemized sublists:
 
     say ($('a', 'b'), 'c').flat;    # OUTPUT: «($("a", "b"), "c")␤»
 
-You can use the L«hyper method call|/language/operators#index-entry-methodop_>>.» to
+You can use the L«hyper method call|/language/operators#index-entry-Language_hyper_method_call_operator-hyper_method_call_operator» to
 call the L«C<.List>|/routine/List» method on all the inner itemized sublists
 and so de-containerize them, so that C<flat> can flatten them:
 

--- a/doc/Type/List.rakudoc
+++ b/doc/Type/List.rakudoc
@@ -24,7 +24,7 @@ nor the elements themselves can be changed. Thus, it is not possible to use
 operations that change the list structure itself such as L<shift|/routine/shift>,
 L<unshift|/routine/unshift>, L<push|/routine/push>, L<pop|/routine/pop>,
 L<splice|/routine/splice>
-and L<binding|/language/operators#index-entry-Binding_operator>.
+and L<binding|/language/operators#infix_:=>.
 
 =begin code :skip-test<illustrates error>
 (1, 2, 3).shift;      # Error Cannot call 'shift' on an immutable 'List'
@@ -198,7 +198,7 @@ operator to flatten the tuple into an argument list, so it is equivalent to:
 
 There are other ways to list the elements of an itemized single argument. For
 example, you can L«decontainerize|/routine/<>» the argument or use the L<C<@>
-list contextualizer|/type/Any#index-entry-@_list_contextualizer>:
+list contextualizer|/type/Any#index-entry-Syntax_@_list_contextualizer>:
 
 =begin code :preamble<my $tuple>
 put list($tuple<>).raku;    # OUTPUT: «(1, 2)␤»
@@ -998,7 +998,7 @@ depends on the operator. In the functional programming world, this operation is
 generally called a L<fold|https://en.wikipedia.org/wiki/Fold_%28higher-order_function%29#Folds_on_lists>.
 With a right-associative operator it is a I<right fold>, otherwise (and usually)
 it is a I<left fold>. In Raku, you can specify the associativity of an operator
-with the L<C«is assoc»|/language/functions#index-entry-is_assoc_(trait)>.
+with the L<C«is assoc»|/language/functions#index-entry-Traits_is_assoc>.
 
     sub infix:<foo>($a, $b) is assoc<right> { "($a, $b)" }
     say [foo] 1, 2, 3, 4; # OUTPUT: «(1, (2, (3, 4)))␤»

--- a/doc/Type/Metamodel/ClassHOW.rakudoc
+++ b/doc/Type/Metamodel/ClassHOW.rakudoc
@@ -131,7 +131,7 @@ Creates a new type from the metamodel, which we can proceed to build
     $instance.hey; # OUTPUT: «Hey␤»
 
 We add a single method by using
-L<Higher Order Workings|/language/mop#index-entry-syntax_HOW-HOW> methods, and
+L<Higher Order Workings|/language/mop#HOW> methods, and
 then we can use
 that method directly as class method; we can then C<compose> the type, following
 which we can create already an instance, which will behave in the exact same

--- a/doc/Type/Metamodel/Mixins.rakudoc
+++ b/doc/Type/Metamodel/Mixins.rakudoc
@@ -58,7 +58,7 @@ but composable state as well. Using this feature, the example above can
 be rewritten so billboards can be vandalized more than once without
 needing to generate more mixins by making C<Billboard::Vandalism>'s
 C<$vandalism> named parameter an
-L<rw|/type/Attribute#index-entry-trait_is_rw_(Attribute)-trait_is_rw>
+L<rw|/type/Attribute#trait_is_rw>
 mixin attribute instead:
 
 =begin code :solo

--- a/doc/Type/Mu.rakudoc
+++ b/doc/Type/Mu.rakudoc
@@ -367,7 +367,7 @@ stringifying non-C<Str> object using the C<.Str> method.
     multi method say()
 
 Will L<C<say>|/type/IO::Handle#method_say> to
-L<standard output|/language/variables#index-entry-$*OUT>.
+L<standard output|/language/variables#Special_filehandles:_STDIN,_STDOUT_and_STDERR>.
 
     say 42;                 # OUTPUT: «42␤»
 
@@ -481,8 +481,8 @@ container to the invocant (see more details here: L<C<return-rw>|/language/contr
     method emit()
 
 Emits the invocant into the enclosing
-L<supply|/language/concurrency#index-entry-supply_(on-demand)> or
-L<react|/language/concurrency#index-entry-react> block.
+L<supply|/language/concurrency#index-entry-Reference_supply_(on-demand)> or
+L<react|/language/concurrency#react> block.
 
     react { whenever supply { .emit for "foo", 42, .5 } {
         say "received {.^name} ($_)";

--- a/doc/Type/Nil.rakudoc
+++ b/doc/Type/Nil.rakudoc
@@ -182,7 +182,7 @@ Will return C<\0>, and also throw a warning.
 
     method FALLBACK(| --> Nil) {}
 
-The L<fallback method|/language/typesystem#index-entry-FALLBACK_(method)>
+The L<fallback method|/language/typesystem#Fallback_method>
 takes any arguments and always returns a L<Nil|/type/Nil>.
 
 =head2 method Numeric

--- a/doc/Type/Proc/Async.rakudoc
+++ b/doc/Type/Proc/Async.rakudoc
@@ -73,7 +73,7 @@ Program finished
 =end code
 
 Alternatively, you can use C<Proc::Async> without using a
-L<react|/language/concurrency#index-entry-react> block:
+L<react|/language/concurrency#react> block:
 
     # command with arguments
     my $proc = Proc::Async.new('echo', 'foo', 'bar');

--- a/doc/Type/Raku.rakudoc
+++ b/doc/Type/Raku.rakudoc
@@ -7,7 +7,7 @@
     class Raku does Systemic { }
 
 Built-in class for providing information related to the implementation of
-the Raku language. Usually accessed through the L<$*RAKU|/language/variables#index-entry-%24*RAKU>
+the Raku language. Usually accessed through the L<$*RAKU|/language/variables#%24*RAKU>
 dynamic variable.
 
 =head1 Methods

--- a/doc/Type/Rat.rakudoc
+++ b/doc/Type/Rat.rakudoc
@@ -25,7 +25,7 @@ To prevent the numerator and denominator from becoming pathologically large,
 the denominator is limited to 64 bit storage. On overflow of the denominator
 a C<Num> (floating-point number) is returned instead.  You can tune this
 behavior by setting the
-L<C<$*RAT-OVERFLOW>|/language/variables#index-entry-%24*RAT-OVERFLOW> dynamic
+L<C<$*RAT-OVERFLOW>|/language/variables#%24*RAT-OVERFLOW> dynamic
 variable.
 
 For example this function crudely approximates a square root, and overflows

--- a/doc/Type/Scalar.rakudoc
+++ b/doc/Type/Scalar.rakudoc
@@ -23,7 +23,7 @@ In addition, C<Scalar>s delegate all method calls to the value which they
 contain. As such, C<Scalar>s are for the most part invisible. There is, however,
 one important place where C<Scalar>s have a visible impact: a C<Scalar>
 container will shield its content from
-L<flattening|/language/subscripts#index-entry-flattening_> by most Raku core list
+L<flattening|/language/subscripts#index-entry-Syntax_flattening_> by most Raku core list
 operations.
 
 =for code

--- a/doc/Type/Str.rakudoc
+++ b/doc/Type/Str.rakudoc
@@ -334,7 +334,7 @@ characters, and ignores additional marks such as combining accents.
 Performs a match of the string against C<$pat> and returns a
 L<Match|/type/Match> object if there is a successful match; it returns C<(Any)>
 otherwise. Matches are stored in the L<default match variable
-C<$/>|/language/variables#index-entry-match_variable>. If C<$pat> is not a
+C<$/>|/language/variables#The_$/_variable>. If C<$pat> is not a
 L<Regex|/type/Regex> object, match will coerce the argument to a Str and then
 perform a literal match against C<$pat>.
 
@@ -370,7 +370,7 @@ that start at the same position.
 Returns the nth match in the string. The argument can be a L<Numeric|/type/Numeric> or
 an L<Iterable|/type/Iterable> producing monotonically increasing numbers (that is, the
 next produced number must be larger than the previous one). The L<Iterable|/type/Iterable>
-will be lazily L<reified|/language/glossary#index-entry-Reify> and if
+will be lazily L<reified|/language/glossary#Reify> and if
 non-monotonic sequence is encountered an exception will be thrown.
 
 If L<Iterable|/type/Iterable> argument is provided the return value and C<$/> variable

--- a/doc/Type/Sub.rakudoc
+++ b/doc/Type/Sub.rakudoc
@@ -54,7 +54,7 @@ L<extended identifiers|/language/syntax#Extended_identifiers>.
 X<|Syntax,trait_mod (declarator)>
 
 A C<Trait> is a sub that is applied at compile time to various objects like
-classes, routines or L<containers|/language/phasers#index-entry-Phasers__will_trait>. It
+classes, routines or L<containers|/language/phasers#index-entry-Phasers_will_trait>. It
 is declared with the C<trait_mod> declarator followed by a colon and a string
 literal containing the name of the trait. A single positional parameter defines
 the type of the object that the trait is applied to. A single named argument

--- a/doc/Type/VM.rakudoc
+++ b/doc/Type/VM.rakudoc
@@ -8,7 +8,7 @@
 
 Built-in class for providing information about the virtual machine in which
 Raku is running. Usually accessed through the
-L<$*VM|/language/variables#index-entry-%24*VM> dynamic variable.
+L<$*VM|/language/variables#%24*VM> dynamic variable.
 
 =head1 Methods
 

--- a/doc/Type/Whatever.rakudoc
+++ b/doc/Type/Whatever.rakudoc
@@ -119,7 +119,7 @@ one.
     multi method ACCEPTS(Whatever:D: Mu $other)
     multi method ACCEPTS(Whatever:U: Mu $other)
 
-If the invocant is L«an instance|/language/classtut#index-entry-.DEFINITE»,
+If the invocant is L«an instance|/language/classtut#A_word_on_types»,
 always returns C<True>. If the invocant is a type object, performs a typecheck.
 
     say 42 ~~ (*);       # OUTPUT: «True␤»

--- a/doc/Type/independent-routines.rakudoc
+++ b/doc/Type/independent-routines.rakudoc
@@ -50,7 +50,7 @@ through EVAL if you activate the C<MONKEY-SEE-NO-EVAL> pragma.
 
 Please note that you can interpolate to create routine names using
 quotation, as can be seen in
-L<this example|/language/quoting#index-entry-%26_(interpolation)>
+L<this example|/language/quoting#index-entry-Syntax_&_(interpolation)>
 or
 L<other ways to interpolate to create identifier names|/language/syntax#Identifiers>.
 This only works, however, for already declared functions and other
@@ -104,7 +104,7 @@ modules which may be found from the
 L<Raku Modules Directory|https://raku.land/?q=inline>.
 
 If the optional  C<$filename> parameter is given, the
-L«C<$?FILE>|/language/variables#index-entry-$%3FFILE» variable is set to
+L«C<$?FILE>|/language/variables#Compile-time_variables» variable is set to
 its value. Otherwise C<$?FILE> is set to a unique and generated file name.
 
 =for code
@@ -348,10 +348,10 @@ By default, only C<:d> test is performed.
     multi sub print(Junction:D --> True)
 
 Prints the given text on standard output (the
-L«C<$*OUT>|/language/variables#index-entry-%24%2AOUT» filehandle), coercing
+L«C<$*OUT>|/language/variables#Special_filehandles:_STDIN,_STDOUT_and_STDERR» filehandle), coercing
 non-L<Str|/type/Str> objects to L<Str|/type/Str> by calling L«C<.Str>
 method|/routine/Str». L<Junction|/type/Junction> arguments
-L<autothread|/language/glossary#index-entry-Autothreading> and the order of
+L<autothread|/language/glossary#Autothreading> and the order of
 printed strings is not guaranteed.
 
     print "Hi there!\n";       # OUTPUT: «Hi there!␤»
@@ -373,7 +373,7 @@ L«C<put>|/language/independent-routines#sub_put».
 Same as L«C<print>|/language/independent-routines#sub_print», except it uses
 L«C<print-nl>|/routine/print-nl» (which prints a L<newline|/language/newline>,
 by default) at the end. L<Junction|/type/Junction> arguments
-L<autothread|/language/glossary#index-entry-Autothreading> and the order of
+L<autothread|/language/glossary#Autothreading> and the order of
 printed strings is not guaranteed.
 
     put "Hi there!\n";   # OUTPUT: «Hi there!␤␤»
@@ -423,7 +423,7 @@ instead.
 
 Like L«C<say>|/routine/say» (in the sense it will invoke the C<.gist> method
 of the printed object), except it prints output to
-L«C<$*ERR>|/language/variables#index-entry-%24%2AERR» handle (C<STDERR>).
+L«C<$*ERR>|/language/variables#Special_filehandles:_STDIN,_STDOUT_and_STDERR» handle (C<STDERR>).
 If no arguments are given to subroutine forms, will use string C<"Noted">.
 
 =begin code
@@ -1322,7 +1322,7 @@ from zero from a L<Main|/routine/MAIN>.
 
 C<exit> prevents the L<LEAVE|/language/phasers#LEAVE> phaser to be
 executed, but it will run the code in the
-L<C<&*EXIT>|/language/variables#index-entry-%26*EXIT> variable.
+L<C<&*EXIT>|/language/variables#%26*EXIT> variable.
 
 C<exit> should be used as last resort only to signal the parent process
 about an exit code different from zero, and not to terminate


### PR DESCRIPTION
Amend links with stale `#index-entry...` targets, in some cases choosing page sections rather than the equivalent index entry.

Manually tested updated links locally.