### PR TITLE
Add missing word

### DIFF
--- a/doc/Type/Cool.rakudoc
+++ b/doc/Type/Cool.rakudoc
@@ -1334,7 +1334,7 @@ Coerces the invocant to L<IO::Path|/type/IO::Path>.
 
     method sprintf(*@args)
 
-Returns a string according to a series L<format
+Returns a string according to a series of L<format
 directives|/routine/sprintf#Directives> that are common in many languages;
 the object will be the format string, while the supplied arguments will be
 what's going to be formatted according to it.


### PR DESCRIPTION
The sentence is missing a 'the'.