### PR TITLE
missing links: Update numerics.rakudoc

### DIFF
--- a/doc/Language/numerics.rakudoc
+++ b/doc/Language/numerics.rakudoc
@@ -720,7 +720,7 @@ that are guaranteed to be performed atomically, i.e. safe to be executed
 by multiple threads without the need for locking with no risk of data races.
 
 For such operations, the L<atomicint|/type/atomicint> native type is required.
-This type is similar to a plain native L<int|/type/int>, except it is sized such
+This type is similar to a plain native L<int|/native/int>, except it is sized such
 that CPU-provided atomic operations can be performed upon it. On a 32-bit CPU it
 will typically be 32 bits in size, and on an a 64-bit CPU it will typically be
 64 bits in size.


### PR DESCRIPTION
## The problem

- to handle case insensitive OS, documentation for 'int' is at `native/int` not `type/int`.

## Solution provided

change type/int to native/int



<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
