### PR TITLE
rb-nutshell: clarify break -> last in Flow interruption statements

### DIFF
--- a/doc/Language/rb-nutshell.rakudoc
+++ b/doc/Language/rb-nutshell.rakudoc
@@ -742,9 +742,7 @@ Same as Ruby:
 =item C<next>
 =item C<redo>
 
-=item2 C<break>
-
-This is C<last> in Raku.
+Ruby's C<break> is C<last> in Raku.
 
 =head1 Regular expressions ( regex / regexp )
 


### PR DESCRIPTION
Currently it looks strange:

![image](https://github.com/Raku/doc/assets/20167110/d82dbaa8-a42f-4615-95a6-f00a3bd02974)
