### PR TITLE
Fix for issue 4518, bad example

### DIFF
--- a/doc/Language/variables.rakudoc
+++ b/doc/Language/variables.rakudoc
@@ -1395,7 +1395,7 @@ use Test;
 use MyLib;
 
 my $resources = my-resources;
-isa-ok $resources, Hash;
+isa-ok $resources, Distribution::Resources;
 =end code
 
 The contents of the compile-time hash are thus exposed to the runtime code.


### PR DESCRIPTION
## The problem

Bad example: 

    isa-ok $resources, Hash;

## Solution provided

Correct error by showing the correct class name:

    isa-ok $resources, Distribution::Resources;