### PR TITLE
Update unicode_ascii.rakudoc

### DIFF
--- a/doc/Language/unicode_ascii.rakudoc
+++ b/doc/Language/unicode_ascii.rakudoc
@@ -42,7 +42,7 @@ aren't decimal digit characters, so can't be combined.) For example:
   my $var = ⅒ + 2 + Ⅻ; # here ⅒ is No and Rat and Ⅻ is Nl and Int
   say $var;              # OUTPUT: «14.1␤»
 
-=head1 X<|Language,Whitespace> Whitespace characters
+=head1 X<Whitespace characters|Language,Whitespace>
 
 Besides spaces and tabs, you can use any other unicode whitespace
 character that has the C<Zs> (Separator, space), C<Zl> (Separator,


### PR DESCRIPTION
## The problem
Regularise X<> in headings
Placing the term whitespace outside the `X<>` has an effect on the rendering in the title. It seems to be the only example of this form in a heading in all the Raku/docs/doc repo. Tested with `rak '/^\=head\d\s+X\<\| /' raku-docs` (**raku-docs** is a local clone of Raku/docs)



## Solution provided
Placing the term whitespace inside the `X<>` 
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
