### PR TITLE
Correct missing links faq.rakudoc

### DIFF
--- a/doc/Language/faq.rakudoc
+++ b/doc/Language/faq.rakudoc
@@ -102,8 +102,8 @@ L<ecosystem|https://raku.land/>.
 
 =head2 Where can I find good documentation on Raku?
 
-See L<the official documentation website|/>
-(especially its L<"Language" section|/language>) as well as the
+See L<the official documentation website|/index>
+(especially its L<"Introduction" section|/introduction>) as well as the
 L<Resources page|https://raku.org/resources/>. You can also consult
 this L<great cheatsheet|https://htmlpreview.github.io/?https://github.com/perl6/mu/blob/master/docs/Perl6/Cheatsheet/cheatsheet.html>.
 
@@ -464,7 +464,7 @@ say $bar; # OUTPUT: «70␤»
 To test whether a variable has any defined values, see
 L<DEFINITE|/language/classtut#index-entry-.DEFINITE> and L<defined|/routine/defined>
 routines. Several other constructs exist that test for definiteness, such as
-L«C<with>, C<orwith>, and C<without>|/syntax/with orwith without»
+L«C<with>, C<orwith>, and C<without>|/language/control#with_orwith_without»
 statements, L«C<//>|/routine/$SOLIDUS$SOLIDUS», L<andthen|/routine/andthen>,
 L<notandthen|/routine/notandthen>, and
 L<orelse|/routine/orelse> operators, as well as


### PR DESCRIPTION
## The problem
3 missing links

## Solution provided

- '/' should be '/index' as otherwise there are other errors
- 'language' will be automatically redirected to 'introduction', so this is a soft error
- 'with orwith with' does not have a composite file, so change to the main source 'language/control', which does

