### PR TITLE
Methods 'julian-date' and 'modified-julian-date' have incomplete description

### DIFF
--- a/doc/Type/DateTime.rakudoc
+++ b/doc/Type/DateTime.rakudoc
@@ -280,6 +280,9 @@ is used in astronomy to define times of celestial objects transiting the
 Earth's Prime Meridian. For any instant, it is the sum of the number of whole days and
 the fraction of a day from that epoch to that instant.
 
+Note the julian-date method does B<not> use any timezone information, and
+silently ignores it in the DateTime object.
+
 Available as of the 2021.04 Rakudo compiler release.
 
 =head2 method modified-julian-date
@@ -295,6 +298,9 @@ Likewise, the integral part of the I<MJD> is the same value as the C<daycount> f
 reference the same epoch (November 17, 1858).
 The MJD is obtained by subtracting the constant C<2_400_000.5> from the I<Julian Date> and is used to simplify
 transformations between civil and astronomical time systems.
+
+Note the modified-julian-date method does B<not> use any timezone information, and
+silently ignores it in the DateTime object.
 
 Available as of the 2021.04 Rakudo compiler release.
 


### PR DESCRIPTION
The methods are only defined for one timezone (UTC-0000) and cannot be converted to local time

There are currently no core methods to convert then to local time, but those routines are  available in distribution 'DateTime::Julian'.

Such details are missing from the current descriptions, and this PR attempts to remedy that.

- Addresses doc issue #4577
- Addresses doc issue #4575
