### PR TITLE
Name the right type of bracket in :100[99, 2, 3]

### DIFF
--- a/doc/Type/Int.rakudoc
+++ b/doc/Type/Int.rakudoc
@@ -27,7 +27,7 @@ separators, but don't carry any meaning:
     0xBEEF_CAFE;   # a strange place
     :2<1010_1010>; # 0d170
 
-Radix notation also supports round and angle brackets which allow you to parse
+Radix notation also supports round and square brackets which allow you to parse
 a string for a given base, and putting together digits into a whole number
 respectively:
 


### PR DESCRIPTION
## The problem

I think angle brackets are `<>`; this text is referring to `[]`.