### PR TITLE
Update typesystem.rakudoc "the ... metamethod .^."

### DIFF
--- a/doc/Language/typesystem.rakudoc
+++ b/doc/Language/typesystem.rakudoc
@@ -10,7 +10,7 @@ A type defines a new object by creating a type object that provides an
 interface to create instances of objects or to check values against. Any type
 object is a subclass of L<Any|/type/Any> or L<Mu|/type/Mu>. Introspection
 methods are provided via inheritance from those base classes and the
-introspection metamethod L<.^|/language/operators#methodop_.^>. A new type is
+introspection metamethods (L<.^|/language/operators#methodop_.^>). A new type is
 introduced to the current scope by one of the following type declarators at
 compile time or with the L<metaobject protocol|/language/mop> at runtime. All
 type names must be unique in their scope.


### PR DESCRIPTION
<.^.> reads like a typo.  I don't like my explicit parentheses as breaking the usual style of  links, but the link is unusual.