### PR TITLE
fix reference to BIND-* methods

### DIFF
--- a/doc/Language/containers.rakudoc
+++ b/doc/Language/containers.rakudoc
@@ -239,8 +239,10 @@ lexpad at runtime.
 
 The answer is that binding to array elements is recognized at the syntax
 level and instead of emitting code for a normal binding operation, a special
-method (called L<C<BIND-KEY>|/routine/BIND-KEY>) is called on the
-array. This method handles binding to array elements.
+method (called L<C<BIND-POS>|/routine/BIND-POS>) is called on the
+array. This method handles binding to array elements. There is also an
+equivalent method for binding to hash elements as well (called
+L<C<BIND-KEY>|/routine/BIND-KEY>)
 
 Note that, while supported, one should generally avoid directly binding
 uncontainerized things into array elements. Doing so may produce


### PR DESCRIPTION
The text claimed that BIND-KEY is used to bind to an array element, but it is actually BIND-POS. Add a new sentence that still mentions BIND-KEY and what it is actually used for, since it's closely related.