### PR TITLE
Split 5to6 section into 3 paragraphs

### DIFF
--- a/doc/Language/5to6-perlop.rakudoc
+++ b/doc/Language/5to6-perlop.rakudoc
@@ -47,13 +47,13 @@ my $list   = (1,);     # a List in a scalar container
 For the Perl C«=>» arrow, see the 
 L<Comma operator|/language/5to6-perlop#Comma_operator>.
 
-The dereferencing operator, C«->» is replaced by the dot, which is
+The dereferencing operator, C«->», is replaced by the dot, which is
 also used for method calls.  So Perl's C«$arrayref->[7]» becomes
 Raku's C<$arrayref.[7]> and C«$user->name» becomes C<$user.name>.
-Dereferencing is less common in Raku so most dots represent method calls.
+Note that dereferencing is rare in Raku.
 
 Raku uses the C<->> to attach L<Signatures|/language/Signature> to
-to Blocks, see L<Blocks|/language/Block>.
+L<Blocks|/language/Block>.
 
 =head2 Auto-increment and auto-decrement
 

--- a/doc/Language/5to6-perlop.rakudoc
+++ b/doc/Language/5to6-perlop.rakudoc
@@ -44,13 +44,16 @@ my $list   = (1,);     # a List in a scalar container
 
 =head2 The arrow operator
 
-As you typically will not be using references in Raku, the arrow is
-probably less useful as a dereferencing operator. If you do need to
-dereference something, however, the arrow is the dot. It is also the dot
-for method calls. So, Perl's C«$arrayref->[7]» becomes
-C<$arrayref.[7]> in Raku and, similarly, C«$user->name» becomes
-C<$user.name>. The C«=>» arrow is used for constructing L<C<Pair>|/type/Pair>s, see
-L<Pair term documentation|/language/terms#Pair>.
+For the Perl C«=>» arrow, see the 
+L<Comma operator|/language/5to6-perlop#Comma_operator>.
+
+The dereferencing operator, C«->» is replaced by the dot, which is
+also used for method calls.  So Perl's C«$arrayref->[7]» becomes
+Raku's C<$arrayref.[7]> and C«$user->name» becomes C<$user.name>.
+Dereferencing is less common in Raku so most dots represent method calls.
+
+Raku uses the C<->> to attach L<Signatures|/language/Signature> to
+to Blocks, see L<Blocks|/language/Block>.
 
 =head2 Auto-increment and auto-decrement
 


### PR DESCRIPTION
Split the _Language/5to6-perlop/The_arrow_operator_ section into 3 paragraphs.

Changed the `fat arrow` redirect to the more local 5to6-perlop#Comma_operator.  And put it first.

Reduced the text of the central point into the second paragraph.  Making a change so the first sentence need not be corrected by the second.           

The third pargraph briefly states the `->`'s Raku purpose with links.

My "dereferencing is rare in Raku" seems justified in my slight experience and by JJ's tone.  If not so, advise.    