### PR TITLE
Improve examples in ff() and related docs

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -2859,7 +2859,7 @@ condition).
 
 A comparison:
 
-    my @list = <A B C>;
+    my @list = <X A B C Y>;
     say $_ if /A/ ff /C/ for @list;    # OUTPUT: «A␤B␤C␤»
     say $_ if /A/ ^ff /C/ for @list;   # OUTPUT: «B␤C␤»
 
@@ -2874,7 +2874,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 Works like L<ff|/routine/ff>, except it does not return C<True> for items matching the
 stop condition (including items that first matched the start condition).
 
-    my @list = <A B C>;
+    my @list = <X A B C Y>;
     say $_ if /A/ ff /C/ for @list;    # OUTPUT: «A␤B␤C␤»
     say $_ if /A/ ff^ /C/ for @list;   # OUTPUT: «A␤B␤»
 
@@ -2889,7 +2889,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 Works like L<ff|/routine/ff>, except it does not return C<True> for items matching either
 the stop or start condition (or both).
 
-    my @list = <A B C>;
+    my @list = <X A B C Y>;
     say $_ if /A/ ff /C/ for @list;    # OUTPUT: «A␤B␤C␤»
     say $_ if /A/ ^ff^ /C/ for @list;  # OUTPUT: «B␤»
 
@@ -2925,7 +2925,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 
 Like L<fff|/routine/fff>, except it does not return true for matches to the left argument.
 
-    my @list = <A B C>;
+    my @list = <X A B C Y>;
     say $_ if /A/ fff /C/ for @list;   # OUTPUT: «A␤B␤C␤»
     say $_ if /A/ ^fff /C/ for @list;  # OUTPUT: «B␤C␤»
 
@@ -2940,7 +2940,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 Like L<fff|/routine/fff>, except it does not return true for matches to the right
 argument.
 
-    my @list = <A B C>;
+    my @list = <X A B C Y>;
     say $_ if /A/ fff /C/ for @list;   # OUTPUT: «A␤B␤C␤»
     say $_ if /A/ fff^ /C/ for @list;  # OUTPUT: «A␤B␤»
 
@@ -2955,7 +2955,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 Like L<fff|/routine/fff>, except it does not return true for matches to either the left or
 right argument.
 
-    my @list = <A B C>;
+    my @list = <X A B C Y>;
     say $_ if /A/ fff /C/ for @list;   # OUTPUT: «A␤B␤C␤»
     say $_ if /A/ ^fff^ /C/ for @list; # OUTPUT: «B␤»
 


### PR DESCRIPTION
## The problem

When quickly looking at a specific example for ff() (or related functions), the examples
provided don't show the core functionality of the function – namely that the function ignores
elements until the first match, and after the second match.

## Solution provided

Add an element in the example array before and after the objects matched, so the
main functionality of the functions is show, in addition to the nuance offered by the
specific variation.