### PR TITLE
remove '::' from links Update Lock.rakudoc

### DIFF
--- a/doc/Type/Lock.rakudoc
+++ b/doc/Type/Lock.rakudoc
@@ -54,7 +54,7 @@ manner; the standard non-blocking behavior of C<await> relies on the
 code following the `await` resuming on a different C<Thread> from the
 pool, which is incompatible with the requirement that a C<Lock> be
 unlocked by the same thread that locked it. See
-L<C<Lock::Async>|/type/Lock::Async>
+L<C<Lock::Async>|/type/Lock/Async>
 for an alternative mechanism that does not have this shortcoming. Other than
 that, the main difference is that C<Lock> mainly maps to operating system
 mechanisms, while C<Lock::Async> uses Raku primitives to achieve similar
@@ -156,7 +156,7 @@ calling C<lock> and C<unlock>. Failing that, use a C<LEAVE> phaser.
 
     method condition(Lock:D: )
 
-Returns a L<condition variable as a C<Lock::ConditionVariable> object|/type/Lock::ConditionVariable>.
+Returns a L<condition variable as a C<Lock::ConditionVariable> object|/type/Lock/ConditionVariable>.
 Check
 L<this article|https://web.stanford.edu/~ouster/cgi-bin/cs140-spring14/lecture.php?topic=locks> or
 L<the Wikipedia|https://en.wikipedia.org/wiki/Monitor_%28synchronization%29>


### PR DESCRIPTION
Changing '::' too '/' in URL of `L<>`
- Having '::' in the **URL part** of `L<...| link url >` markup is a hold-over from Perl5 behaviour.
- There are only two files in the Raku/docs/doc suite that contain `L<>` **URLs** with '::' instead of `/`.
- New RakuDoc v2 renderers will not automatically make this change.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
