### PR TITLE
Fix IO::Socket::Async::connect-path method name

### DIFF
--- a/doc/Type/IO/Socket/Async.rakudoc
+++ b/doc/Type/IO/Socket/Async.rakudoc
@@ -138,7 +138,7 @@ made.
 
 =head2 method connect-path
 
-    method connect(Str $path --> Promise)
+    method connect-path(Str $path --> Promise)
 
 Attempts to connect to a unix domain stream socket specified by C<$path>,
 returning a L<Promise|/type/Promise> that will either be kept with a


### PR DESCRIPTION
Fix `connect-path` method name in example.