### PR TITLE
Document Parameter.modifier

### DIFF
--- a/doc/Type/Parameter.rakudoc
+++ b/doc/Type/Parameter.rakudoc
@@ -373,6 +373,20 @@ returns the empty string.
     say $named-sig.params[0].suffix; # OUTPUT: «!␤»
     say $named-sig.params[1].suffix; # OUTPUT: «␤»
 
+=head2 method modifier
+
+    method modifier(Parameter:D: --> Str:D)
+
+Returns the L<type
+smiley|language/signatures#Constraining_argument_definiteness> (C<:U>, C<:D>, or
+C<:_>) a parameter was declared with. It returns the empty string for the C<:_>
+type smiley.
+
+    my Signature $sig = :(Str:U $a, UInt:D $b, $c);
+    say $sig.params[0].modifier; # OUTPUT: «:U␤»
+    say $sig.params[1].modifier; # OUTPUT: «:D␤»
+    say $sig.params[2].modifier; # OUTPUT: «␤»
+
 =head1 Runtime creation of Parameter objects (6.d, 2019.03 and later)
 
    Parameter.new( ... )


### PR DESCRIPTION
## The problem

[`Parameter.modifier`](https://github.com/rakudo/rakudo/blob/c2449ef601a12eec8014b8893f90ab5151d7c869/src/core.c/Parameter.pm6#L307C5-L313) was undocumented. See #4294.

## Solution provided

This PR documents `Paramete.modifier`.

![image](https://github.com/Raku/doc/assets/22332927/9033c9c0-7721-4e32-a41a-49b19a57314f)


<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
