### PR TITLE
Update List.rakudoc

### DIFF
--- a/doc/Type/List.rakudoc
+++ b/doc/Type/List.rakudoc
@@ -262,9 +262,9 @@ Returns the index of the last element.
     method keys(List:D: --> Seq:D)
 
 Returns a sequence of indexes into the list (e.g.,
-C<0..(@list.elems-1)>).
+C<0...(@list.elems-1)>).
 
-    say (1,2,3,4).keys; # OUTPUT: «0..3␤»
+    say (1,2,3,4).keys; # OUTPUT: «(0 1 2 3)␤»
 
 =head2 routine values
 


### PR DESCRIPTION
Under "routine keys":

1) Text shows result as a Range.

2) Example shows `say` output as the creating  literal for a Pair.
