### PR TITLE
Replace incorrect use of "currying" with "priming"

### DIFF
--- a/doc/Language/glossary.rakudoc
+++ b/doc/Language/glossary.rakudoc
@@ -817,6 +817,16 @@ easily applied using the GitHub web user interface. It means you request
 someone to do a git pull from your L<repository|#Repository> to hers. PR
 is its usual acronym.
 
+=head1 X<priming|Reference,priming>
+
+Priming (sometimes called L<partial function
+application|https://en.wikipedia.org/wiki/Partial_application> in other
+programming languages) is the act of creating a new function by providing some
+but not all of the arguments to an existing function.  For example, to create a
+function that takes one argument and adds 42 to it, you could prime the addition
+operator with C<42> as a single argument: C<* + 42>.  See
+L<Whatever-priming|/type/Whatever> and L<assuming|/type/Code#method_assuming>.
+
 =head1 X<property|Reference,property>
 
 In this context, it either refers to an

--- a/doc/Language/subscripts.rakudoc
+++ b/doc/Language/subscripts.rakudoc
@@ -183,7 +183,7 @@ important. Passing a bare negative integer (e.g. C<@alphabet[-1]>) like you
 would do in many other programming languages, throws an error in Raku.
 
 What actually happens here, is that an expression like C<*-1> declares a code
-object via L<Whatever|/type/Whatever>-currying - and the C<[ ]> subscript reacts
+object via L<Whatever|/type/Whatever>-priming - and the C<[ ]> subscript reacts
 to being given a code object as an index, by calling it with the length of the
 collection as argument and using the result value as the actual index. In other
 words, C<@alphabet[*-1]> becomes C<@alphabet[@alphabet.elems - 1]>.

--- a/doc/Type/Code.rakudoc
+++ b/doc/Type/Code.rakudoc
@@ -42,9 +42,10 @@ code object's C<Signature> do not contribute, nor do named parameters.
 
     method assuming(Callable:D $self: |primers)
 
-Returns a C<Callable> that implements the same behavior as the
-original, but has the values passed to C<.assuming> already bound to the
-corresponding parameters.
+Returns a new C<Callable> that has been L<primed|/language/glossary#priming>
+with the arguments passed to C<assuming>.  In other words, the new function
+implements the same behavior as the original, but has the values passed to
+C<.assuming> already bound to the corresponding parameters.
 
     my sub slow($n){ my $i = 0; $i++ while $i < $n; $i };
 

--- a/doc/Type/HyperWhatever.rakudoc
+++ b/doc/Type/HyperWhatever.rakudoc
@@ -13,7 +13,7 @@ than a single one.
 =head1 Standalone term
 
 Just like with L<Whatever|/type/Whatever>, if a
-L<HyperWhatever|/type/HyperWhatever> is used as a term on its own, no currying
+L<HyperWhatever|/type/HyperWhatever> is used as a term on its own, no priming
 is done and the L<HyperWhatever|/type/HyperWhatever> object will be used as-is:
 
     sub foo ($arg) { say $arg.^name }
@@ -33,7 +33,7 @@ being smartmatched.
 
 =head1 Currying
 
-When it comes to currying, the L<HyperWhatever|/type/HyperWhatever> follows the
+When it comes to priming, the L<HyperWhatever|/type/HyperWhatever> follows the
 same rules as L<Whatever|/type/Whatever>. The only difference is
 L<HyperWhatever|/type/HyperWhatever> produces a L<Callable|/type/Callable> with
 a L«C<*@> slurpy|/language/signatures#Flattened_slurpy» as a signature:
@@ -47,7 +47,7 @@ that simply maps each element in the arguments over:
     my &hyper-whatever = sub (*@args) { map *², @args }
     say hyper-whatever(1, 2, 3, 4, 5); # OUTPUT: «(1 4 9 16 25)␤»
 
-When currying, mixing L<HyperWhatever|/type/HyperWhatever> with
+When priming, mixing L<HyperWhatever|/type/HyperWhatever> with
 L<Whatever|/type/Whatever> is not permitted.
 
 =end pod

--- a/doc/Type/Whatever.rakudoc
+++ b/doc/Type/Whatever.rakudoc
@@ -12,8 +12,8 @@ gets its semantics from other routines that accept C<Whatever>-objects
 as markers to do something special. Using the C<*> literal as an operand
 creates a C<Whatever> object.
 
-X<|Syntax,Whatever-currying>
-Much of C<*>'s charm comes from I<Whatever-currying>. When C<*> is used
+X<|Syntax,Whatever-priming>
+Much of C<*>'s charm comes from I<Whatever-priming>. When C<*> is used
 in term position, that is, as an operand, in combination with most
 operators, the compiler will transform the expression into a closure of
 type L<WhateverCode|/type/WhateverCode>, which is actually a
@@ -37,7 +37,7 @@ Calling a method on C<*> also creates a closure:
 =for code
 <a b c>.map: *.uc;      # same as    <a b c>.map: -> $char { $char.uc }
 
-As mentioned before, not all operators and syntactic constructs curry
+As mentioned before, not all operators and syntactic constructs prime
 C<*> (or C<Whatever>-stars) to C<WhateverCode>. In the following cases,
 C<*> will remain a C<Whatever> object.
 
@@ -54,8 +54,8 @@ C<*> will remain a C<Whatever> object.
 
 =end table
 
-The range operators are handled specially. They do not curry with
-C<Whatever>-stars, but they do curry with C<WhateverCode>
+The range operators are handled specially. They do not prime with
+C<Whatever>-stars, but they do prime with C<WhateverCode>
 
     say (1..*).^name;       # OUTPUT: «Range␤»
     say ((1..*-1)).^name;   # OUTPUT: «WhateverCode␤»
@@ -71,8 +71,8 @@ and
     say @a[0..*];           # OUTPUT: «(1 2 3 4)␤»
     say @a[0..*-2];         # OUTPUT: «(1 2 3)␤»
 
-Because I<Whatever-currying> is a purely syntactic compiler transform,
-you will get no runtime currying of stored C<Whatever>-stars into
+Because I<Whatever-priming> is a purely syntactic compiler transform,
+you will get no runtime priming of stored C<Whatever>-stars into
 C<WhateverCode>s.
 
 =for code
@@ -83,7 +83,7 @@ CATCH { default { put .^name, ': ', .Str } };
 # none of these signatures match:␤
 # (Mu:U \v: *%_)»
 
-The use cases for stored C<Whatever>-stars involve those curry-exception
+The use cases for stored C<Whatever>-stars involve those prime-exception
 cases mentioned above. For example, if you want an infinite series by
 default.
 
@@ -93,7 +93,7 @@ my $series = known-lower-limit() ... $max;
 
 A stored C<*> will also result in the generation of a C<WhateverCode> in
 the specific case of smartmatch. Note that this is not actually the
-stored C<*> which is being curried, but rather the C<*> on the left-hand
+stored C<*> which is being primed, but rather the C<*> on the left-hand
 side.
 
 =for code :preamble<sub find-constraint {};>

--- a/doc/Type/WhateverCode.rakudoc
+++ b/doc/Type/WhateverCode.rakudoc
@@ -2,11 +2,11 @@
 
 =TITLE class WhateverCode
 
-=SUBTITLE Code object constructed by Whatever-currying
+=SUBTITLE Code object constructed by Whatever-priming
 
     class WhateverCode is Code { }
 
-C<WhateverCode> objects are the result of L<Whatever|/type/Whatever>-currying.
+C<WhateverCode> objects are the result of L<Whatever|/type/Whatever>-priming.
 See the L<Whatever|/type/Whatever> documentation for details.
 
 When you wish to control how a method or function interprets any I<Whatever


### PR DESCRIPTION
The documentation currently uses the term "currying" to refer to what is more broadly known as "partial function application" (but frequently incorrectly called "currying").  However, Raku generally doesn't use the phrase "partial function application", probably because it's a real mouthful and could be off-putting to people not familiar with functional programming jargon.  Instead, Raku prefers the term "priming", see
[S06](https://design.raku.org/S06.html#Priming).

Accordingly, this PR changes (nearly) all uses of "currying" or related words to the "priming" equivalent; it also adds a "priming" entry to the glossary.

The only two (intentional) uses of "currying" left are in a TODO section of the Haskell-to-Raku guide and in the documentation for the (Rakudo-specific, unspecified) type `CurriedRoleHOW`.

See related discussion with @raiph in the comments to [this StackOverflow answer](https://stackoverflow.com/a/77207543).