### PR TITLE
Remove `X<L<` form in Update operators.rakudoc

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -686,7 +686,7 @@ L<hash|/routine/hash> routine instead:
 
 =head2 circumfix C«[ ]»
 
-The X<L<Array|/type/Array> constructor|Circumfix operators,Array constructor> returns an itemized L<Array|/type/Array> that does not flatten
+The X<Array constructor|Circumfix operators,Array constructor> returns an itemized L<Array|/type/Array> that does not flatten
 in list context. Check this:
 
     say .raku for [3,2,[1,0]]; # OUTPUT: «3␤2␤$[1, 0]␤»


### PR DESCRIPTION
## The problem
See #280 in Raku/doc-website.
- A search for `X<L<` in all documents, it only occurs once - here
- Having markup codes inside other markup codes, as here, should be valid, and it will be in the next iteration of the Renderer. But that might take some time. 
- Better in the short term to create a workaround

## Solution provided
Remove the inner link, which is provided later in the same line anyway. No information lost.