### PR TITLE
Describe additional word splitters for quote protection

### DIFF
--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -386,10 +386,16 @@ Thus, if you wish to preserve quoted sub-strings as single items in the resultin
 you need to use the C<qww> variant:
 
     say qww{"a b" c}.raku; # OUTPUT: «("a b", "c")␤»
+    
+The delimiters of sub-strings are always considered word splitters:
+
+    say qww{'alpha'beta'gamma' 'delta'"epsilon"}.raku; # OUTPUT: «("alpha", "beta", "gamma", "delta", "epsilon")␤»
 
 Other kind of quotes are also supported
 
-    say qww{ ’this and that’ “here or there” ｢infinity and beyond｣ }.raku;
+    my $one = 'here';
+    my $other = 'there';
+    say qww{ ’this and that’ “$one or $other” ｢infinity and beyond｣ }.raku;
     # OUTPUT: «("this and that", "here or there", "infinity and beyond")␤»
 
 =head2 X<Word quoting with interpolation: qqw|Syntax,qqw>
@@ -422,6 +428,17 @@ Thus, if you wish to preserve quoted sub-strings as single items in the
 resulting words you need to use the C<qqww> variant:
 
     my $a = 42; say qqww{"$a b" c}.raku; # OUTPUT: «("42 b", "c")␤»
+    
+The delimiters of sub-strings are always considered word splitters:
+
+    say qww{'alpha'beta'gamma' 'delta'"epsilon"}.raku; # OUTPUT: «("alpha", "beta", "gamma", "delta", "epsilon")␤»
+    
+Unlike the C<qqw> form, interpolation also always splits, unless it happens inside a sub-string:
+
+    my $time = "now";
+    $_ = 'ni';
+    my @list = qqww<$time$time {6*7}{7*6} "$_$_">;
+    .say for @list; # OUTPUT: «now␤now␤42␤42␤nini␤»
 
 Quote protection happens before interpolation, and interpolation happens
 before word splitting, so quotes coming from inside interpolated variables are

--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -382,21 +382,21 @@ them in the resulting words:
 
     say qw{"a b" c}.raku; # OUTPUT: «("\"a", "b\"", "c")␤»
 
-Thus, if you wish to preserve quoted sub-strings as single items in the resulting words
-you need to use the C<qww> variant:
+Using C<qww> variant allows you to use quote characters for embedding strings
+in the word quoting structure:
 
     say qww{"a b" c}.raku; # OUTPUT: «("a b", "c")␤»
-    
-The delimiters of sub-strings are always considered word splitters:
 
-    say qww{'alpha'beta'gamma' 'delta'"epsilon"}.raku; # OUTPUT: «("alpha", "beta", "gamma", "delta", "epsilon")␤»
-
-Other kind of quotes are also supported
+Other kind of quotes are also supported with their usual semantics:
 
     my $one = 'here';
     my $other = 'there';
     say qww{ ’this and that’ “$one or $other” ｢infinity and beyond｣ }.raku;
     # OUTPUT: «("this and that", "here or there", "infinity and beyond")␤»
+
+The delimiters of embedded strings are always considered word splitters:
+
+    say qww{'alpha'beta'gamma' 'delta'"epsilon"}.raku; # OUTPUT: «("alpha", "beta", "gamma", "delta", "epsilon")␤»
 
 =head2 X<Word quoting with interpolation: qqw|Syntax,qqw>
 
@@ -424,16 +424,16 @@ leaving them in the resulting words:
 
     my $a = 42; say qqw{"$a b" c}.raku;  # OUTPUT: «("\"42", "b\"", "c")␤»
 
-Thus, if you wish to preserve quoted sub-strings as single items in the
-resulting words you need to use the C<qqww> variant:
+Using C<qqww> variant allows you to use quote characters for embedding strings
+in the word quoting structure:
 
     my $a = 42; say qqww{"$a b" c}.raku; # OUTPUT: «("42 b", "c")␤»
     
-The delimiters of sub-strings are always considered word splitters:
+The delimiters of embedded strings are always considered word splitters:
 
-    say qww{'alpha'beta'gamma' 'delta'"epsilon"}.raku; # OUTPUT: «("alpha", "beta", "gamma", "delta", "epsilon")␤»
+    say qqww{'alpha'beta'gamma' 'delta'"epsilon"}.raku; # OUTPUT: «("alpha", "beta", "gamma", "delta", "epsilon")␤»
     
-Unlike the C<qqw> form, interpolation also always splits, unless it happens inside a sub-string:
+Unlike the C<qqw> form, interpolation also always splits (except for interpolation that takes place in an embedded string):
 
     my $time = "now";
     $_ = 'ni';

--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -387,7 +387,7 @@ in the word quoting structure:
 
     say qww{"a b" c}.raku; # OUTPUT: «("a b", "c")␤»
 
-Other kind of quotes are also supported with their usual semantics:
+Other kinds of quotes are also supported with their usual semantics:
 
     my $one = 'here';
     my $other = 'there';

--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -382,7 +382,7 @@ them in the resulting words:
 
     say qw{"a b" c}.raku; # OUTPUT: «("\"a", "b\"", "c")␤»
 
-Using C<qww> variant allows you to use quote characters for embedding strings
+Using the C<qww> variant allows you to use quote characters for embedding strings
 in the word quoting structure:
 
     say qww{"a b" c}.raku; # OUTPUT: «("a b", "c")␤»
@@ -424,7 +424,7 @@ leaving them in the resulting words:
 
     my $a = 42; say qqw{"$a b" c}.raku;  # OUTPUT: «("\"42", "b\"", "c")␤»
 
-Using C<qqww> variant allows you to use quote characters for embedding strings
+Using the C<qqww> variant allows you to use quote characters for embedding strings
 in the word quoting structure:
 
     my $a = 42; say qqww{"$a b" c}.raku; # OUTPUT: «("42 b", "c")␤»


### PR DESCRIPTION
## The problem
It's not obvious that interpolating word quotes break on any interpolation, even without a space.

## Solution provided
I added this remark and the analoguous remark for "sub-strings" in general. Also, I thought an example of being able to interpolate within qww "sub-strings" can give the reader a bit of sanity boost.

