### PR TITLE
subst '/' for '::' in URL of L<> Update Async.rakudoc

### DIFF
--- a/doc/Type/Lock/Async.rakudoc
+++ b/doc/Type/Lock/Async.rakudoc
@@ -50,7 +50,7 @@ be available in a non-blocking manner.
     my $l = Lock::Async.new;
     await $l.lock;
 
-Prefer to use L<protect|/type/Lock::Async#method_protect> instead of
+Prefer to use L<protect|/type/Lock/Async#method_protect> instead of
 explicit calls to C<lock> and C<unlock>.
 
 =head2 method unlock
@@ -67,7 +67,7 @@ wants to obtain the lock, but not to execute that code).
     await $l.lock;
     $l.unlock;
 
-Prefer to use L<protect|/type/Lock::Async#method_protect> instead of
+Prefer to use L<protect|/type/Lock/Async#method_protect> instead of
 explicit calls to C<lock> and C<unlock>. However, if wishing to use
 the methods separately, it is wise to use a C<LEAVE> block to ensure
 that C<unlock> is reliably called. Failing to C<unlock> will mean that
@@ -88,10 +88,10 @@ lock it is called on.  It calls C<lock>, does an C<await> to wait for
 the lock to be available, and reliably calls C<unlock> afterwards,
 even if the code throws an exception.
 
-Note that the L<Lock::Async|/type/Lock::Async> itself needs to be
+Note that the L<Lock::Async|/type/Lock/Async> itself needs to be
 created outside the portion of the code that gets threaded and it
 needs to protect. In the first example below,
-L<Lock::Async|/type/Lock::Async> is first created and assigned to
+L<Lock::Async|/type/Lock/Async> is first created and assigned to
 C<$lock>, which is then used I<inside> the L<Promises|/type/Promise>
 code to protect the sensitive code. In the second example, a mistake is
 made, the C<Lock::Async> is created right inside the
@@ -151,10 +151,10 @@ for ^50 -> $thread {
 
     method protect-or-queue-on-recursion(Lock::Async:D: &code)
 
-When calling L<protect|/type/Lock::Async#method_protect> on a C<Lock::Async>
+When calling L<protect|/type/Lock/Async#method_protect> on a C<Lock::Async>
 instance that is already locked, the method is forced to block until the lock
 gets unlocked. C<protect-or-queue-on-recursion> avoids this issue by either
-behaving the same as L<protect|/type/Lock::Async#method_protect> if the lock is
+behaving the same as L<protect|/type/Lock/Async#method_protect> if the lock is
 unlocked or the lock was locked by something outside the caller chain,
 returning C<Nil>, or queueing the call to C<&code> and returning a C<Promise>
 if the lock had already been locked at another point in the caller chain.
@@ -196,7 +196,7 @@ if the lock had already been locked at another point in the caller chain.
 Temporarily resets the Lock::Async recursion list so that it no longer includes
 the lock this method is called on and runs the given C<&code> immediately if
 the call to the method occurred in a caller chain where
-L<protect-or-queue-on-recursion|/type/Lock::Async#method_protect-or-queue-on-recursion>
+L<protect-or-queue-on-recursion|/type/Lock/Async#method_protect-or-queue-on-recursion>
 has already been called and the lock has been placed on the recursion list.
 
     my Lock::Async $lock .= new;


### PR DESCRIPTION
- '::' in URL instead of '/' is Perl5 behaviour. 
- subst '/' for '::'

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
