### PR TITLE
missing link - Update variables.rakudoc

### DIFF
--- a/doc/Language/variables.rakudoc
+++ b/doc/Language/variables.rakudoc
@@ -1314,7 +1314,7 @@ C<$?FILE> and C<$?LINE> are also available from L<CallFrame|/type/CallFrame> as
 the L<C<file>|/type/CallFrame#method_file> and
 L<C<line>|/type/CallFrame#method_line> methods, respectively.
 
-=head3 C<%?RESOURCES>
+=head3 X<C<%?RESOURCES>|Variables,%?RESOURCES>
 
 C<%?RESOURCES> is a B<compile-time> variable available to the code of a
 L<Distribution|/type/Distribution>.
@@ -1349,7 +1349,6 @@ C<META6.json> file:
 ]
 =end code
 
-X<|Variables,%?RESOURCES>
 Every resource file is added to an B<installed> Distribution and is
 accessible using a C<Hash>-like access to C<%?RESOURCES>, returning a
 C<Distribution::Resources> object:


### PR DESCRIPTION
## The problem

Link to `/syntax/%?RESOURCES` in `/type/Distribution/Resource` fails because Composite not generated

## Solution provided

Add X<> markup to Heading


<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
