### PR TITLE
Polish the "list prefix" entry

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -53,11 +53,11 @@ level.
     Tight and        | list          | &&
     Tight or         | list          | \|\| ^^ // min max
     Conditional¹     | right         | ?? !! ff ff^ ^ff ^ff^ fff fff^ ^fff ^fff^
-    Item assignment  | right         | = => \+= -= **= xx=
+    Item assignment  | right         | =² => \+= -= **= xx=
     Loose unary      | left          | so not
     Comma            | list          | , :
     List infix       | list          | Z minmax X X~ X* Xeqv ... … ...^ …^ ^... ^… ^...^ ^…^
-    List prefix      | right         | print push say die map substr ... [\+] [*] any Z=
+    List prefix      | right         | =³ ??? !!! ... [\+] [*] Z=
     Loose and        | list          | and andthen notandthen
     Loose or         | list          | or xor orelse
     Sequencer¹       | list          | <== ==> <<== ==>>
@@ -65,11 +65,15 @@ level.
 
 =end table
 
-Note: for the precedence levels marked with C<¹>, there are no operator
+Notes: 
+=item1 for the precedence levels marked with C<¹>, there are no operator
 subroutines with that precedence level (usually because the operators at that
 precedence level are special-cased by the compiler).  This means that you cannot
 access that precedence level when setting the L<precedence of custom
 operators|/language/functions#Precedence>.
+=item1 C<=²> denotes L<item
+assignment|/language/operators#infix_=_(item_assignment)> while C<=³> denotes L<list assignment
+operator|/language/operators#infix_=_(list_assignment)>.
 
 =head1 Operator associativity
 


### PR DESCRIPTION
Addressing https://github.com/Raku/doc/issues/4073

Moreover removing fake "operators" that are mere
functions from the list.
