### PR TITLE
Update Any.rakudoc

### DIFF
--- a/doc/Type/Any.rakudoc
+++ b/doc/Type/Any.rakudoc
@@ -561,7 +561,7 @@ L<C<Hash>|/type/Hash> would be a L<C<Pair>|/type/Pair>).
 
 The interface of the C<max> method / routine is the same as the one of
 L<min|#routine min>.  But instead of the lowest value, it will return the
-B<highest> value, obviously.
+B<highest> value.
 
     say (1,7,3).max();                # OUTPUT: «7␤»
     say (1,7,3).max({1/$_});          # OUTPUT: «1␤»


### PR DESCRIPTION
Deleting 'obviously' because, if the sentence was obvious, it could be deleted entirely.