### PR TITLE
Change `contains` snippet to a non-trap

### DIFF
--- a/doc/Type/Junction.rakudoc
+++ b/doc/Type/Junction.rakudoc
@@ -79,7 +79,7 @@ Junction of the values that it would usually return.
 Since L<C<.head>|/routine/head> returns a list, the autothreaded version returns
 a C<Junction> of lists.
 
-    (1..3).contains( 2&3 ).say; # OUTPUT: «all(True, True)␤»
+    'walking on sunshine'.contains( 'king'&'sun' ).say; # OUTPUT: «all(True, True)␤»
 
 Likewise, L<C<.contains>|/routine/contains> returns a Boolean; thus, the
 autothreaded version returns a C<Junction> of Booleans. In general, all methods


### PR DESCRIPTION
The earlier example reassured the misconception that it's a good idea to use `contains` to check for elements in a list. I changed it to a more idiomatic use of `contains`.