### PR TITLE
Update create-cli.rakudoc

### DIFF
--- a/doc/Language/create-cli.rakudoc
+++ b/doc/Language/create-cli.rakudoc
@@ -452,7 +452,7 @@ say 'Verbosity ', ($verbose ?? 'on' !! 'off');
 Note that this is only appropriate if you can get by with just a single
 (only) C<sub MAIN>.
 
-=head2 X<sub USAGE|Tutorial,USAGE>X<|Tutorial,$*USAGE>
+=head2 X<sub USAGE|Tutorial,USAGE> and X<C«$*USAGE»|Tutorial,$*USAGE>
 
 If no multi candidate of C<MAIN> is found for the given command line
 parameters, the sub C<USAGE> is called. If no such method is found,


### PR DESCRIPTION
## The problem
regularise use of multiple X in `=head`
as in #4550

## Solution provided
as suggested in #4550
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
