### PR TITLE
Reduce size of entry for READMEs in other languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ to build and run this site is [available on github](https://github.com/Raku/doc-
 
 ## README in other languages
 
-* [README in Chinese](resources/i18n/zh/README.zh.md)
-* [README in Dutch](resources/i18n/nl/README.nl.md)
-* [README in French](resources/i18n/fr/README.fr.md)
-* [README in German](resources/i18n/de/README.de.md)
-* [README in Italian](resources/i18n/it/README.it.md)
-* [README in Japanese](resources/i18n/jp/README.jp.md)
-* [README in Portuguese](resources/i18n/pt/README.pt.md)
-* [README in Spanish](resources/i18n/es/README.es.md)
+  [Chinese](resources/i18n/zh/README.zh.md)
+| [Dutch](resources/i18n/nl/README.nl.md)
+| [French](resources/i18n/fr/README.fr.md)
+| [German](resources/i18n/de/README.de.md)
+| [Italian](resources/i18n/it/README.it.md)
+| [Japanese](resources/i18n/jp/README.jp.md)
+| [Portuguese](resources/i18n/pt/README.pt.md)
+| [Spanish](resources/i18n/es/README.es.md)
 
 ## Help Wanted!
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ to build and run this site is [available on github](https://github.com/Raku/doc-
 
 ## README in other languages
 
-  [Chinese](resources/i18n/zh/README.zh.md)
-| [Dutch](resources/i18n/nl/README.nl.md)
-| [French](resources/i18n/fr/README.fr.md)
-| [German](resources/i18n/de/README.de.md)
-| [Italian](resources/i18n/it/README.it.md)
-| [Japanese](resources/i18n/jp/README.jp.md)
-| [Portuguese](resources/i18n/pt/README.pt.md)
-| [Spanish](resources/i18n/es/README.es.md)
+  [日本語](resources/i18n/jp/README.jp.md)
+| [普通话](resources/i18n/zh/README.zh.md)
+| [Deutsche](resources/i18n/de/README.de.md)
+| [español](resources/i18n/es/README.es.md)
+| [français](resources/i18n/fr/README.fr.md)
+| [italiano](resources/i18n/it/README.it.md)
+| [nederlands](resources/i18n/nl/README.nl.md)
+| [Português](resources/i18n/pt/README.pt.md)
 
 ## Help Wanted!
 


### PR DESCRIPTION
For issue #4244 

## The problem

The bullet point entry for READMEs in other languages is too long.

## Solution provided

I reformatted the list as a one liner separated by | (idea stolen from coke)


