### PR TITLE
missing links: Update intro.rakudoc

### DIFF
--- a/doc/Language/intro.rakudoc
+++ b/doc/Language/intro.rakudoc
@@ -5,13 +5,13 @@
 =SUBTITLE Using Raku official documentation
 
 This official documentation covers a variety of presentation styles.
-See the main L</language/> page for a list of documents in
+See the main L</introduction> and L</reference> pages for a list of documents in
 the following styles.
 
 =begin item
 Raku has a high level of L<unicode support|/language/unicode>, including
 many unicode operators. While this may be daunting for those coming from an
-ASCII background, we have some L<help|language/unicode_entry> introducing
+ASCII background, we have some L<help|/language/unicode#Entering_unicode_codepoints_and_codepoint_sequences> introducing
 users to how to use it in your program. Finally, if you would really prefer
 to use ASCII, you can in L<most cases|/language/unicode_ascii>.
 =end item


### PR DESCRIPTION
## The problem
Missing links reported 

## Solution provided
- documentation suite has 'introduction' and 'reference' pages in place of 'language', so update the text to include them
- 'help' should point to the section on entering unicode

