### PR TITLE
Update `rakudoc -h` output to match current rakudoc

### DIFF
--- a/doc/Programs/02-reading-docs.rakudoc
+++ b/doc/Programs/02-reading-docs.rakudoc
@@ -15,7 +15,7 @@ Note that C<rakudoc> may not be installed automatically depending upon
 how you installed Rakudo Raku.  To install it use C<zef>:
 
 =for code :lang<usage>
-zef install rakudoc
+zef install 'rakudoc:auth<zef:coke>'
 
 =head1 SYNOPSIS
 
@@ -24,32 +24,28 @@ rakudoc [switches] [arguments]
 
 =head1 DESCRIPTION
 
-With no switches or arguments, C<rakudoc> lists its help to C<$*OUT> (C<stdout>):
+With no switches or arguments, C<rakudoc> lists its help to C<$*OUT> (C<stdout>).
+For C«rakudoc:ver<0.2.5>», this output is:
 
 =begin code :lang<output>
-You want to maintain the index?
-To build the index for `rakudoc -r ...`:
-          rakudoc -b
+Usage:
+  rakudoc [-d|--doc-sources=<Directories>] [-D|--no-default-docs] <query>
+  rakudoc -b|--build-index [-d|--doc-sources=<Directories>] [-D|--no-default-docs]
+  rakudoc -V|--version
+  rakudoc -h|--help <ARGUMENTS>
 
-What documentation do you want to read?
-Examples: rakudoc Str
-          rakudoc Str.split
-          rakudoc faq
-          rakudoc path/to/file
-
-You can also look up specific method/routine/sub definitions:
-          rakudoc -r hyper
-          rakudoc -r push
-
-You can bypass the pager and print straight to stdout:
-          rakudoc -n Str
+    <query>                           Example: 'Map', 'IO::Path.add', '.add'
+    -d|--doc-sources=<Directories>    Additional directories to search for documentation
+    -D|--no-default-docs              Use only directories in --doc-sources / $RAKUDOC
+    -b|--build-index                  Index all documents found in doc source directories
 =end code
 
 The text output can be captured and converted to other forms if desired.
 
 If you want to use ANSI escape sequences, which will apply boldface
-and other enhancements to the output, you will have to set
-POD_TO_TEXT_ANSI, which is unset by default
+and other enhancements when the output is printed to a terminal, you
+will have to set the enviornmental variable POD_TO_TEXT_ANSI, which is
+unset by default
 
 =for code :lang<shell>
 export POD_TO_TEXT_ANSI=1


### PR DESCRIPTION
The [programs/02-reading-docs](https://docs.raku.org/programs/02-reading-docs) page showed usage info for the old version of `rakudoc`; this PR updates the info to the current version.