### PR TITLE
missing links - Update traits.rakudoc

### DIFF
--- a/doc/Language/traits.rakudoc
+++ b/doc/Language/traits.rakudoc
@@ -23,7 +23,7 @@ following forms, depending on the type of the first argument.
 =head2 C<is> applied to classes.
 
 The most common form, involving two classes, one that is being defined and the
-other existing, L<defines parenthood|/syntax/is>. C<A is B>, if both are
+other existing, L<defines parenthood|/routine/is>. C<A is B>, if both are
 classes, defines A as a subclass of B.
 
 L<C<is DEPRECATED>|/type/Attribute#trait_is_DEPRECATED> can be applied to


### PR DESCRIPTION
## The problem
link to `/syntax/is` should be `/routine/is`



## Solution provided
change url
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
