### PR TITLE
Add examples of octal Unicode entry

### DIFF
--- a/doc/Language/unicode.rakudoc
+++ b/doc/Language/unicode.rakudoc
@@ -100,12 +100,18 @@ Reading with this type of encoding and encoding them back to UTF8-C8 will give y
 
 Please note that this encoding so far is not supported in the JVM implementation of Rakudo.
 
-=head1 Entering unicode codepoints and codepoint sequences
+=head1 Defining Unicode characters with Unicode codepoints and codepoint sequences
 
-=head2 Entering codepoints by number
+X<|inserting into strings|Language, decimal codepoint;\
+Language, hexadecimal codepoint;\ Language, octal codepoint>
+=head2 Entering codepoints in strings by number
 
-You can enter Unicode codepoints by number (decimal as well as hexadecimal or octal). For example, the character named
-"latin capital letter ae with macron" has decimal codepoint 482, hexadecimal codepoint 0x1E2, and octal codepoint 0o742:
+X<|Syntax,\c[N+] Unicode decimal codepoint>
+X<|Syntax,\xN+ Unicode hexadecimal codepoint>
+X<|Syntax,\oN+ Unicode octal codepoint>
+You can insert Unicode codepoints by number (decimal or hexadecimal or octal). 
+For example, the character named "latin capital letter ae with macron" has 
+decimal codepoint 482, hexadecimal codepoint 0x1E2, and octal codepoint 0o742:
 
     say "\c[482]"; # OUTPUT: «Ǣ␤»
     say "\x1E2";   # OUTPUT: «Ǣ␤»
@@ -123,33 +129,30 @@ For example:
 The same type of result would occur for the octal version if the ending character
 was not in the set (0..7).
 
-Codepoint sequences can be made in a single string by following a codepoint entry
-with others or intermingled with single characters, words, and spaces as normal
-text. Such codepoint entries are very useful for users who not have ready access to
-a Unicode capable keyboard.
+=head2 Inserting codepoints in strings by name
 
-=head2 Entering codepoints by name
-
-You can also access Unicode codepoints by name (which may be necessary when a 
-Unicode character has more than one format).
-Raku supports all Unicode names. X<|Syntax,\c[] unicode name>
+You can also access Unicode codepoints by name, and
+Raku supports all Unicode names. X<|Syntax,\c[some name] Unicode name>
 
     say "\c[PENGUIN]"; # OUTPUT: «🐧␤»
     say "\c[BELL]";    # OUTPUT: «🔔␤» (U+1F514 BELL)
 
-All Unicode codepoint names/named seq/emoji sequences are now case-insensitive:
+All Unicode codepoint names and name sequences sequences are now case-insensitive:
 [Starting in Rakudo 2017.02]
 
     say "\c[latin capital letter ae with macron]"; # OUTPUT: «Ǣ␤»
     say "\c[latin capital letter E]";              # OUTPUT: «E␤» (U+0045)
 
-You can specify multiple characters by using a comma separated list with C<\c[]>. You
-can combine numeric and named styles as well:
+(However, those names will be shown in upper-case when interrogating the character's
+uniname.)
+
+You can specify multiple characters by using a comma separated list inside
+a single C<\c[]> instance. You can combine numeric and named styles as well:
 
     say "\c[482,PENGUIN]"; # OUTPUT: «Ǣ🐧␤»
 
 In addition to using C<\c[]> inside interpolated strings, you can also use
-the L<uniparse|/routine/uniparse>:
+the L<uniparse|/routine/uniparse> to show its character:
 
     say "DIGIT ONE".uniparse;  # OUTPUT: «1␤»
     say uniparse("DIGIT ONE"); # OUTPUT: «1␤»
@@ -157,6 +160,22 @@ the L<uniparse|/routine/uniparse>:
 See L<uniname|/routine/uniname> and L<uninames|/routine/uninames> for routines
 that work in the opposite direction with a single codepoint and multiple
 codepoints, respectively.
+
+=head2 Codepoint sequences
+
+Codepoint sequences can be inserted into a single string by following a codepoint entry
+with others or intermingling them with single characters, words, and spaces as normal
+text. Such codepoint entries are very useful for users who do not have ready access to
+a Unicode capable keyboard. Strings may use any or all of the methods
+of Unicode insertion. For example, to use a French word in a phrase
+needing an 'accent aigu', create the text like this:
+
+    say "Le Caf\xe9 Marly"; # OUTPUT: «Le Café Marly␤»
+
+Finally, here is a more complete example showing all the methods in one string:
+
+    say "\c[PENGUIN] went looking for \x1F41F but found only \o[375274,40,373046]."
+    # Output: «🐧 went looking for 🐟 but found only 🪼 😦.␤»
 
 =head2 Name aliases
 
@@ -210,7 +229,7 @@ commas to separate different codepoints/sequences inside the same C<\c> sequence
 
 =head2 Confusability
 
-Because of the number of glyphs in unicode, wider support means you may find some that are
+Because of the number of characters in unicode, wider support means you may find some that are
 confusable. For general tips on how to avoid issues, see
 L<Confusability|https://www.unicode.org/reports/tr39/#Confusable_Detection>
 at the unicode.org site.

--- a/doc/Language/unicode.rakudoc
+++ b/doc/Language/unicode.rakudoc
@@ -113,9 +113,9 @@ You can insert Unicode codepoints by number (decimal or hexadecimal or octal).
 For example, the character named "latin capital letter ae with macron" has 
 decimal codepoint 482, hexadecimal codepoint 0x1E2, and octal codepoint 0o742:
 
-    say "\c[482]"; # OUTPUT: «Ǣ␤»
-    say "\x1E2";   # OUTPUT: «Ǣ␤»
-    say "\o742";   # OUTPUT: «Ǣ␤»
+    say "\c[482]"; # OUTPUT: «Ǣ␤» (mnemonic aid: 'c - character name or decimal')
+    say "\x1E2";   # OUTPUT: «Ǣ␤» (mnemonic aid: 'x - hexidecimal')
+    say "\o742";   # OUTPUT: «Ǣ␤» (mnemonic aid: 'o - octal')
 
 Note any character following the hexidecimal and octal examples above will
 be interpreted as part of the conversion unless it is not valid for the number type.
@@ -172,7 +172,7 @@ needing an 'accent aigu', create the text like this:
 
     say "Le Caf\xe9 Marly"; # OUTPUT: «Le Café Marly␤»
 
-Finally, here is a more complete example showing all the methods in one string:
+Finally, here is a more complete example showing many of the methods in one string:
 
     say "\c[PENGUIN] went looking for \x1F41F but found only \o[375274,40,373046]."
     # Output: «🐧 went looking for 🐟 but found only 🪼 😦.␤»

--- a/doc/Language/unicode.rakudoc
+++ b/doc/Language/unicode.rakudoc
@@ -124,7 +124,7 @@ The same type of result would occur for the octal version if the ending characte
 was not in the set (0..7).
 
 Codepoint sequences can be made in a single string by following a codepoint entry
-with others or intermingled with single character and spaces, in other word: normal
+with others or intermingled with single characters, words, and spaces as normal
 text. Such codepoint entries are very useful for users who not have ready access to
 a Unicode capable keyboard.
 

--- a/doc/Language/unicode.rakudoc
+++ b/doc/Language/unicode.rakudoc
@@ -102,13 +102,36 @@ Please note that this encoding so far is not supported in the JVM implementation
 
 =head1 Entering unicode codepoints and codepoint sequences
 
-You can enter Unicode codepoints by number (decimal as well as hexadecimal). For example, the character named
-"latin capital letter ae with macron" has decimal codepoint 482 and hexadecimal codepoint 0x1E2:
+=head2 Entering codepoints by number
+
+You can enter Unicode codepoints by number (decimal as well as hexadecimal or octal). For example, the character named
+"latin capital letter ae with macron" has decimal codepoint 482, hexadecimal codepoint 0x1E2, and octal codepoint 0o742:
 
     say "\c[482]"; # OUTPUT: «Ǣ␤»
     say "\x1E2";   # OUTPUT: «Ǣ␤»
+    say "\o742";   # OUTPUT: «Ǣ␤»
 
-You can also access Unicode codepoints by name:
+Note any character following the hexidecimal and octal examples above will
+be interpreted as part of the conversion unless it is not valid for the number type.
+For example:
+
+    say "\x1E2";   # OUTPUT: «Ǣ␤»
+    say "\x1E2P";  # OUTPUT: «ǢP␤» ('P' is not a hexadecimal digit, result: 2 chars)
+    say "\x1E2 ";  # OUTPUT: «Ǣ ␤» (' ' is not a hexadecimal digit, result: 2 chars)
+    say "\x1E20";  # OUTPUT: «Ḡ␤»  ('0' is a hexidecimal digit', result: 1 char)
+
+The same type of result would occur for the octal version if the ending character
+was not in the set (0..7).
+
+Codepoint sequences can be made in a single string by following a codepoint entry
+with others or intermingled with single character and spaces, in other word: normal
+text. Such codepoint entries are very useful for users who not have ready access to
+a Unicode capable keyboard.
+
+=head2 Entering codepoints by name
+
+You can also access Unicode codepoints by name (which may be necessary when a 
+Unicode character has more than one format).
 Raku supports all Unicode names. X<|Syntax,\c[] unicode name>
 
     say "\c[PENGUIN]"; # OUTPUT: «🐧␤»

--- a/doc/Language/unicode.rakudoc
+++ b/doc/Language/unicode.rakudoc
@@ -137,7 +137,7 @@ Raku supports all Unicode names. X<|Syntax,\c[some name] Unicode name>
     say "\c[PENGUIN]"; # OUTPUT: «🐧␤»
     say "\c[BELL]";    # OUTPUT: «🔔␤» (U+1F514 BELL)
 
-All Unicode codepoint names and name sequences sequences are now case-insensitive:
+All Unicode codepoint names and name sequences are now case-insensitive:
 [Starting in Rakudo 2017.02]
 
     say "\c[latin capital letter ae with macron]"; # OUTPUT: «Ǣ␤»


### PR DESCRIPTION
## The problem

The current docs do not fully explain all the ways to enter Unicode
characters into a string.

## Solution provided

I have expanded the examples to show Unicode entry by octal number.
I have alse added a section on using numerical codepoint entries
in a mixed string of normal text.

Additionally, I inserted level 2 headings to better separate the
several types of Unicode entry.

Note the docs search mechanism needs to be made more aware of entering Unicode characters in strings.
