### PR TITLE
Remove invalid <|w> syntax

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -1197,9 +1197,9 @@ two leading spaces each.
 
 =head2 X«Word boundary|Regexes,<|w>;Regexes,<!|w>»
 
-To match any word boundary, use C«<|w>» or C«<?wb>». This is similar to
+To match any word boundary, use C«<?wb>». This is similar to
 X«C<\b>|Regexes,\b» in other languages. To match the opposite, any
-character that is not bounding a word, use C«<!|w>» or C«<!wb>». This is similar
+character that is not bounding a word, use C«<!wb>». This is similar
 to X«C<\B>|Regexes,\B» in other languages; C<\b> and C<\B> will
 throw an L<C<X::Obsolete>|/type/X::Obsolete> exception from version 6.d of Raku.
 


### PR DESCRIPTION
The docs currently refer to `<|w>` as a synonym for `<?wb>`, but this doesn't seem to be valid syntax – it's not spec'd in Roast, it isn't documented elsewhere, and it doesn't work in Raku AST. So this commit removes it from here.

See https://stackoverflow.com/q/78069120 for details.


