### PR TITLE
missing links - Update Hash.rakudoc

### DIFF
--- a/doc/Type/Hash.rakudoc
+++ b/doc/Type/Hash.rakudoc
@@ -90,7 +90,7 @@ Hashes can be parameterized with types. You can change the type of the keys like
 
     my %next-prime{Int} = 2 => 3, 3 => 5, 5 => 7, 7 => 11, 11 => 13;
 
-The type of the values defaults to L<Mu>, but you can constrain it to other types:
+The type of the values defaults to L<Mu|/type/Mu>, but you can constrain it to other types:
 
     my Array %lists;
 
@@ -336,7 +336,7 @@ L<named arguments|/type/Capture> and as such won't end up in the C<Hash>:
     my %h .= push(e => 6);
     say %h.raku; # OUTPUT: «{}␤»
 
-Use the corresponding L<subroutine|/language/independent-routines#sub_push> to
+Use the corresponding L<subroutine|/type/independent-routines#sub_push> to
 catch this kind of mistake:
 
     push my %h, f => 7;
@@ -400,7 +400,7 @@ is:
 Returns the default value of the invocant, i.e. the value which is returned when
 a non existing key is used to access an element in the C<Hash>. Unless the
 C<Hash> is declared as having a default value by using the
-L<is default|/syntax/trait is default> trait the method returns the type object
+L<is default|/syntax/is default (Attribute)> trait the method returns the type object
 C<(Any)>.
 
     my %h1 = 'apples' => 3, 'oranges' => 7;


### PR DESCRIPTION
## The problem

3 missing links all different


## Solution provided

- `L<Mu>` needs to point at a source, provided /type/Mu
- `L<subroutine|/language/...>` should be type/independent...
- `is default` points to an incorrect Composite. Found the most probable one. 