### PR TITLE
missing link - Update Perl.rakudoc

### DIFF
--- a/doc/Type/Perl.rakudoc
+++ b/doc/Type/Perl.rakudoc
@@ -7,6 +7,6 @@
     class Perl is Raku { }
 
 A class that provides the same internal language information as the
-L<Raku> class.  Only maintained for historical reasons.
+L<Raku|/type/Raku> class.  Only maintained for historical reasons.
 
 =end pod


### PR DESCRIPTION
## The problem

`L<Raku>` identified as missing link, but web server recognises bare url `/Raku` as `/type/Raku`


## Solution provided

add url for robustness


<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
