### PR TITLE
Tweak description of `dir` in `IO::Path` doc

### DIFF
--- a/doc/Type/IO/Path.rakudoc
+++ b/doc/Type/IO/Path.rakudoc
@@ -462,11 +462,12 @@ platforms, e.g. Windows, since C<resolve> assumes POSIX semantics.
     multi sub dir(IO()       $path, |c)
     method dir(IO::Path:D: Mu :$test = $*SPEC.curupdir)
 
-Returns the contents of a directory as a lazy list of C<IO::Path> objects
-representing relative paths, filtered by
-L<smartmatching|/language/operators#infix_~~> their names (as strings) against
-the C<:test> parameter. The path of returned files will be absolute or
-relative depending on what C<$path> is, and are returned in an arbitrary order.
+Returns a lazy list of C<IO::Path> objects corresponding to the entries in a
+directory, optionally filtered by L<smartmatching|/language/operators#infix_~~>
+their names I<as strings> per the C<:test> parameter. The order in which the
+filesystem returns entries determines the order of the entries/objects in the
+list. Objects corresponding to special directory entries C<.> and C<..> are not
+included. C<$path> determines whether the objects' paths are absolute or relative.
 
 Since the tests are performed against C<Str> arguments, not C<IO>, the tests are
 executed in the C<$*CWD>, instead of the target directory. When testing against


### PR DESCRIPTION
Quoting the current version of https://docs.raku.org/routine/dir:

> Returns the contents of a directory as a lazy list of IO::Path objects representing relative paths, filtered by [smartmatching](https://docs.raku.org/language/operators#infix_~~) their names (as strings) against the `:test` parameter. The path of returned files will be absolute or relative depending on what `$path` is, and are returned in an arbitrary order.

The first sentence says there's a list of "objects representing relative paths". The second says it's "absolute or relative". That seems wrong. (Or am I misunderstanding something?)

The first sentence mentions "as strings" as a parenthetical but I think the fact the filtering is against strings ought be *emphasized* given the import of what's explained in the paragraph after the one I've quoted, which begins:

> Since the tests are performed against `Str` arguments, not `IO`, the tests are executed in the `$*CWD`, instead of the target directory...

The "arbitrary order" is helpful inasmuch as folk might expect them to be listed in some sorted order but it's not exactly arbitrary but rather whatever the file system chooses for their ordering. I think that ought be mentioned. Though perhaps what I've written goes too far by eliminating the word "arbitrary". What do you think?

And while we're about it, I've also mentioned the fact that the `.` and `..` entries are removed.