### PR TITLE
Update 5to6-perlfunc.rakudoc

### DIFF
--- a/doc/Language/5to6-perlfunc.rakudoc
+++ b/doc/Language/5to6-perlfunc.rakudoc
@@ -173,7 +173,7 @@ still be useful.
 
 It does not exist in Raku. For breaking out of C<given> blocks, you should
 probably take a look at
-L<C<proceed> and C<succeed>|/language/control#index-entry-control_flow__proceed-proceed>.
+L<C<proceed> and C<succeed>|/language/control#proceed_and_succeed>.
 
 =head2 X<caller|Other languages,caller - perlfunc>
 


### PR DESCRIPTION
link destination does not exist, changing to one that does

## The problem
Bad link.

The obvious substitution is to the heading

## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
