### PR TITLE
standardizes the reference to the metamodel #4201

### DIFF
--- a/doc/Type/Metamodel/ConcreteRoleHOW.rakudoc
+++ b/doc/Type/Metamodel/ConcreteRoleHOW.rakudoc
@@ -32,7 +32,7 @@ The main difference with
 L<C<ClassHOW.new_type>|/type/Metamodel::ClassHOW#method_new_type> is that you
 can mix-in roles in this newly created one.
 
-This class is Rakudo specific, and provided only for completeness. Not really
-intended to be used by the final user.
+I<Warning>: this class is part of the Rakudo implementation, and is not
+a part of the language specification.
 
 =end pod

--- a/doc/Type/Metamodel/CurriedRoleHOW.rakudoc
+++ b/doc/Type/Metamodel/CurriedRoleHOW.rakudoc
@@ -62,7 +62,7 @@ a single parameter an instantiated role will also be of the same type:
     role Zape[::T] {};
     say Zape[Int].HOW; #: «Perl6::Metamodel::CurriedRoleHOW.new␤»
 
-I<Note>: As most of the C<Metamodel> classes, this class is here mainly for
-illustration purposes and it's not intended for the final user to instantiate.
+I<Note>: As with most of the C<Metamodel> classes, this one is mainly for illustration
+purposes and is not intended for the end user to instantiate.
 
 =end pod

--- a/doc/Type/Metamodel/ParametricRoleGroupHOW.rakudoc
+++ b/doc/Type/Metamodel/ParametricRoleGroupHOW.rakudoc
@@ -28,7 +28,7 @@ my \zape := Metamodel::ParametricRoleGroupHOW.new_type( name => "zape");
 my \zipi := Metamodel::ParametricRoleHOW.new_type( name => "zipi", group => zape);
 say zipi.HOW; # OUTPUT: «Perl6::Metamodel::ParametricRoleHOW.new␤»
 
-I<Note>: As most of the C<Metamodel> classes, this class is here mainly for
-illustration purposes and it's not intended for the final user to instantiate.
+I<Note>: As with most of the C<Metamodel> classes, this one is mainly for illustration
+purposes and is not intended for the end user to instantiate.
 
 =end pod

--- a/doc/Type/Metamodel/ParametricRoleHOW.rakudoc
+++ b/doc/Type/Metamodel/ParametricRoleHOW.rakudoc
@@ -39,8 +39,7 @@ say zipi.HOW; # OUTPUT: «Perl6::Metamodel::ParametricRoleHOW.new␤»
 The extra C<group> argument will need to be used to integrate it in a parametric
 role group, which will need to be defined in advance.
 
-I<Note>: As most of the C<Metamodel> classes, this one is here mainly for
-illustration purposes and it's not intended for the final user to instantiate,
-unless their intention is really to create a parametric role group.
+I<Note>: As with most of the C<Metamodel> classes, this one is mainly for illustration
+purposes and is not intended for the end user to instantiate.
 
 =end pod


### PR DESCRIPTION
## The Problem  
The reference to the `metamodel` is ambiguous, as mentioned in #4201.  

## Solution Provided  
Standardize and update the notes.