### PR TITLE
Update operators.rakudoc

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -316,7 +316,7 @@ work:
 
     # And an example of a custom operator:
     sub infix:<space-concat> ($a, $b) { $a ~ " " ~ $b };
-    my $a = 'word1';
+    $a = 'word1';
     $a space-concat= 'word2';                 # OUTPUT: «'word1 word2'␤»
 
 One thing the simple and compound assignment operators have in common is that


### PR DESCRIPTION
## The problem
Example in code will cause an error in RakuAST, redeclaration of 'my $a'

## Solution provided
remove second 'my'
