### PR TITLE
Fix broken link in `uniprop`

### DIFF
--- a/doc/Type/Cool.rakudoc
+++ b/doc/Type/Cool.rakudoc
@@ -901,7 +901,7 @@ L«C<Str.samecase>|/type/Str#method_samecase» on it.
     multi sub uniprop(Int:D $code, Stringy:D $propname)
     multi method uniprop(|c)
 
-Returns the L<unicode property|http://userguide.icu-project.org/strings/properties>
+Returns the L<unicode property|https://en.wikipedia.org/wiki/Unicode_character_property>
 of the first character. If no property is specified returns the
 L<General Category|https://en.wikipedia.org/wiki/Unicode_character_property#General_Category>.
 Returns a Bool for Boolean properties. A L<uniprops|/routine/uniprops> routine can be used


### PR DESCRIPTION
Attempts to fix #4449 with a Wikipedia link. There is a more formal [link](https://www.unicode.org/versions/Unicode15.0.0/ch04.pdf) from the Unicode standard itself but i) the next sentence in the documentation refers to the Wikipedia page (a subsection therein) already and ii) formal link is harder to digest as it is a reference document and it's also a PDF.