### PR TITLE
missing links - Update syntax.rakudoc

### DIFF
--- a/doc/Language/syntax.rakudoc
+++ b/doc/Language/syntax.rakudoc
@@ -859,7 +859,7 @@ for more details on other scopes (C<our>, C<has>).
 
 =head3 Callable declarations
 
-Raku provides syntax for multiple L<C<Callable>|type/Callable> code objects
+Raku provides syntax for multiple L<C<Callable>|/type/Callable> code objects
 (that is, code objects that can be invoked, such as subroutines). Specifically,
 Raku provides syntax for subroutines (both single- and multiple-dispatch), code
 blocks, and methods (again, both single- and multiple-dispatch).
@@ -905,7 +905,7 @@ could be combined into a single C<greet> multi as follows:
     multi greet($name) { say "Hello $name!" }
 
 You may optionally precede C<multi> declarations with a
-L<C<proto>|language/functions#proto> declarations; C<proto>s declare a signature
+L<C<proto>|/language/functions#proto> declarations; C<proto>s declare a signature
 that any call must conform to before being dispatched to candidates.  For
 example, this C<proto> requires that all candidates take at least one positional
 parameter:
@@ -925,10 +925,10 @@ L<C<Block>|/type/Block>s are invocable code objects similar to subroutines but
 intended for small-scale code reuse.  Blocks are created by a code block inside
 of C<{ }> curly braces, optionally preceded by C«->» followed by a signature (or
 C«<->» followed by a signature for L<rw (aka,
-read-write)|type/Routine#trait_is_rw> blocks).  If no signature is provided,
+read-write)|/type/Routine#trait_is_rw> blocks).  If no signature is provided,
 Blocks can accept parameters implicitly by using placeholder variables with the
-L<C<^> twigil|language/variables#The_^_twigil> and the L<C:>
-twigil|language/variables#The_:_twigil>.  Blocks with neither an explicit nor
+L<C<^> twigil|/language/variables#The_^_twigil> and the L<C:>
+twigil|/language/variables#The_:_twigil>.  Blocks with neither an explicit nor
 implicit signature have a default signature of C<$_>.
 
 
@@ -962,7 +962,7 @@ methods are declared by the keyword C<method> followed by a name, followed by an
 optional signature, followed by a code block.  Methods defined inside a class,
 have that class as their default invocant but can override that default (for
 example, to L<constrain the invocant's
-definiteness|language/signatures#Constraining_argument_definiteness>).
+definiteness|/language/signatures#Constraining_argument_definiteness>).
 
     class Greeter {
        method greet($to-whom)           { say "Hello $to-whom!" }
@@ -1098,7 +1098,7 @@ precedence to the C<uc> method.
 
 If a method is called without an invocant (that is, with nothing to the left of
 the C<.>), then it will use the current L<topic
-variable|language/variables#The_$__variable> as its invocant.  For example:
+variable|/language/variables#The_$__variable> as its invocant.  For example:
 
     given 'Foo Fighters' {
        say .substr: 0, 3;  # OUTPUT: «Foo␤»


### PR DESCRIPTION
## The problem

missing `/` in Link url

## Solution provided

add `/` to url eg `L< `... `|language/functions`...`>` to `|/language/functions`


<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
