### PR TITLE
Finish s/`<|w>`/`<?wb>`/ in doc (headings.rakutest)

### DIFF
--- a/xt/headings.rakutest
+++ b/xt/headings.rakutest
@@ -27,7 +27,7 @@ for @files -> $file {
             # ignore "class X::TypeCheck" and the like
             $title ~~ s:g/^ ( class | role | module | enum | package ) \s+ \S+//;
             # proper names, macros, acronyms, and other exceptions
-            $title ~~ s:g/ <|w> (
+            $title ~~ s:g/ <?wb> (
                 I
                 | Raku | RakuAST | Rakudo | RakuDoc | Perl 6 | Pod6 | P6 | C3 | NQP
                 | AST | EVAL | PRE | POST | CLI | MOP
@@ -49,10 +49,10 @@ for @files -> $file {
                 | ( <:Lu><:L>+ "::" )+ <:Lu><:L>+
                 # these seem fishy?
                 | Socket
-            ) <|w> //;
-            $title ~~ s:g/ <|w> <[ C ]> \< .*? \> //;
+            ) <?wb> //;
+            $title ~~ s:g/ <?wb> <[ C ]> \< .*? \> //;
             # ignore known classes like "Real" and "Date" which are capitalized
-            my @words = $title ~~ m:g/ <|w> ( <:Lu> \S+ ) /;
+            my @words = $title ~~ m:g/ <?wb> ( <:Lu> \S+ ) /;
             for @words -> $word {
                 # if it exists, skip it
                 try {


### PR DESCRIPTION
While `<|w>` works in Rakudo, it isn't official Raku, and while I personally like it, there's a chance it will go away. Its semantics are the same as `<?wb>`, which _is_ official Raku, so I've switched to that. (See also https://github.com/Raku/doc/commit/5c1a147e68e800a35baea3505f4cdc14fee63efa.)

I meant my prior related commit (which changed the regex doc page) to be a PR because I wasn't 100% sure about the `X<...>` stuff and regardless of that I felt it could still do with a quick check by someone else. But I clicked the wrong button. Otoh, once I'd done that I thought it would almost certainly work and be wanted, and if it didn't it wouldn't be a big deal and would be easy for me to spot it even if no one else does, and to fix it.

But for _this_ change I'm making sure I do it as a PR. I still expect it to work, but it may not, and the consequence of that might be a waste of others' time, and even if it does it might not be wanted.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
