### PR TITLE
Small fixes in JS comparison

### DIFF
--- a/doc/Language/js-nutshell.rakudoc
+++ b/doc/Language/js-nutshell.rakudoc
@@ -122,7 +122,7 @@ function logDupe() {
     console.log(foo);
 }
 
-logDupe(2);       // OUTPUT: 2
+logDupe();       // OUTPUT: 2
 console.log(foo); // OUTPUT: 1
 =end code
 


### PR DESCRIPTION
## The problem

There are a few typos / small issues in the Raku <-> JS comparison:

- `logDupe` does not take any args, and calling it with one (particularly `2`) may be confusing.
- The dice roll will never sum to 16 (and 16 is also not boxcars) since each die only rolls up to 6

## Solution provided

- Remove redundant, possibly confusing, argument to `logDupe` function
- Change "Boxcars!" condition to `diceRoll === 12` and `$dice-roll == 12`, respectively

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
