### PR TITLE
Remove numeric comparison operators from DateTime

### DIFF
--- a/doc/Type/DateTime.rakudoc
+++ b/doc/Type/DateTime.rakudoc
@@ -424,54 +424,10 @@ L«C<Duration>|/type/Duration», preserving the time zone.
     say Duration.new(42) + DateTime.new(:2015year, :3600timezone);
     # OUTPUT: «2015-01-01T00:00:42+01:00␤»
 
-=head2 sub infix:«<=>»
-
-    multi sub infix:«<=>»(DateTime:D \a, DateTime:D \b --> Order:D)
-
-Compares the equivalent instant, returns the Order.
-
-    say DateTime.now <=> DateTime.now; # OUTPUT: «Less␤»
-
 =head2 sub infix:<cmp>
 
     multi sub infix:<cmp>(DateTime:D \a, DateTime:D \b --> Order:D)
 
 Compares the equivalent instant, returns the Order.
-
-=head2 sub infix:«<»
-
-    multi sub infix:«<»(DateTime:D \a, DateTime:D \b --> Bool:D)
-
-Compares the equivalent instant, returns a C<Bool>
-
-=head2 sub infix:«>»
-
-    multi sub infix:«>»(DateTime:D \a, DateTime:D \b --> Bool:D)
-
-Compares the equivalent instant, returns a C<Bool>
-
-=head2 sub infix:«<=»
-
-    multi sub infix:«<=»(DateTime:D \a, DateTime:D \b --> Bool:D)
-
-Compares the equivalent instant, returns a C<Bool>
-
-=head2 sub infix:«>=»
-
-    multi sub infix:«>=»(DateTime:D \a, DateTime:D \b --> Bool:D)
-
-Compares the equivalent instant, returns a C<Bool>
-
-=head2 sub infix:«==»
-
-    multi sub infix:«==»(DateTime:D \a, DateTime:D \b --> Bool:D)
-
-Compares the equivalent instant, returns a C<Bool>
-
-=head2 sub infix:«!=»
-
-    multi sub infix:«!=»(DateTime:D \a, DateTime:D \b --> Bool:D)
-
-Compares the equivalent instant, returns a C<Bool>
 
 =end pod


### PR DESCRIPTION
The numeric comparison operators were previously documented here because they were specifically implemented for this type.

However, this changed with https://github.com/rakudo/rakudo/commit/72856df91b2e1cafb439bcd8bcc7ae46c378d01e .

Now, the fact that this type can be used with these operators is simply a natural consequence of the provided coercion.