### PR TITLE
Update MultipleInheritance.rakudoc

### DIFF
--- a/doc/Type/Metamodel/MultipleInheritance.rakudoc
+++ b/doc/Type/Metamodel/MultipleInheritance.rakudoc
@@ -38,9 +38,9 @@ L<composed|/language/mop#Composition_time_and_static_reasoning> typed.
 Otherwise an exception of type L<C<X::Inheritance::NotComposed>|/type/X::Inheritance::NotComposed>
 is thrown.
 
-=head2 method parents
+=head2 method ^parents
 
-    method parents($obj, :$all, :$tree)
+    method ^parents($obj, :$all, :$tree)
 
 Returns the list of parent classes. By default it stops at L<C<Cool>|/type/Cool>, L<C<Any>|/type/Any> or
 L<C<Mu>|/type/Mu>, which you can suppress by supplying the C<:all> adverb. With C<:tree>,


### PR DESCRIPTION
Carets are good for `parents`.