### PR TITLE
Update subscripts.rakudoc

### DIFF
--- a/doc/Language/subscripts.rakudoc
+++ b/doc/Language/subscripts.rakudoc
@@ -374,7 +374,7 @@ elements and dimensions.
     say %pantheon{'Bragi','Nótt';'consort'}; # 'consort' value for both keys
     # OUTPUT: «(Iðunn Dellingr)␤»
 
-X<|Syntax,flattening ;>
+X<|Syntax,flattening>
 
 Multidimensional subscripts can be used to flatten nested lists when combined
 with L<C<Whatever>|/type/Whatever>.


### PR DESCRIPTION
## The problem
An `;` inside `X<>` is a list delimiter, so **X<|xxxx**`,`**xxx**`;`**>** creates an empty list

## Solution provided
Remove extra `;`

This is the only file that has this error. 
