### PR TITLE
Remove multi new candidate

### DIFF
--- a/doc/Type/Mu.rakudoc
+++ b/doc/Type/Mu.rakudoc
@@ -290,7 +290,6 @@ copied via shallow copy.
 =head2 method new
 
     multi method new(*%attrinit)
-    multi method new($, *@)
 
 Default method for constructing (create + initialize) new objects
 of a class. This method expects only named arguments which are then


### PR DESCRIPTION
## The problem

Remove the `multi method new($, *@)` candidate from the docs. It throws an error when used, and going by the description of `Mu.new` it wasn't meant to be documented.

See #4188.

## Solution provided

Remove `multi method new($, *@)` from the docs.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
