### PR TITLE
Update independent-routines.rakudoc

### DIFF
--- a/doc/Type/independent-routines.rakudoc
+++ b/doc/Type/independent-routines.rakudoc
@@ -139,7 +139,7 @@ I<Note>: C<repl> was introduced in release 2021.06 of the Rakudo compiler.
 
 Pauses execution and enters a REPL (read-eval-print loop) in the current
 context.  This REPL is exactly like the one created when you run C<raku>
-L<without any arguments|Programs/04-running-raku#DESCRIPTION> except that
+L<without any arguments|/programs/04-running-raku#DESCRIPTION> except that
 you can access/modify the program's current context (such as lexical
 variables).
 


### PR DESCRIPTION
link typo. `/programs/....` not `Programs/...`

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
