### PR TITLE
NativeCall void function returns Mu type object

### DIFF
--- a/doc/Language/nativecall.rakudoc
+++ b/doc/Language/nativecall.rakudoc
@@ -91,8 +91,10 @@ an example.
 Here, we have declared that the function takes two 32-bit integers and returns a
 32-bit integer. You can find the other types that you may pass in the
 L<native types|/language/nativetypes> page. Note that the lack of a C<returns>
-trait is used to indicate C<void> return type. Do I<not> use the C<void> type
-anywhere except in the C<Pointer> parameterization.
+trait may be used to indicate I<C> C<void> return; the actual return is a C<Mu>
+type object.
+
+Do I<not> use the C<void> type anywhere except in a C<Pointer> parameterization.
 
 For strings, there is an additional C<encoded> trait to give some extra hints on
 how to do the marshaling.


### PR DESCRIPTION
Doc' that NativeCall's `returns` trait's default is `Mu:U`.

Emphasize `void`-is-only-for-pointers with its own paragraph.

Ref #5293