### PR TITLE
Update 5to6-nutshell.rakudoc

### DIFF
--- a/doc/Language/5to6-nutshell.rakudoc
+++ b/doc/Language/5to6-nutshell.rakudoc
@@ -287,10 +287,10 @@ first $coderef, @values, :k;
 =begin item
 C<&foo;> I<and> C<goto &foo;> I<for re-using the caller's argument
 list / replacing the caller in the call stack>. Raku can use either
-L<C<callsame>|/language/functions#index-entry-dispatch_callsame> for
+L<C<callsame>|/language/functions#sub_callsame> for
 re-dispatching or
-L<C<nextsame>|/language/functions#index-entry-dispatch_nextsame> and
-L<C<nextwith>|/language/functions#index-entry-dispatch_nextwith>, which have no
+L<C<nextsame>|/language/functions#sub_nextsame> and
+L<C<nextwith>|/language/functions#sub_nextwith>, which have no
 exact equivalent in Perl.
 
 =for code :lang<perl>
@@ -310,7 +310,7 @@ multi foo ( Any $n ) {
 multi foo ( Int $n ) {
     say "Int"; callsame;
 };
-foo(3); # /language/functions#index-entry-dispatch_callsame
+foo(3); # /language/functions#sub_callsame
 =end code
 
 =end item


### PR DESCRIPTION
fix incorrect link destinations. #index-entry_#dispatch_callsame / ditto samewith / callwith do not exist, but sub_callsame sub_samewith sub_callwith do exist

## The problem
fixing bad links

## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
