### PR TITLE
Update ipc.rakudoc Demonstrating how to pipe data into a process using `:in`

### DIFF
--- a/doc/Language/ipc.rakudoc
+++ b/doc/Language/ipc.rakudoc
@@ -63,6 +63,44 @@ and check the exitcode.
         say 'something went wrong';
     }
 
+=head2 Example with shell
+
+Suppose there is a utility that will takes input from STDIN and outputs to STDOUT, but there
+isn't yet a Raku wrapper. For this example, lets use L<sass|https://sass-lang.com/documentation/cli/dart-sass/>,
+which preprocesses a more convenient form of CSS called SCSS into standard CSS. In a terminal the utility would
+be used as
+    sass --stdin
+
+We want to convert multiple strings of SCSS into CSS. The code below only converts one string and captures the output
+into a variable, but it should be obvious how to adapt this into a loop.
+=begin code
+    #| process with utility, first check it exists in the environment
+    my $proc = shell( <<sass --version>>, :out, :merge);
+    exit note 'Cannot run sass' unless $proc.out.slurp(:close) ~~ / \d \. \d+ /;
+    
+    # set up the process for stdin. Note it only needs setting up once.
+    $proc = shell( <<sass --stdin --style=compressed>>, :in, :err, :out );
+
+    # later 
+    # start loop here for multiple SCSS strings
+    my $scss = q:to/SCSS/;
+        div.rendered-formula {
+            display: flex;
+            justify-content: space-around;
+            align-items: center;
+            img.logo {
+                align-self: center;
+            }
+        }
+        SCSS
+    # now pipe the SCSS string into the process as STDIN (remembering to close the pipe)
+    $proc.in.spurt($scss,:close);
+    # extract the output or the error
+    my $error = $_ with $proc.err.slurp(:close);
+    my $ouput = $_ with $proc.out.slurp(:close);
+
+    # end loop here
+=end code
 =head1 The L<C<Proc::Async>|/type/Proc::Async> object
 
 When you need more control over the communication with and from another process,

--- a/doc/Language/ipc.rakudoc
+++ b/doc/Language/ipc.rakudoc
@@ -77,11 +77,11 @@ into a variable, but it should be obvious how to adapt this into a loop.
     #| process with utility, first check it exists in the environment
     my $proc = shell( <<sass --version>>, :out, :merge);
     exit note 'Cannot run sass' unless $proc.out.slurp(:close) ~~ / \d \. \d+ /;
-    
+
     # set up the process for stdin. Note it only needs setting up once.
     $proc = shell( <<sass --stdin --style=compressed>>, :in, :err, :out );
 
-    # later 
+    # later
     # start loop here for multiple SCSS strings
     my $scss = q:to/SCSS/;
         div.rendered-formula {

--- a/doc/Language/ipc.rakudoc
+++ b/doc/Language/ipc.rakudoc
@@ -96,8 +96,8 @@ into a variable, but it should be obvious how to adapt this into a loop.
     # now pipe the SCSS string into the process as STDIN (remembering to close the pipe)
     $proc.in.spurt($scss,:close);
     # extract the output or the error
-    my $error = $_ with $proc.err.slurp(:close);
-    my $ouput = $_ with $proc.out.slurp(:close);
+    my $error  = $_ with $proc.err.slurp(:close);
+    my $output = $_ with $proc.out.slurp(:close);
 
     # end loop here
 =end code

--- a/xt/an-grammar.rakutest
+++ b/xt/an-grammar.rakutest
@@ -69,7 +69,7 @@ sub test-it(Str $output, Str $file) {
                             'once' | 'one' | 'u' | 'uc' | 'ucfirst' | 'udp' | 'ui' | 'unary' | 'uni' |
                             'unicode' | 'uniform' | 'uniprops' | 'unique' | 'unit' | 'unitcheck' |
                             'universally'| 'unix' | 'uri' | 'url' | 'usable' | 'usage' | 'use' |
-                            'useful' | 'used' | 'user' | 'usual' | 'usually' | 'utc' | 'utf8'
+                            'useful' | 'used' | 'user' | 'usual' | 'usually' | 'utc' | 'utf8' | 'utility'
                             {
                             $wanted = "a";
                         }

--- a/xt/pws/words.pws
+++ b/xt/pws/words.pws
@@ -1093,6 +1093,7 @@ prepended
 prepends
 prepost
 preprocessed
+preprocesses
 prev
 primality
 printf
@@ -1250,6 +1251,7 @@ saruman
 sbin
 scalarization
 scalarized
+scss
 sech
 sed
 seekable


### PR DESCRIPTION
## The problem
`proc` (run/shell) is covered in a few places, but the way arbitrary data is piped into spawned process is very cryptic.

## Solution provided
An example is provided that illustrates how to employ a terminal utility that is useful for web page design.