### PR TITLE
Update Date.rakudoc

### DIFF
--- a/doc/Type/Date.rakudoc
+++ b/doc/Type/Date.rakudoc
@@ -28,8 +28,7 @@ an object the current day according to the system clock.
     say $n - $d;                    # OUTPUT: «7␤», 7 days between New Years/Christmas Eve
     say $n + 1;                     # OUTPUT: «2016-01-01␤»
 
-B<Note> since version 6.d, .raku can be called on C<Date>. It will also
-reject synthetic numerics such as 7̈ .
+B<Note> since version 6.d, .raku can be called on C<Date>.
 
 =head1 Methods
 


### PR DESCRIPTION
 Remove extraneous statement that `.raku` will not accept numerics.

I think this PR might be improved by removing the preceding sentence:
```Note since version 6.d, .raku can be called on Date.```
but I am unsure whether the bug is that `v6.c` has it or that  the doc is incorrect.

