### PR TITLE
Rewrite `pick` description of Bool.rakudoc

### DIFF
--- a/doc/Type/Bool.rakudoc
+++ b/doc/Type/Bool.rakudoc
@@ -78,15 +78,18 @@ and any key.
 
 =head2 routine pick
 
-    multi method pick(Bool:U --> Bool:D)
-    multi method pick(Bool:U $count --> Seq:D)
+    multi method pick(Bool:U: --> Bool:D)
+    multi method pick(Bool:U: $count --> Seq:D)
 
-Returns C<True> or C<False> if called without any argument. Otherwise returns
-C<$count> elements chosen at random (without repetition) from the C<enum>. If
-C<*> is passed as C<$count>, or C<$count> is greater than or equal to two, then
-both elements are returned in random order.
+Returns a random pick of C<True> or C<False> if called without any argument:
 
     say Bool.pick;                                    # OUTPUT: «True␤»
+
+Returns a C<Seq> if called with an argument (C<$count>). The C<Seq> has one
+element, C<True> or C<False>, if C<$count> is one, and has two elements, one
+of them C<True>, the other C<False>, in random order, if C<$count> is C<*>
+or greater than or equal to two:
+
     say Bool.pick(1);                                 # OUTPUT: «(False)␤»
     say Bool.pick(*);                                 # OUTPUT: «(False True)␤»
 

--- a/doc/Type/Bool.rakudoc
+++ b/doc/Type/Bool.rakudoc
@@ -87,13 +87,12 @@ If it's called without an argument then it returns just one pick:
 
     say Bool.pick;                                    # OUTPUT: «True␤»
 
-If it's called with a C<$count> of one then it returns a C<Seq> with either
-C<True> or C<False>):
+If it's called with a C<$count> of one then it returns a C<Seq> with just one pick:
 
     say Bool.pick(1);                                 # OUTPUT: «(False)␤»
 
-If C<$count> is C<*> or greater than or equal to two then it returns a two
-element C<Seq> that's either C<True> then C<False> or C<False> then C<True>:
+If C<$count> is C<*> or greater than or equal to two then it returns a C<Seq>
+with I<two> elements -- either C<True> then C<False>, or C<False> then C<True>:
 
     say Bool.pick(*);                                 # OUTPUT: «(False True)␤»
 

--- a/doc/Type/Bool.rakudoc
+++ b/doc/Type/Bool.rakudoc
@@ -81,16 +81,20 @@ and any key.
     multi method pick(Bool:U: --> Bool:D)
     multi method pick(Bool:U: $count --> Seq:D)
 
-Returns a random pick of C<True> or C<False> if called without any argument:
+Returns a random pick of C<True> and/or C<False>.
+
+If it's called without an argument then it returns just one pick:
 
     say Bool.pick;                                    # OUTPUT: «True␤»
 
-Returns a C<Seq> if called with an argument (C<$count>). The C<Seq> has one
-element, C<True> or C<False>, if C<$count> is one, and has two elements, one
-of them C<True>, the other C<False>, in random order, if C<$count> is C<*>
-or greater than or equal to two:
+If it's called with a C<$count> of one then it returns a C<Seq> with either
+C<True> or C<False>):
 
     say Bool.pick(1);                                 # OUTPUT: «(False)␤»
+
+If C<$count> is C<*> or greater than or equal to two then it returns a two
+element C<Seq> that's either C<True> then C<False> or C<False> then C<True>:
+
     say Bool.pick(*);                                 # OUTPUT: «(False True)␤»
 
 =head2 routine roll


### PR DESCRIPTION
I found the existing prose description way too complicated to understand, and when rewriting it decided to separate the description and example that corresponds to one signature from the description and examples that corresponds to the other signature.