### PR TITLE
Clarify built-in regexes

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -601,16 +601,22 @@ includes a leading dot: C«<.name>».
 
 =head2 Predefined Regexes
 
-Besides the built-in character classes, the following other rules are built into Raku:
+Besides the built-in character classes, Raku provides built-in
+L<anchors|language/regexes#Anchors> and L<zero-width
+assertions|language/regexes#Zero-width_assertions> defined as named regexes.
+These include C<wb> (word boundary), C<ww> (within word), and C<same> (the next
+and previous character are the same).  See the
+L<anchors|language/regexes#Anchors> and L<zero-width
+assertions|language/regexes#Zero-width_assertions> sections for details.
+
+Raku also provides the two predefined tokens (i.e., regexes that don't
+L<backtrack|language/regexes#Backtracking>) shown below:
 
 =table
-    Regex    | Zero-width | Matches
-    =========+=========================
-    <same>   |  yes       | Matches between two identical characters
-    <wb>     |  yes       | Word boundary
-    <ws>     |  no        | Whitespace, same as: <!ww>\s*
-    <ww>     |  yes       | Within word
-    <ident>  |  no        | Basic identifier (no support for ' or -). Same as: <.alpha> \w*
+    Token    | Regex equivalent |   Description
+    =========+=====================================
+    <ws>     |  <!ww> \s*:      | Word-separating whitespace (including zero, e.g. at EOF)
+    <ident>  |  <.alpha> \w*:   | Basic identifier (no support for ' or -).
 
 =head2 X«Unicode properties|Regexes,<:property>»
 


### PR DESCRIPTION
This PR is my attempt to solve (most of) the issues discussed in #4356.  I've split the discussion of Raku's built-in regexes into two sections: one discussing the anchors/zero-width assertions and one discussing the two built-in tokens (`<ws>` and `<ident>`) – and calling them tokens.  I've also edited the table to show a "rexex equivalent" that uses the `:` backtracking control character.  Hopefully this will help clarify the ratcheting behavior of `<ws>`.

However, this PR does not document the fact that `<ws>` enables backtracking for the _previous_ atom.  That's largely because there's no consensus about whether that behavior is intentional (see raku/problem-solving#390; it seems likely that `<ws>`'s behavior is a bug).