### PR TITLE
Add ｢…｣, ‘…’, and “…”  as Regex syntax

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -327,14 +327,17 @@ literally matching strings by quoting them in single or double quotes:
 
     / '#!:@' /;         # this regex matches the string of metacharacters '#!:@'
 
-Quoting does not simply turn every metacharacter into a literal, however. This
-is because quotes allow for backslash-escapes and interpolation. Specifically:
-in single quotes, the backslash may be used to escape single quotes and the
-backslash itself; double quotes additionally enable the interpolation of
-variables, and of code blocks of the form C<{...}>. Hence all of this works:
+Quoting does not necessarily turn every metacharacter into a literal, however.
+This is because quotes follow Raku's normal L<rules for
+interpolation|language/quoting#The_Q_lang>. In particular, C<｢…｣> quotes do not
+allow any interpolation; single quotes (either C<'…'> or C<‘…’>) allow the
+backslash to escape single quotes and the backslash itself; and double quotes
+(either C<"…"> or C<“…”>) enable the interpolation of variables and code blocks
+of the form C<{…}>. Hence all of this works:
+
 
     / '\\\'' /;          # matches a backslash followed by a single quote: \'
-
+    / ｢\'｣ /;       # also matches a backslash followed by a single quote
     my $x = 'Hi';
     / "$x there!" /;     # matches the string 'Hi there!'
 


### PR DESCRIPTION
We mention the main quoting options, but left out a couple.  `｢…｣`  is particularly worth documenting, since it makes matching `\`s much easier.