### PR TITLE
Fix typo in structures documentation

### DIFF
--- a/doc/Language/structures.rakudoc
+++ b/doc/Language/structures.rakudoc
@@ -70,7 +70,7 @@ element, in order, and do whatever the block passed requires,
     # OUTPUT: «[[1 1 [1 1]] [1 1 [1 1]]]␤»
 
 which returns C<1> because it goes to the deeper level and applies C<elems> to
-them, C<deepmap> can perform more complicated operations:
+them, C<duckmap> can perform more complicated operations:
 
     say [[1, 2, [3, 4]], [[5, 6, [7, 8]]]].duckmap:
        -> $array where .elems == 2 { $array.elems };


### PR DESCRIPTION

The sentence is explaining the difference between `deepmap` and `duckmap` as it continues to exemplify `duckmap`, but it was erroneously typed `deepmap`.