### PR TITLE
Missing links classtut.rakudoc

### DIFF
--- a/doc/Language/classtut.rakudoc
+++ b/doc/Language/classtut.rakudoc
@@ -27,7 +27,8 @@ my $r1 = Rectangle.new(length => 2, width => 3);
 say $r1.area(); # OUTPUT: «6␤»
 =end code
 
-We define a new I<Rectangle> class using the L<class|/language/objects#Classes> keyword. It has two L<attributes|Attributes>, C<$!length> and C<$!width> introduced with the L<has> keyword. Both default to C<1>. Read only accessor methods are automatically generated. (Note the C<.> instead of C<!> in the declaration, which triggers the generation. Mnemonic: C<!> resembles a closed door, C<.> an open one.)
+We define a new I<Rectangle> class using the L<class|/language/objects#Classes> keyword. It has two L<attributes|#Attributes>, C<$!length> and C<$!width> introduced 
+with the L<has|/syntax/has> keyword. Both default to C<1>. Read only accessor methods are automatically generated. (Note the C<.> instead of C<!> in the declaration, which triggers the generation. Mnemonic: C<!> resembles a closed door, C<.> an open one.)
 
 The L<method|/language/objects#Methods> named C<area> will return the area of the rectangle.
 


### PR DESCRIPTION
## The problem
2 Missing links 

## Solution provided

- Link to Attributes is to the heading in same file, but missing a `#`
- Link text `L<has>` would reference a primary source file `has`, which does not exist. But there is a `/syntax/has` file