### PR TITLE
mention dist tools

### DIFF
--- a/doc/Language/modules.rakudoc
+++ b/doc/Language/modules.rakudoc
@@ -688,6 +688,43 @@ on the two steps are below.
 For a module to work in any of the ecosystems, it needs to follow a certain
 structure. Here is how to do that:
 
+=head3 Using a dist manager
+
+=item fez
+
+=begin item
+Run the commands:
+
+=begin code :lang<text>
+fez init MyNew::Module
+
+# Will create the following:
+# MyNew--Module/
+# ├── lib
+# │   └── MyNew
+# │       └── Module.rakumod
+# ├── META6.json
+# └── t
+#     └── 00-use.rakutest
+=end code
+
+=begin item
+
+If you need to add new modules, classes, resources, build-depends, or depends you may use the following (respectively,
+these resources will automatically be added to META6.json):
+
+=begin code :lang<text>
+fez module My::New::Module
+fez module --class My::New::Module
+fez resource xyz
+fez depends --build Build::Dependency
+fez depends Runtime::Dependency
+=end code
+=end item
+=end item
+
+=head3 Manually
+
 =item Create a project directory named after your module. For
     example, if your module is C<Vortex::TotalPerspective>, then create a
     project directory named C<Vortex-TotalPerspective>.

--- a/xt/pws/code.pws
+++ b/xt/pws/code.pws
@@ -325,6 +325,7 @@ myfoo
 myhome
 myletter
 mylib
+mynew
 mynumber
 myrange
 mysqlclient


### PR DESCRIPTION
## The problem

The how to section for distributing your module could also mention that dist management tools can also make the boilerplate faster

## Solution provided

Added `fez` to the list of ways you can initialize a skeleton dist repo