### PR TITLE
document Firefox Unicode config in unicode.rakudoc

### DIFF
--- a/doc/Language/unicode.rakudoc
+++ b/doc/Language/unicode.rakudoc
@@ -14,7 +14,7 @@ L<MoarVM string documentation|https://github.com/MoarVM/MoarVM/blob/master/docs/
 
 =begin nested
 For security reasons, browsers (eg., Firefox) may restrict the display of Unicode
-glyphs not in a trusted font, even if the OS has got a font installed that displays the glyph.
+glyphs not in a trusted font, even if the OS has a font installed that displays the glyph.
 To overcome this problem for Firefox, set the `privacy.fingerprintingProtection` config option to `False`.
 =end nested
 

--- a/doc/Language/unicode.rakudoc
+++ b/doc/Language/unicode.rakudoc
@@ -12,6 +12,12 @@ methods.
 For an overview on MoarVM's internal representation of strings, see the
 L<MoarVM string documentation|https://github.com/MoarVM/MoarVM/blob/master/docs/strings.asciidoc>.
 
+=begin nested
+For security reasons, browsers (eg., Firefox) may restrict the display of Unicode
+glyphs not in a trusted font, even if the OS has got a font installed that displays the glyph.
+To overcome this problem for Firefox, set the `privacy.fingerprintingProtection` config option to `False`.
+=end nested
+
 =head1 Filehandles and I/O
 
 X<|Reference,Normalization>


### PR DESCRIPTION
## The problem
Firefox does not display some "rare" Unicode fonts

## Solution provided
Document the work around for Firefox in unicode.rakudoc 

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
