### PR TITLE
Update modules.rakudoc

### DIFF
--- a/doc/Language/modules.rakudoc
+++ b/doc/Language/modules.rakudoc
@@ -51,7 +51,7 @@ L<synopsis S11|https://design.raku.org/S11.html#Units> says: Confusing? Yes it
 is.> , a C<t> directory for tests, and possibly a C<bin> directory for
 executable programs and scripts.
 
-See L<Language/filename-extensions> for current and historic
+See L<filename extensions|/language/filename-extensions> for current and historic
 extensions for various file types.
 
 =head1 X<Loading and basic importing|Language,compunit>


### PR DESCRIPTION
Link url has a typo (should be `/language/filename-extensions`, not  `/Language/...`

## The problem
Link for filename-extensions leads to a 404

## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
