### PR TITLE
Explicitly say alternations/conjunctions don't scope adverbs

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -2314,6 +2314,11 @@ Square brackets and parentheses limit the scope of an adverb:
     / (:i a b) c /;         # matches 'ABc' but not 'ABC'
     / [:i a b] c /;         # matches 'ABc' but not 'ABC'
 
+Alternations and conjunctions, and their branches, have no impact on the scope of an adverb:
+
+/  :i a | b c /;            # matches 'a', 'A', 'bc', 'Bc', 'bC' or 'BC'
+/ [:i a | b] c /;           # matches 'ac', 'Ac', 'bc', or 'Bc' but not 'aC', 'AC', 'bC' or 'BC'
+
 When two adverbs are used together, they keep their colon at the front
 
     "þor is Þor" ~~ m:g:i/þ/;  # OUTPUT: «(｢þ｣ ｢Þ｣)␤»


### PR DESCRIPTION
PR corresponding to half of what I meant by "Open a new doc issue?" in Rakudo issue [Lining up `|` in a regex doesn't work as expected when using adverbs](https://github.com/rakudo/rakudo/issues/4147).

Quoting @zerodogg from the Rakudo issue:

> The [documentation for raku](https://docs.raku.org/language/regexes#Quoted_lists_are_LTM_matches) on regexes and `|` matches states that "If the first branch is an empty string, it is ignored.". This doesn't appear to be working when using an adverb like `:i`

This is true, so I've opened a new Rakudo issue narrowly focused on the hope that that can be fixed as part of the RakuAST work and doesn't warrant altering the doc.

That said, @jnthn went on to say:

> One could maybe argue that `|` should imply adverb scoping ... Perhaps a docs issue would be in order if the scoping of adverbs isn't clear there.

@jnthn wasn't implying Raku should change how things are (alternations/conjunctions do _not_ impact adverb scoping) but I do think some might think adverbs are scoped, even down to an individual branch of an alternation/conjunction. I demonstrated/discussed this a bit in the new issue https://github.com/rakudo/rakudo/issues/5667

So I felt it was appropriate to write this PR as part of closing the old issue.

If y'all think it's better to not change the doc at all, that's fine too.