### PR TITLE
missing link - Update operators.rakudoc

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -830,7 +830,7 @@ Technically, not a real operator; it's syntax special-cased in the compiler.
 =head2 methodop C«.=»
 
 A X<mutating method call|Syntax,mutating method call>. C<$invocant.=method> desugars to
-C<$invocant = $invocant.method>, similar to L<=|/routine/=> .
+C<$invocant = $invocant.method>, similar to L<= (item assignment)|/routine/= (item assignment)> .
 
 Technically, not a real operator; it's syntax special-cased in the compiler.
 


### PR DESCRIPTION
## The problem

Link to `/routine/=` does not exist because separate `=` heading does not exist. The heading is `= (item assignment)`

## Solution provided

Change '=' to '= (item assignment)'

