### PR TITLE
Update --man code example in pod.rakudoc

### DIFF
--- a/doc/Language/pod.rakudoc
+++ b/doc/Language/pod.rakudoc
@@ -862,8 +862,10 @@ traditional Unix command line "--man" option to your program with a
 multi MAIN subroutine like this:
 
 =begin code
+use Pod::To::Text;
+
 multi MAIN(Bool :$man) {
-    run $*EXECUTABLE, '--doc', $*PROGRAM;
+    say pod2text $=pod;
 }
 =end code
 


### PR DESCRIPTION
## The problem
The `--man` code example provided in the Rendering Pod to Text section has some issues:
* It will only render Pod in the file being executed by Raku. This is
problematic if you intend to distribute the program via Zef, as `$*PROGRAM` will
not point to the original script but a wrapper without the Pod instead.
* Performance issues from invoking Raku.

## Solution provided

* Print the output of `pod2text $=pod` using `Pod::To::Text` directly. This way
we do not have to rely on `$*PROGRAM` pointing to our script file. It's also
faster than re-invoking Raku.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
