### PR TITLE
Avoid pod6 markup in table cells

### DIFF
--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -991,12 +991,14 @@ $sig2 = :(:$excludes = ['.', '..']);        # a new Array for every call
 Table showing checks of whether an argument was passed for a given parameter:
 
 =begin table
- Parameter kind | Example | Comment | Check for no arg passed
- ============================================================
- L<Slurpy|https://docs.raku.org/language/signatures#Slurpy_parameters>|`*@array`|Don't check using `.defined`|`if not @array`
- Required|C<$foo>|Can't be omitted|(not applicable)
- Optional|C<@bar = default>|Pick, and check, a suitable defaultN<A suitable default is an Object that has a distinct identity, as may be checked by the L<C<WHICH>|https://docs.raku.org/type/Mu#method_WHICH> method.>|C<if @bar === default {...}>
+ Parameter kind | Example        | Comment                    | Check for no arg passed
+ ===============|================|============================|========================
+ Slurpy         | *@array        | Don't check using .defined | if not @array
+ Required       | $foo           | Can't be omitted           | (not applicable)
+ Optional       | @bar = default | Pick a suitable default¹   | if @bar =:= default
 =end table
+
+¹ A suitable default is an Object that has a distinct identity, as may be checked by the L<C<WHICH>|https://docs.raku.org/type/Mu#method_WHICH> method.
 
 A parameter with a default is always I<optional>, so there is no need to mark it with a C<?> or the C<is optional> trait.
 


### PR DESCRIPTION
Sadly the table in my last commit - when rendered did not produce desired output. My POD6 skills are low, afaict it is not possible to embed markup in table cells. So I have rewritten accordingly and tested locally.

Feel free to edit if you can improve.

https://github.com/Raku/doc/issues/4493
