### PR TITLE
Explain that List.fmt flattens

### DIFF
--- a/doc/Type/List.rakudoc
+++ b/doc/Type/List.rakudoc
@@ -1395,7 +1395,10 @@ say @a.sum(:wrap);        # OUTPUT: «499999500000␤»
     method fmt($format = '%s', $separator = ' ' --> Str:D)
 
 Returns a string where each element in the list has been formatted according
-to C<$format> and where each element is separated by C<$separator>.
+to C<$format> and where each element is separated by C<$separator>.  If the
+list contains nested sub-lists, then C<fmt> will flatten them before
+formatting each element.  Thus, C<fmt> will treat C<[1, 2, [3, 4]]> as a list
+with 4 elements rather than 3.
 
 For more information about formats strings, see L<sprintf|/routine/sprintf>.
 


### PR DESCRIPTION
This PR clarifies that `List.fmt` flattens the lists it operates on; e.g., `(<a b>, <c d>).fmt('[%s]')` produces `[a] [b] [c] [d]`.  See https://stackoverflow.com/a/69144246

(I really should have clarified the docs when this confused me two years ago, instead of waiting to run into the same confusion again!)