### PR TITLE
Fix missing index entries

### DIFF
--- a/doc/Language/modules-core.rakudoc
+++ b/doc/Language/modules-core.rakudoc
@@ -9,8 +9,8 @@ note that the implementation is not part of the Raku specification and thus
 might be subject to change without prior notice. The following is a list of
 them, along with links to their source code.
 
-=head2 C<CompUnit::*> modules and roles
 X<|Modules,CompUnit (Rakudo classes)>
+=head2 C<CompUnit::*> modules and roles
 
 These modules are mostly used by distribution build tools, and are not intended
 to be used (at least until version 6.c) by the final user.

--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -3155,9 +3155,9 @@ lists are replaced by the value from applying the operator to the list:
     1..3 X~ <a b c> X~ 9
     # produces (1a9 1b9 1c9 2a9 2b9 2c9 3a9 3b9 3c9)
 
-=head2 infix C«...»
 X<|Infix operators,...>X<|Infix operators,...^>X<|Infix operators,^...>X<|Infix operators,^...^>
 X<|Infix operators,…>X<|Infix operators,…^>X<|Infix operators,^…>X<|Infix operators,^…^>
+=head2 infix C«...»
 
     multi infix:<...>(**@) is assoc<list>
     multi infix:<...^>(**@) is assoc<list>

--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -315,8 +315,8 @@ say "alive"; # this line is dead code
 CONTROL { .die };
 =end code
 
-=head2 Word quoting: qw
 X<|Syntax,qw word quote>
+=head2 Word quoting: qw
 
 =for code :allow<B L>
 qw|! @ # $ % ^ & * \| < > | eqv '! @ # $ % ^ & * | < >'.words.list;

--- a/doc/Language/syntax.rakudoc
+++ b/doc/Language/syntax.rakudoc
@@ -59,8 +59,8 @@ if True {say "Hello"}
 
 though you can't leave out any more whitespace in this last example.
 
-=head2 X<Unspace|Syntax,\>
 X<|Syntax,Unspace>
+=head2 X<Unspace|Syntax,\>
 
 In places where the compiler would not allow a space you can use
 any amount of whitespace, as long as it is quoted with a backslash.

--- a/doc/Language/typesystem.rakudoc
+++ b/doc/Language/typesystem.rakudoc
@@ -260,8 +260,8 @@ you must use private attribute notation instead.
     # OUTPUT: «C.new(attr => 42)␤
     #          C.new(attr => "answer")␤»
 
-=head4 Fallback method
 X<|Language,FALLBACK (method)>
+=head4 Fallback method
 
 A method with the special name C<FALLBACK> will be called when other means to
 resolve the name produce no result. The first argument holds the name and all

--- a/doc/Language/unicode_entry.rakudoc
+++ b/doc/Language/unicode_entry.rakudoc
@@ -14,8 +14,8 @@ available as actual characters on a keyboard.
 General information about entering unicode under various operating systems
 and environments can be found on the Wikipedia L<unicode input page|https://en.wikipedia.org/wiki/Unicode_input>.
 
-=head1 XCompose (Linux)
 X<|Reference,XCompose>
+=head1 XCompose (Linux)
 
 Xorg includes digraph support using a
 L<I<Compose key>|https://en.wikipedia.org/wiki/Compose_key#GNU.2FLinux> .
@@ -52,8 +52,8 @@ If you use KDE you can put this file in C<~/.config/plasma-workspace/env/compose
 and that should work. Other desktop environments will be different. Look up
 how to set environment variables in yours or use the system-wide option above.
 
-=head2 ibus
 X<|Reference,ibus>
+=head2 ibus
 
 If you have problems entering high codepoint symbols such as B<🐧> using the
 C<xim> input module, you can instead use ibus. You will have to install the ibus
@@ -66,8 +66,8 @@ ibus-daemon --xim --verbose --daemonize --replace
 Setting C<--xim> should also allow programs not using ibus to still use the xim
 input method and be backward compatible.
 
-=head1 XKB (Linux)
 X<|Reference,Xkb>
+=head1 XKB (Linux)
 
 The X Window System receives keyboard events using the XKB extension, which makes it possible to read the output of various kinds of keyboards, provided that there's a configuration file available.
 
@@ -350,8 +350,8 @@ and login back again.
 Note that since Ubuntu Gnome uses one C<Super> key for its own purposes, one might want to substitute one or
 both the Super_* keys with, for example, Meta_R.
 
-=head1 WinCompose (Windows)
 X<|Reference,WinCompose>
+=head1 WinCompose (Windows)
 
 L<WinCompose|https://github.com/samhocevar/wincompose> adds
 L<compose key|https://en.wikipedia.org/wiki/Compose_key> functionality to Windows.
@@ -433,8 +433,8 @@ L<digraphs|https://github.com/gfldex/digraphs> if you prefer a Raku friendly
 digraph table over L<RFC 1345|https://tools.ietf.org/html/rfc1345> or change it
 to your needs.
 
-=head2 Vim
 X<|Reference,Vim>
+=head2 Vim
 
 In L<Vim|https://www.vim.org/>, unicode characters are entered (in
 insert-mode) by pressing first C<Ctrl-V> (also denoted C<^V>), then C<u> and
@@ -466,8 +466,8 @@ configured to optionally replace ASCII based ops with their Unicode based
 equivalents. This will convert the ASCII based ops on the fly while typing
 them.
 
-=head2 Emacs
 X<|Reference,Emacs>
+=head2 Emacs
 
 In L<Emacs|https://www.gnu.org/software/emacs/>, unicode characters are
 entered by first entering the chord C<C-x 8 RET> at which point the

--- a/doc/Language/variables.rakudoc
+++ b/doc/Language/variables.rakudoc
@@ -11,8 +11,8 @@ followed optionally by a second special character named I<twigil> and then an
 L<identifier|/language/syntax#Identifiers>.
 
 
-=head1 Sigils
 X<|Syntax,$>X<|Syntax,@>X<|Syntax,% (sigil)>X<|Syntax,&>
+=head1 Sigils
 
 There are four sigils. The scalar-sigil C<$>, the positional-sigil C<@>, the
 associative-sigil C<%> and the callable-sigil C<&>.
@@ -184,8 +184,8 @@ C<@array>, such that it becomes an Array with a single element, namely a List.
 See L<operators|/language/operators> for more details on precedence and
 associativity.
 
-=head2 Sigilless variables
 X<|Syntax,\ (sigilless variables)>
+=head2 Sigilless variables
 
 Using the C<\> prefix, it's possible to create variables that do not
 have a sigil:
@@ -240,10 +240,9 @@ variable, that is, where that variable is defined and can be changed.
 
 =end table
 
-X<|Syntax,$*>
 X<|Language,Dynamically scoped variables>
-=head2 The C<*> twigil
 X<|Syntax,*>X<|Syntax,$*>X<|Syntax,@*>X<|Syntax,%*>X<|Syntax,&*>
+=head2 The C<*> twigil
 
 This twigil is used for dynamic variables which are looked up through the
 caller's, not through the outer, scope. Look at the example below.N<The example
@@ -306,8 +305,8 @@ scope when declared with C<our>. Dynamic resolution and resolution through
 symbol tables introduced with C<our> are two orthogonal issues.
 
 
-=head2 The C<?> twigil
 X<|Syntax,$?>X<|Syntax,?>X<|Syntax,$?>X<|Syntax,@?>X<|Syntax,%?>X<|Syntax,&?>
+=head2 The C<?> twigil
 
 Compile-time variables may be addressed via the C<?> twigil. They are known
 to the compiler and may not be modified after being compiled in. A popular
@@ -320,8 +319,8 @@ example for this is:
 For a list of these special variables, see
 L<compile-time variables|/language/variables#Compile-time_variables>.
 
-=head2 The C<!> twigil
 X<|Syntax,!>X<|Syntax,$!>X<|Syntax,@!>X<|Syntax,%!>X<|Syntax,&!>
+=head2 The C<!> twigil
 
 L<Attributes|/language/objects#Attributes> are variables that exist per instance
 of a class. They may be directly accessed from within the class via C<!>:
@@ -343,8 +342,8 @@ you though. For more details on objects, classes and their attributes see
 L<object orientation|/language/objects>.
 
 
-=head2 The C<.> twigil
 X<|Syntax,.>X<|Syntax,$.>X<|Syntax,@.>X<|Syntax,%.>X<|Syntax,&.>
+=head2 The C<.> twigil
 
 The C<.> twigil isn't really for variables at all. In fact, something along
 the lines of
@@ -376,8 +375,8 @@ is also possible:
 For more details on objects, classes and their attributes and methods see
 L<object orientation|/language/objects>.
 
-=head2 The C<^> twigil
 X<|Syntax,^>X<|Syntax,$^>X<|Syntax,@^>X<|Syntax,%^>X<|Syntax,&^>
+=head2 The C<^> twigil
 
 The C<^> twigil declares a formal positional parameter to blocks or subroutines;
 that is, variables of the form C<$^variable> are a type of placeholder variable.
@@ -417,8 +416,8 @@ in the L<Sigils table|#Sigils>. Thus C<@^array>, C<%^hash>, and C<&^fun> are all
 valid placeholder variables.
 
 
-=head2 The C<:> twigil
 X<|Syntax,:>X<|Syntax,$:>X<|Syntax,@:>X<|Syntax,%:>X<|Syntax,&:>
+=head2 The C<:> twigil
 
 The C<:> twigil declares a formal named parameter to a block or subroutine.
 Variables declared using this form are a type of placeholder variable too.
@@ -460,8 +459,8 @@ the L<semantics of that sigil|#Sigils>).  Thus C<@:array>, C<%:hash>, and
 C<&:fun> are all valid, and each creates a formal named parameter with the
 specified sigil.
 
-=head2 The C<=> twigil
 X<|Syntax,=>X<|Syntax,$=>X<|Syntax,@=>X<|Syntax,%=>X<|Syntax,&=>
+=head2 The C<=> twigil
 
 The C<=> twigil is used to access Pod variables. Every Pod block in the
 current file can be accessed via a Pod object, such as C<$=data>,
@@ -481,8 +480,8 @@ hierarchical data structure through C<$=pod>.
 Note that all those C<$=someBlockName> support the L<C<Positional>|/type/Positional> and the
 L<C<Associative>|/type/Associative> roles.
 
-=head2 The C<~> twigil
 X<|Syntax,$~>
+=head2 The C<~> twigil
 
 The C<~> twigil is for referring to sublanguages (called slangs). The
 following are useful:

--- a/doc/Type/IO/Handle.rakudoc
+++ b/doc/Type/IO/Handle.rakudoc
@@ -881,8 +881,8 @@ with 'test'.IO {
 
 Returns C<True> if the handle is open, C<False> otherwise.
 
-=head2 method t
 X<|Reference,tty>
+=head2 method t
 
     method t(IO::Handle:D: --> Bool:D)
 

--- a/doc/Type/Sub.rakudoc
+++ b/doc/Type/Sub.rakudoc
@@ -50,8 +50,8 @@ L<code, precedence and associativity|/language/functions#Defining_operators>.
 The syntax used in their definition is an example of
 L<extended identifiers|/language/syntax#Extended_identifiers>.
 
-=head1 Traits
 X<|Syntax,trait_mod (declarator)>
+=head1 Traits
 
 A C<Trait> is a sub that is applied at compile time to various objects like
 classes, routines or L<containers|/language/phasers#index-entry-will_trait>. It


### PR DESCRIPTION
Zero-width index directives don't seem to work if they appear after a heading, so fix all occurrences by moving them before the heading.

The broken index directives also had the side-effect of causing blank headings in some situations, e.g.

 - https://docs.raku.org/language/variables#Sigils
 - https://docs.raku.org/language/operators#infix_%2E%2E%2E
