### PR TITLE
Address formatto in create-cli.rakudoc

### DIFF
--- a/doc/Language/create-cli.rakudoc
+++ b/doc/Language/create-cli.rakudoc
@@ -247,7 +247,7 @@ Here's how it works; with Raku distinguishing between three types of options:
 And here's the signature that produces each type of argument:
 
 =item Boolean options: A L<C<Bool>|/type/Bool> type constraint.
-    Options with a mandatory argument: A type that does not
+=item Options with a mandatory argument: A type that does not
     L<C<.ACCEPT>|/routine/ACCEPTS> a L<C<Bool>|/type/Bool>.
 =item Options with an optional argument: A type that C<.ACCEPTS> a
    C<True> (because passing an option without an argument is equivalent


### PR DESCRIPTION
## The problem

There's a segment in the doc which has two consecutive `=item` lists. It's clear to me the second list is supposed to correspond to the first list, with three items in the second list to match the three items in the first list. But the second list was just two items.

## Solution provided

This PR just fixes what I consider just a clear mistake with a minimalist fix by making the second list be a three item list corresponding to the three items in the first list.

----

It seems to me a better fix would be to turn the two lists into a single list of three items, or, better yet, a table. But rather than write that (more complicated) PR I've decided to wait for responses to this simpler PR.