### PR TITLE
Update faq.rakudoc

### DIFF
--- a/doc/Language/faq.rakudoc
+++ b/doc/Language/faq.rakudoc
@@ -102,8 +102,8 @@ L<ecosystem|https://raku.land/>.
 
 =head2 Where can I find good documentation on Raku?
 
-See L<the official documentation website|/>
-(especially its L<"Language" section|/language>) as well as the
+See L<the official documentation website|/index>
+(especially its L<"Introduction" section|/introduction>) as well as the
 L<Resources page|https://raku.org/resources/>. You can also consult
 this L<great cheatsheet|https://htmlpreview.github.io/?https://github.com/perl6/mu/blob/master/docs/Perl6/Cheatsheet/cheatsheet.html>.
 


### PR DESCRIPTION
## The problem
2 links listed as missing, but browser handle
1 link listed as missing, but problem is in `language/control`

## Solution provided
- link reference `L< ... |/ >` is probably better shown explicitly as `|/index`
- link reference to `/language` is automatically redirected to `/introduction`. Best to change it
- missing link to `/syntax/with orwith without` arises because the file is not generated. This is because the `X<>` markup in `Language/control` is wrongly specified