### PR TITLE
Update ipc.rakudoc revise example

### DIFF
--- a/doc/Language/ipc.rakudoc
+++ b/doc/Language/ipc.rakudoc
@@ -78,11 +78,9 @@ into a variable, but it should be obvious how to adapt this into a loop.
     my $proc = shell( <<sass --version>>, :out, :merge);
     exit note 'Cannot run sass' unless $proc.out.slurp(:close) ~~ / \d \. \d+ /;
 
-    # set up the process for stdin. Note it only needs setting up once.
-    $proc = shell( <<sass --stdin --style=compressed>>, :in, :err, :out );
-
-    # later
     # start loop here for multiple SCSS strings
+    # set up the process for stdin.
+    $proc = shell( <<sass --stdin --style=compressed>>, :in, :err, :out );
     my $scss = q:to/SCSS/;
         div.rendered-formula {
             display: flex;


### PR DESCRIPTION
## The problem
Although the example using shell works correctly, applying the 
comments about how to extend for repeated strings does not in fact work

## Solution provided
Minimal change is to revise the comments. 

The following program, which has a loop, does work. Not sure about whether to include this in the example.
```
use v6.d;
#| process with utility, first check it exists
my $proc = shell( <<sass --version>>, :out, :merge);
exit note 'Cannot run sass' unless $proc.out.slurp(:close) ~~ / \d \. \d+ /;
# later 
my @scss = q:to/SCSS/ , q:to/SCC2/;
    div.rendered-formula {
        display: flex;
        justify-content: space-around;
        align-items: center;
        img.logo {
            align-self: center;
        }
    }
    SCSS
    .new { color: red }
    SCC2
for @scss {
    #| set up the process for stdin
    $proc = shell( <<sass --stdin --style=compressed>>, :in, :err, :out );
    $proc.in.spurt($_,:close) ;
    say "Error: $_" with $proc.err.slurp(:close);
    say "Output: $_" with $proc.out.slurp(:close);
}
say "Sass completed";
```