### PR TITLE
Fix incorrect Proc::Async output #4324

### DIFF
--- a/doc/Type/Proc/Async.rakudoc
+++ b/doc/Type/Proc/Async.rakudoc
@@ -68,7 +68,7 @@ line: and
 line: Camelia
 line: ♥
 line: I
-Proc finished. Exit code: 0
+Proc finished: exitcode=0 signal=0
 Program finished
 =end code
 


### PR DESCRIPTION
## The problem
Referring to issue #4324, the output of `class Proc::Async` is incorrect in the template sample.  
## Solution Provided  
Adjust the output for [Proc::Async](https://docs.raku.org/type/Proc/Async).