### PR TITLE
[Custom_operators_and_operator_overloading] Mention circumfix

### DIFF
--- a/doc/Language/js-nutshell.rakudoc
+++ b/doc/Language/js-nutshell.rakudoc
@@ -371,7 +371,7 @@ multi infix:<|-|>($a, $b) is equiv(&infix:<->) { abs $a - $b }
 say -1 |-| 3; # OUTPUT: 4
 =end code
 
-Operators can be defined as C<prefix>, C<infix>, or C<postfix>. The
+Operators can be defined as C<prefix>, C<infix>, C<postfix> or C<circumfix>. The
 C<is tighter>, C<is equiv>, and C<is looser> traits optionally define the
 operator's precedence. In this case, C<|-|> has the same precedence as C<->.
 


### PR DESCRIPTION
Under [Custom_operators_and_operator_overloading](https://docs.raku.org/language/js-nutshell#Custom_operators_and_operator_overloading)

> Operators can be defined as prefix, infix, or postfix.

Operators can be defined as prefix, infix, postfix or _circumfix_.
