### PR TITLE
Clarify :sigspace behavior for % and %%

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -2420,7 +2420,10 @@ In addition, if whitespace comes after a term but I<before> a quantifier
 (C<+>, C<*>, or C<?>), C«<.ws>» will be matched after every match of the
 term. So, C<foo +> becomes C«[ foo <.ws> ]+». On the other hand, whitespace
 I<after> a quantifier acts as normal significant whitespace; e.g.,
-Z<ignore-code-ws>"C<foo+ >" becomes C«foo+ <.ws>».
+Z<ignore-code-ws>"C<foo+ >" becomes C«foo+ <.ws>».  On the other hand,
+whitespace between a quantifier and the C<%> or C<%%> quantifier modifier
+is not significant.  Thus C<foo+ % ,> does I<not> become C«foo+ <.ws>% ,»
+(which would be invalid anyway); instead, neither of the spaces are significant.
 
 In all, this code:
 


### PR DESCRIPTION
We currently say that space after a quantifier becomes a `<.ws>` call with `:sigspace`.  However, that's not true if the quantifier is modified by `%` or `%%`; In that case, whitespace after the quantifier is ignored (which is logical, since `a+ <.ws>%` isn't valid).

