### PR TITLE
Cross reference uniname(s) and uniparse routines

### DIFF
--- a/doc/Language/unicode.rakudoc
+++ b/doc/Language/unicode.rakudoc
@@ -124,6 +124,10 @@ the L<uniparse|/routine/uniparse>:
     say "DIGIT ONE".uniparse;  # OUTPUT: «1␤»
     say uniparse("DIGIT ONE"); # OUTPUT: «1␤»
 
+See L<uniname|/routine/uniname> and L<uninames|/routine/uninames> for routines
+that work in the opposite direction with a single codepoint and multiple
+codepoints respectively.
+
 =head2 Name aliases
 
 Name Aliases are used mainly for codepoints without an official

--- a/doc/Type/Cool.rakudoc
+++ b/doc/Type/Cool.rakudoc
@@ -951,19 +951,21 @@ Available as of the 2021.04 Rakudo compiler release.
     sub uninames(Str:D)
     method uninames()
 
-Returns of a Seq of Unicode names for the all the codepoints in the Str
+Returns of a C<Seq> of Unicode names for the all the codepoints in the C<Str>
 provided.
 
     say ‘»ö«’.uninames.raku;
     # OUTPUT: «("RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK", "LATIN SMALL LETTER O WITH DIAERESIS", "LEFT-POINTING DOUBLE ANGLE QUOTATION MARK").Seq␤»
 
-Note this example, which gets a Seq where each element is a Seq of all the
+Note this example, which gets a C<Seq> where each element is a C<Seq> of all the
 codepoints in that character.
 
     say "Ḍ̇'oh".comb>>.uninames.raku;
     # OUTPUT: «(("LATIN CAPITAL LETTER D WITH DOT BELOW", "COMBINING DOT ABOVE").Seq, ("APOSTROPHE",).Seq, ("LATIN SMALL LETTER O",).Seq, ("LATIN SMALL LETTER H",).Seq)␤»
 
-See L<uniparse|/routine/uniparse> for the opposite direction.
+See L<uniname|/routine/uniname> for the name of the first codepoint of the first
+character in the provided C<Str> and L<uniparse|/routine/uniparse> for the
+opposite direction.
 
 =head2 routine unimatch
 

--- a/doc/Type/Str.rakudoc
+++ b/doc/Type/Str.rakudoc
@@ -494,6 +494,10 @@ around character names is ignored.
     say "I {uniparse 'TWO HEARTS'} Raku"; # OUTPUT: «I 💕 Raku␤»
     'TWO HEARTS, BUTTERFLY'.uniparse.say; # OUTPUT: «💕🦋␤»
 
+See L<uniname|/routine/uniname> and L<uninames|/routine/uninames> for routines
+that work in the opposite direction with a single codepoint and multiple
+codepoints respectively.
+
 Note that unlike C<\c[...]> construct available in string interpolation,
 C<uniparse> does not accept decimal numerical values. Use L<chr|/routine/chr> routine to
 convert those:


### PR DESCRIPTION
## The problem

The routines uniname(s) & uniparse should refer to each other. See #4299.

## Solution provided

The routines uniname(s) & uniparse now reference each other when they're defined. Also surround some types with `C<>`.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
