### PR TITLE
Update modules.rakudoc

### DIFF
--- a/doc/Language/modules.rakudoc
+++ b/doc/Language/modules.rakudoc
@@ -708,7 +708,7 @@ fez init MyNew::Module
 #     └── 00-use.rakutest
 =end code
 
-=begin item
+=begin item2
 
 If you need to add new modules, classes, resources, build-depends, or depends you may use the following (respectively,
 these resources will automatically be added to META6.json):
@@ -720,7 +720,7 @@ fez resource xyz
 fez depends --build Build::Dependency
 fez depends Runtime::Dependency
 =end code
-=end item
+=end item2
 =end item
 
 =head3 Manually


### PR DESCRIPTION
## The problem
The changes introduced on March 29 broke the website :( 

The changes to this file are not in fact correct Rakudoc, but Rakudo does not flag it as an error, and passes what seems to be a valid Pod-Block to the Renderer. 

An attempt (around line 712) has been made to create an inner item, but standard Rakudoc is to label the inner block as `=item2`. Thus
```
=item top
=item2 next level
```
Since the 'delimited block' syntax was used, the following occurred
```
=begin item

top

=begin item

next level

=end item
=end item
```

## Solution provided

Labeling the inner `=begin item2` explicitly, as done here, resolves the problem.

This is what this PR does.

Since Raku does not compile this Rakudoc source correctly, the ProcessedPod Renderer fails (an issue of itself). I am working on ProcessedPod, so that a mal-formed list, like this one, is transformed into some form of valid HTML without failing completely.

However, for the time being, I recommend this PR be accepted as it is breaking doc-website.
