### PR TITLE
subtest Pair can use any order

### DIFF
--- a/doc/Type/Test.rakudoc
+++ b/doc/Type/Test.rakudoc
@@ -648,7 +648,7 @@ subtest {
 =end code
 
 You can also place the description as the first positional argument, or use a
-L<C<Pair>|/type/Pair> with description as the key and subtest's code as the value. This can be
+L<C<Pair>|/type/Pair> with description and code in any order. This can be
 useful for subtests with large bodies.
 
 =begin code :preamble<use Test;>
@@ -658,11 +658,11 @@ subtest 'A bunch of tests', {
     ...
 }
 
-subtest 'Another bunch of tests' => {
+subtest  {
     plan 72;
     ...
     ...
-}
+} => 'Another bunch of tests'
 =end code
 
 =head2 sub todo


### PR DESCRIPTION
## The problem

The original text says that Pairs need to be in a certain order. That's not really true; tested the alternative order and it works anyway.


## Solution provided

Changed example to reflect that too.
