### PR TITLE
missing links - Update regexes.rakudoc

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -329,7 +329,7 @@ literally matching strings by quoting them in single or double quotes:
 
 Quoting does not necessarily turn every metacharacter into a literal, however.
 This is because quotes follow Raku's normal L<rules for
-interpolation|language/quoting#The_Q_lang>. In particular, C<｢…｣> quotes do not
+interpolation|/language/quoting#The_Q_lang>. In particular, C<｢…｣> quotes do not
 allow any interpolation; single quotes (either C<'…'> or C<‘…’>) allow the
 backslash to escape single quotes and the backslash itself; and double quotes
 (either C<"…"> or C<“…”>) enable the interpolation of variables and code blocks
@@ -605,15 +605,15 @@ includes a leading dot: C«<.name>».
 =head2 Predefined Regexes
 
 Besides the built-in character classes, Raku provides built-in
-L<anchors|language/regexes#Anchors> and L<zero-width
-assertions|language/regexes#Zero-width_assertions> defined as named regexes.
+L<anchors|/language/regexes#Anchors> and L<zero-width
+assertions|/language/regexes#Zero-width_assertions> defined as named regexes.
 These include C<wb> (word boundary), C<ww> (within word), and C<same> (the next
 and previous character are the same).  See the
-L<anchors|language/regexes#Anchors> and L<zero-width
-assertions|language/regexes#Zero-width_assertions> sections for details.
+L<anchors|/language/regexes#Anchors> and L<zero-width
+assertions|/language/regexes#Zero-width_assertions> sections for details.
 
 Raku also provides the two predefined tokens (i.e., regexes that don't
-L<backtrack|language/regexes#Backtracking>) shown below:
+L<backtrack|/language/regexes#Backtracking>) shown below:
 
 =table
     Token    | Regex equivalent |   Description
@@ -2930,7 +2930,7 @@ for the third (C<\d+>).
 =end code
 
 C<:ratchet> is enabled by default in C<token>s and C<rule>s; see
-L<grammars|language/grammars> for more details.
+L<grammars|/language/grammars> for more details.
 
 Raku also offers three regex metacharacters to control backtracking at for an
 individual atom.
@@ -2946,7 +2946,7 @@ leaving nothing for the C<a> to match without backtracking.
 The C<:!> metacharacter enables greedy backtracking for the previous atom – that
 is, provides the backtracking behavior that's used when C<:ratchet> is not in
 effect.  C<:!> is closely related to the C<!> L<greedy quantifier
-modifier|language/regexes#Greedy_versus_frugal_quantifiers:_?>; however – unlike
+modifier|/language/regexes#Greedy_versus_frugal_quantifiers:_?>; however – unlike
 C<!>, which can only be used after a quantifier – C<:!> can be used after any
 atom.  For example, C<:!> can be used after an alternation:
 
@@ -2959,9 +2959,9 @@ atom.  For example, C<:!> can be used after an alternation:
 
 The C<:?> metacharacter works exactly like C<:!>, except that it enables frugal
 backtracking.  It is thus closely related to C<?> L<frugal quantifier
-modifier|language/regexes#Greedy_versus_frugal_quantifiers:_?>; again,
+modifier|/language/regexes#Greedy_versus_frugal_quantifiers:_?>; again,
 however C<:?> can be used after non-quantifier atoms.  This includes contexts in
-which C<?> would be the L<zero or one|language/regex#Zero_or_one:_?> quantifier
+which C<?> would be the L<zero or one|/language/regex#Zero_or_one:_?> quantifier
 (instead of providing backtracking control):
 
 =begin code


### PR DESCRIPTION
## The problem

link url requires initial `/`. Several urls missing one.

## Solution provided

add `/` to url, eg. `L<grammars|language/grammars>` to `L<grammars|/language/grammars>`



<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
