### PR TITLE
Corrected CX::Oops to CX::Vaya (which matches the rest of the page)

### DIFF
--- a/doc/Type/X/Control.rakudoc
+++ b/doc/Type/X/Control.rakudoc
@@ -15,7 +15,7 @@ C<X::Control> can raise a control exception which is caught by the L<CONTROL
 phaser|/language/phasers#CONTROL> instead of L<CATCH|/language/phasers#CATCH>.
 This allows to define custom control exceptions.
 
-For example, the custom C<CX::Oops> control exception we define below:
+For example, the custom C<CX::Vaya> control exception we define below:
 
 =begin code
 class CX::Vaya does X::Control {


### PR DESCRIPTION
## The problem

For some reason, the documentation referred to CX::Oops, but the code used CX::Vaya.  

## Solution provided

Made documentation match code