### PR TITLE
Making %% for regexes more noticeable and precise

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -864,8 +864,11 @@ exception will be thrown:
 To more easily match things like comma separated values, you can tack on a
 C<%> modifier to any of the above quantifiers to specify a separator that must
 occur between each of the matches. For example, C<a+ % ','> will match
-C<a> or C<a,a> or C<a,a,a>, etc. To also match trailing delimiters
-( C<a,> or C<a,a,> ), you can use C<%%> instead of C<%>.
+C<a> or C<a,a> or C<a,a,a>, etc. 
+
+C<%%> is like C<%>, with the difference that it can optionally match trailing
+delimiters as well. This means that besides C<a> and C<a,a>, it can also match
+C<a,> and C<a,a,>.
 
 The quantifier interacts with C<%> and controls the number of overall
 repetitions that can match successfully, so C<a* % ','> also matches the empty


### PR DESCRIPTION
The previous phrasing didn't make it clear whether the trailing separator is optional or mandatory.

https://design.raku.org/S05.html line 1118 clarifies that it is optional, which is in accordance with the current behavior.

I made it stand out a bit more by taking it into a separate paragraph.