### PR TITLE
Remove allusions to "eigenstate".

### DIFF
--- a/doc/Language/faq.rakudoc
+++ b/doc/Language/faq.rakudoc
@@ -537,7 +537,7 @@ already specified in the signature.
 X<|Reference,Junction (FAQ)>
 =head2 How can I extract the values from a Junction?
 
-If you want to extract the values (eigenstates) from a
+If you want to extract the values from a
 L<C<Junction>|/type/Junction>, you are probably doing something wrong and
 should be using a L<C<Set>|/type/Set> instead.
 
@@ -546,13 +546,13 @@ Junctions are meant as matchers, not for doing algebra with them.
 If you want to do it anyway, you can abuse autothreading for that:
 
 =begin code
-sub eigenstates(Mu $j) {
-    my @states;
-    -> Any $s { @states.push: $s }.($j);
-    @states;
+sub junction-values(Mu $j) {
+    my @values;
+    -> Any $s { @values.push: $s }.($j);
+    @values;
 }
 
-say eigenstates(1|2|3).join(', ');
+say junction-values(1|2|3).join(', ');
 # prints 1, 2, 3 or a permutation thereof
 =end code
 


### PR DESCRIPTION
Larry deliberately used the name "Junctions", not "Superpositions" because he felt officially leaning on the quantum analogy was a mistake.

I think the use of the word "eigenstate" is appropriate in its one use on the Junctions page but not in its uses in this FAQ question.