### PR TITLE
Replace Pod6 with Rakudoc

### DIFF
--- a/doc/Language/pod.rakudoc
+++ b/doc/Language/pod.rakudoc
@@ -1,28 +1,28 @@
 =begin pod :kind("Language") :subkind("Language") :category("reference")
 
-=TITLE Pod6
+=TITLE Rakudoc (aka Pod6)
 
 =SUBTITLE An easy-to-use markup language for documenting Raku modules and programs
 
-Pod6 is an easy-to-use markup language. It can be used for
+Rakudoc is an easy-to-use markup language. It can be used for
 writing language documentation, for documenting programs and modules, as
 well as for other types of document composition.
 
-Every Pod6 document has to begin with C<=begin pod> and end with C<=end pod>.
+Every Rakudoc document has to begin with C<=begin pod> and end with C<=end pod>.
 Everything between these two delimiters will be processed and used to generate
 documentation.
 
 =begin code :lang<rakudoc>
 =begin pod
 
-A very simple Pod6 document
+A very simple Rakudoc document
 
 =end pod
 =end code
 
 =head1 Block structure
 
-A Pod6 document may consist of multiple Pod6 blocks. There are four ways to
+A Rakudoc document may consist of multiple Rakudoc blocks. There are four ways to
 define a block: delimited, paragraph, abbreviated, and declarator; the first three
 yield the same result but the fourth differs. You can use whichever form is most
 convenient for your particular documentation task.
@@ -75,7 +75,7 @@ outside of strings. Hash keys need not be quote-delimited unless they contain
 significant whitespace. Strings entered inside angle brackets become lists if
 any whitespace is used inside the angle brackets.
 
-All option keys and values must be constants since Pod6 is a
+All option keys and values must be constants since Rakudoc is a
 specification language, not a programming language. Specifically, option
 values cannot be closures. See L<Synopsis 2|https://design.raku.org/S02.html>
 for details of the various
@@ -85,7 +85,7 @@ The configuration section may be extended over subsequent
 lines.
 Each subsequent line must start
 with an C<=> in the first virtual column, meaning that it must vertically
-align with the C<=> of the Pod6 Block declaration,
+align with the C<=> of the Rakudoc Block declaration,
 and it must be followed
 by at least one horizontal whitespace character.
 
@@ -138,7 +138,7 @@ Top Level Heading
 Abbreviated blocks begin with an C<=> sign, which is followed immediately by the
 C<typename> of the block. All following data are part of the contents of the
 block, thus configuration data B<cannot> be specified for an I<abbreviated>
-block. The block ends at the next Pod6 directive or the first blank line.
+block. The block ends at the next Rakudoc directive or the first blank line.
 
 =begin code :lang<rakudoc>
 =head1 Top level heading
@@ -215,7 +215,7 @@ L<S26-documentation/block-leading-user-format.t|https://github.com/Raku/roast/bl
 
 =head1 Block types
 
-Pod6 offers a wide range of standard block types.
+Rakudoc offers a wide range of standard block types.
 
 =head2 Headings
 
@@ -326,7 +326,7 @@ and C<=end code>
 
 =head2 I/O blocks
 
-Pod6 provides blocks for specifying the input and output of programs.
+Rakudoc provides blocks for specifying the input and output of programs.
 
 The C<=input> block is used to specify pre-formatted keyboard input,
 which should be rendered without re-justification or squeezing of whitespace.
@@ -338,7 +338,7 @@ which should also be rendered without re-justification or whitespace-squeezing.
 
 =head3 Unordered lists
 
-Lists in Pod6 are specified as a series of C<=item> blocks.
+Lists in Rakudoc are specified as a series of C<=item> blocks.
 
 For example:
 
@@ -459,9 +459,9 @@ As you can see, folk wisdom is often of dubious value.
 Check out this page for documentation related to L<Tables|/language/tables>
 Z<Eventually copy everything from tables.rakudoc and put it here>
 
-=head2 Pod6 comments
+=head2 Rakudoc comments
 
-Pod6 comments are comments that Pod6 renderers ignore.
+Rakudoc comments are comments that Rakudoc renderers ignore.
 
 Comments are useful for I<meta>documentation (documenting the documentation).
 Single-line comments use the C<=comment> marker:
@@ -507,7 +507,7 @@ documentation, publishing, source components, or meta-information.
 
 Formatting codes provide a way to add inline mark-up to a piece of text.
 
-All Pod6 formatting codes consist of a single capital letter followed immediately
+All Rakudoc formatting codes consist of a single capital letter followed immediately
 by a set of single or double angle brackets; Unicode double angle brackets may
 be used.
 
@@ -704,7 +704,7 @@ Z<If used will bust Pod::To::BigPage>
 
 =head2 Unicode
 
-To include Unicode code points or HTML5 character references in a Pod6 document,
+To include Unicode code points or HTML5 character references in a Rakudoc document,
 enclose them in C<E< >>
 
 C<E< >> can enclose a number, which is treated as the decimal Unicode
@@ -857,7 +857,7 @@ You can omit the C<=Text> portion:
 raku --doc input.rakudoc > output.txt
 =end code
 
-You can even embed Pod6 directly in your program and add the
+You can even embed Rakudoc directly in your program and add the
 traditional Unix command line "--man" option to your program with a
 multi MAIN subroutine like this:
 
@@ -867,20 +867,20 @@ multi MAIN(Bool :$man) {
 }
 =end code
 
-Now C<myprogram --man> will output your Pod6 rendered as a man page.
+Now C<myprogram --man> will output your Rakudoc rendered as a man page.
 
 =head1 Accessing Pod
 
-In order to access Pod6 documentation from within a Raku program the
+In order to access Rakudoc documentation from within a Raku program the
 special C<=> twigil, as documented
 in the L<variables section|/language/variables#The_=_twigil>, must be used.
 
-The C<=> twigil provides the introspection over the Pod6 structure,
+The C<=> twigil provides the introspection over the Rakudoc structure,
 providing a L<C<Pod::Block>|/type/Pod::Block> tree root from which it is possible
-to access the whole structure of the Pod6 document.
+to access the whole structure of the Rakudoc document.
 
 As an example, the following piece of code introspects
-its own Pod6 documentation:
+its own Rakudoc documentation:
 
 =begin code
 =begin pod


### PR DESCRIPTION
## The problem

References to Pod6 in this document are outdated since the new name is Rakudoc

## Solution provided

Replaced all occurences of `Pod6` with `Rakudoc`
