### PR TITLE
Mention ordering from dir is arbitrary

### DIFF
--- a/doc/Type/IO/Path.rakudoc
+++ b/doc/Type/IO/Path.rakudoc
@@ -466,7 +466,7 @@ Returns the contents of a directory as a lazy list of C<IO::Path> objects
 representing relative paths, filtered by
 L<smartmatching|/language/operators#infix_~~> their names (as strings) against
 the C<:test> parameter. The path of returned files will be absolute or
-relative depending on what C<$path> is.
+relative depending on what C<$path> is, and are returned in an arbitrary order.
 
 Since the tests are performed against C<Str> arguments, not C<IO>, the tests are
 executed in the C<$*CWD>, instead of the target directory. When testing against


### PR DESCRIPTION
Question came up in raku-beginner Discord about why `dir` was returning files in a "strange order", and it was noted the docs do not mention this.