### PR TITLE
Update quoting.rakudoc

### DIFF
--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -2,7 +2,7 @@
 
 =TITLE Quoting constructs
 
-=SUBTITLE Writing strings, word lists, and regexes in Raku
+=SUBTITLE Writing strings and word lists, in Raku
 
 =head1 The Q lang
 
@@ -15,6 +15,9 @@ Most of the time, though, the most you'll need is
 C<'…'>
  or C<"…">,
 described in more detail in the following sections.
+
+For information about quoting as applied in regexes, see the L<regular
+expression documentation|/language/regexes>.
 
 =head2 X<Literal strings: Q|Syntax,Q;Syntax,｢ ｣>
 
@@ -653,9 +656,5 @@ In this example, C<\qq> will do double-quoting interpolation, and C<\qqw> word
 quoting with interpolation. Escaping any other quoting construct as above will
 act in the same way, allowing interpolation in literal strings.
 
-=head1 Regexes
-
-For information about quoting as applied in regexes, see the L<regular
-expression documentation|/language/regexes>.
 
 =end pod


### PR DESCRIPTION
Fixing  misdirection for regex interpolation rules.  I guess the /reference page will be rebuilt with the heading changed here.