### PR TITLE
IO::Socket::Async: add documentation for connect-path and listen-path

### DIFF
--- a/doc/Type/IO/Socket/Async.rakudoc
+++ b/doc/Type/IO/Socket/Async.rakudoc
@@ -136,6 +136,15 @@ C<$port>, returning a L<Promise|/type/Promise> that will either be kept with a
 connected L<IO::Socket::Async|/type/IO::Socket::Async> or broken if the connection cannot be
 made.
 
+=head2 method connect-path
+
+    method connect(Str $path --> Promise)
+
+Attempts to connect to a unix domain stream socket specified by C<$path>,
+returning a L<Promise|/type/Promise> that will either be kept with a
+connected L<IO::Socket::Async|/type/IO::Socket::Async> or broken if the connection cannot be
+made.
+
 =head2 method listen
 
     method listen(Str $host, Int $port --> Supply)
@@ -153,6 +162,21 @@ returned represents the underlying listening TCP socket, which can be closed
 using its L<close|/type/Tap#method_close> method. If C<$port> was set to C<0>,
 you can get the port the socket ended up with using its
 L<socket-port|/type/IO::Socket::Async::ListenSocket#method_socket-port> method.
+
+=head2 method listen-path
+
+    method listen-path(Str $path)
+
+Creates a unix domain stream listening socket on the specified C<$path>,
+returning a L<Supply|/type/Supply> to which the accepted client
+L<IO::Socket::Async|/type/IO::Socket::Async>s will be emitted. This
+L<Supply|/type/Supply> should be tapped start listening for client
+connections.
+
+The L<IO::Socket::Async::ListenSocket|/type/IO::Socket::Async::ListenSocket>
+returned by calling the L<tap|/type/Supply#method_tap> method on the supply
+returned represents the underlying listening TCP socket, which can be closed
+using its L<close|/type/Tap#method_close> method.
 
 =head2 method udp
 


### PR DESCRIPTION
This adds documentation for for the `connect-path` and `listen-path` methods of `IO::Socket::Async`

This fixes #4355