### PR TITLE
Label links to remove #s from display text in subscripts page

### DIFF
--- a/doc/Language/subscripts.rakudoc
+++ b/doc/Language/subscripts.rakudoc
@@ -161,7 +161,7 @@ address nonexistent elements:
     say array[uint8].new(1, 2)[2] # OUTPUT: «0␤»
 
 To silently skip nonexistent elements in a subscripting operation, see
-L<#Truncating slices> and the L<#:v> adverb.
+L<Truncating slices|#Truncating slices> and the L<C<:v>|#:v> adverb.
 
 =head1 From the end
 
@@ -280,7 +280,7 @@ dimensions>) the subscript is preserved across the slice operation
 =head2 Truncating slices
 
 Referring to nonexistent elements in a slice subscript causes the output C<List>
-to contain undefined values (or L<whatever else| #Nonexistent elements> the
+to contain undefined values (or L<whatever else|#Nonexistent elements> the
 collection in question chooses to return for nonexistent elements):
 
     =begin code
@@ -301,7 +301,7 @@ not currently exist.
     =end code
 
 If you want the resulting slice to only include existing elements, you can
-silently skip the non-existent elements using the L<#:v> adverb.
+silently skip the non-existent elements using the L<C<:v>|#:v> adverb.
 
     =begin code
     my  @letters = <a b c d e f>;
@@ -479,7 +479,8 @@ faster.
 =comment TODO: Add expanded documentation on building complex data structures
                at /language/datastructures.html, and link to it from here.
 
-See L<#method BIND-POS> and L<#method BIND-KEY> for the underlying mechanism.
+See L<method C<BIND-POS>|#method BIND-POS> and L<method C<BIND-KEY>|#method
+BIND-KEY> for the underlying mechanism.
 
 
 =head1 Adverbs
@@ -542,13 +543,13 @@ It can be used on multi-dimensional arrays and hashes:
     say %multi-dim{1;'bar';3}:exists;            # OUTPUT: «False␤»
 
 
-C<:exists> can be combined with the L<#:delete> and L<#:p>/L<#:kv> adverbs - in
-which case the behavior is determined by those adverbs, except that any returned
-element I<value> is replaced with the corresponding L<Bool|/type/Bool>
-indicating element I<existence>.
+C<:exists> can be combined with the L<C<:delete>|#:delete> and
+L<C<:p>|#:p>/L<C<:kv>|#:kv> adverbs - in which case the behavior is determined
+by those adverbs, except that any returned element I<value> is replaced with the
+corresponding L<Bool|/type/Bool> indicating element I<existence>.
 
-See L<#method EXISTS-POS> and L<#method EXISTS-KEY> for the underlying
-mechanism.
+See L<method C<EXISTS-POS>|#method EXISTS-POS> and L<method
+C<EXISTS-KEY>|#method EXISTS-KEY> for the underlying mechanism.
 
 X<|Adverbs,:delete (subscript adverb)>
 =head2 C<:delete>
@@ -585,12 +586,13 @@ say %fruit<apple> :delete($flag);  # deletes the element only if $flag is
                                    # true, but always returns the value.
 =end code
 
-Can be combined with the L<#:exists> and L<#:p>/L<#:kv>/L<#:k>/L<#:v> adverbs -
+It can be combined with the L<C<:exists>|#:exists> and
+L<C<:p>|#:p>/L<C<:kv>#:kv>/L<C<:k>|#:k>/L<C<:v>|#:v> adverbs -
 in which case the return value will be determined by those adverbs, but the
 element will at the same time also be deleted.
 
-See L<#method DELETE-POS> and L<#method DELETE-KEY> for the underlying
-mechanism.
+See L<method C<DELETE-POS>|#method DELETE-POS> and L<method
+C<DELETE-KEY>|#method DELETE-KEY> for the underlying mechanism.
 
 You can use also these adverbs on associative type objects, but it will
 actually do nothing; it will also return C<Nil>
@@ -624,7 +626,7 @@ If you I<don't> want to skip nonexistent elements, use the negated form:
     say %month<Jan Foo Mar>:!p;  # OUTPUT: «(Jan => 1 Foo => (Any) Mar => 3)␤»
     =end code
 
-Can be combined with the L<#:exists> and L<#:delete> adverbs.
+It can be combined with the L<C<:exists>|#:exists> and L<C<:delete>|#:delete> adverbs.
 
 See also the L<pairs|/routine/pairs> routine.
 
@@ -658,7 +660,7 @@ This adverb is commonly used to iterate over slices:
     }
     =end code
 
-Can be combined with the L<#:exists> and L<#:delete> adverbs.
+It can be combined with the L<C<:exists>|#:exists> and L<C<:delete>|#:delete> adverbs.
 
 See also the L<kv|/routine/kv> routine.
 


### PR DESCRIPTION
## The problem

If you're linking within the same page, the `#` will show up in the display text unless you provide a label. This looks out of place in comparison to other links. It also might confuse readers into thinking `#:delete` is the adverb instead of `:delete` for example.

![image](https://github.com/Raku/doc/assets/22332927/3a894152-a830-4ac4-b5a4-b3758ff56c03)

Also change `Can...` to `It can...`.

## Solution provided

Provide a label to links pointing somewhere within the same page in order to remove the `#`s from the display text.

![image](https://github.com/Raku/doc/assets/22332927/b0dc8131-2936-4e02-80f5-695982af5e2f)

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
