### PR TITLE
missing links - Update traps.rakudoc

### DIFF
--- a/doc/Language/traps.rakudoc
+++ b/doc/Language/traps.rakudoc
@@ -155,7 +155,7 @@ instead:
 
 =head2 Using set subroutines on C<Associative> when the value is falsy
 
-Using L<(cont)|/routine/(cont) , infix  ∋>, L<∋|/routine/(cont),%20infix%20∋>, L<∌|/routine/∌>,
+Using L<(cont)|/routine/(cont), infix ∋>, L<∋|/routine/(cont), infix ∋>, L<∌|/routine/∌>,
 L<(elem)|/routine/(elem), infix ∈>, L<∈|/routine/(elem), infix ∈>, or L<∉|/routine/∉> on classes
 implementing L<Associative|/type/Associative> will return C<False> if the value
 of the key is falsy:


### PR DESCRIPTION
## The problem

Too many spaces in url


## Solution provided
remove spaces 
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
