### PR TITLE
fix typo in link to :kv adverb

### DIFF
--- a/doc/Language/subscripts.rakudoc
+++ b/doc/Language/subscripts.rakudoc
@@ -587,7 +587,7 @@ say %fruit<apple> :delete($flag);  # deletes the element only if $flag is
 =end code
 
 It can be combined with the L<C<:exists>|#:exists> and
-L<C<:p>|#:p>/L<C<:kv>#:kv>/L<C<:k>|#:k>/L<C<:v>|#:v> adverbs -
+L<C<:p>|#:p>/L<C<:kv>|#:kv>/L<C<:k>|#:k>/L<C<:v>|#:v> adverbs -
 in which case the return value will be determined by those adverbs, but the
 element will at the same time also be deleted.
 


### PR DESCRIPTION
## The problem

The link generated for :kv near https://docs.raku.org/language/subscripts#:k:~:text=in%20which%20case%20the%20return%20value%20will%20be%20determined%20by%20those%20adverbs is malformed.


## Solution provided

The pipe character appears to have been omitted. It is now provided.
