### PR TITLE
Correct for bad links: classtut.rakudoc

### DIFF
--- a/doc/Language/classtut.rakudoc
+++ b/doc/Language/classtut.rakudoc
@@ -27,11 +27,14 @@ my $r1 = Rectangle.new(length => 2, width => 3);
 say $r1.area(); # OUTPUT: «6␤»
 =end code
 
-We define a new I<Rectangle> class using the L<class|/language/objects#Classes> keyword. It has two L<attributes|Attributes>, C<$!length> and C<$!width> introduced with the L<has> keyword. Both default to C<1>. Read only accessor methods are automatically generated. (Note the C<.> instead of C<!> in the declaration, which triggers the generation. Mnemonic: C<!> resembles a closed door, C<.> an open one.)
+We define a new I<Rectangle> class using the L<class|/language/objects#Classes> keyword. It has two L<attributes|#Attributes>, C<$!length> and C<$!width> 
+introduced with the B<has> keyword. Both default to C<1>. Read only accessor methods are automatically generated. 
+(Note the C<.> instead of C<!> in the declaration, which triggers the generation. Mnemonic: C<!> resembles a closed door, C<.> an open one.)
 
 The L<method|/language/objects#Methods> named C<area> will return the area of the rectangle.
 
-It is rarely necessary to explicitly write a constructor. An automatically inherited default constructor called L<new|/language/objects#Object_construction> will automatically initialize attributes from named parameters passed to the constructor.
+It is rarely necessary to explicitly write a constructor. An automatically inherited default constructor called L<new|/language/objects#Object_construction> 
+will automatically initialize attributes from named parameters passed to the constructor.
 
 =head1 The Task example
 


### PR DESCRIPTION
## The problem
Bad links in file `has` and `Attributes` are not source files.

## Solution provided

- `L<>` markup is used for `has`, but probably should be `I`/`B`. Chose `B`
- Missing `#` in attributes link, to refer to heading later
