### PR TITLE
Update control.rakudoc

### DIFF
--- a/doc/Language/control.rakudoc
+++ b/doc/Language/control.rakudoc
@@ -363,7 +363,7 @@ unless 0 { "0 is false".say }  ; # says "0 is false"
     my $c = 0; say (1, (unless 0 { $c += 42; 2; }), 3, $c); # says "(1 2 3 42)"
     my $d = 0; say (1, (unless 1 { $d += 42; 2; }), 3, $d); # says "(1 3 0)"
 
-=head1 X<C<with orwith without>|Control flow,with;Control flow,orwith;Control flow,without>
+=head1 X<C<with orwith without>|Control flow,with orwith without>
 
 The C<with> statement is like C<if>, but tests for definedness rather than
 truth, and it topicalizes on the condition, much like C<given>:


### PR DESCRIPTION
## The problem
Fix incorrect X<>
see issue #4412



## Solution provided
The `X<>` for **with orwith without** generates **three** syntax files for *with*, *orwith* and *without*. But reference elsewhere is to `with orwith without`.
Change fixes this