### PR TITLE
Update variables.rakudoc

### DIFF
--- a/doc/Language/variables.rakudoc
+++ b/doc/Language/variables.rakudoc
@@ -1358,7 +1358,7 @@ C<META6.json> file:
 
 Every resource file is added to an B<installed> Distribution and is
 accessible using a L<C<Hash>|/type/Hash>-like access to C<%?RESOURCES>, returning a
-C<Distribution::Resources> object:
+C<Distribution::Resource> object:
 
 =begin code
 my $foo-IO = %?RESOURCES<images/foo.jpg>;          # gets an object you can slurp
@@ -1371,7 +1371,7 @@ installed distribution, so do not rely on their values in any other
 case besides using them as keys for the C<%?RESOURCES> variable.
 
 The C<%?RESOURCES> variable is not implemented as a plain L<C<Hash>|/type/Hash>, but as an
-instance of the L<C<Distribution::Resources>|/type/Distribution::Resources> type, so do not expect to see
+instance of the L<C<Distribution::Resource>|/type/Distribution::Resource> type, so do not expect to see
 all available resource files in a distribution by printing or by using other
 ways to inspect its value. Instead, use the API described above to
 access particular files.
@@ -1395,7 +1395,7 @@ use Test;
 use MyLib;
 
 my $resources = my-resources;
-isa-ok $resources, Distribution::Resources;
+isa-ok $resources, Distribution::Resource;
 =end code
 
 The contents of the compile-time hash are thus exposed to the runtime code.


### PR DESCRIPTION
Distribution::Resources s/b singular, not plural

## The problem

There's a 404 deadlink [Distribution::Resources](https://docs.raku.org/type/Distribution/Resources) which I believe can be fixed by removing the s on the end of Resources.

## Solution provided

s/Distribution::Resources/Distribution::Resource/ 

in the link, the linktext, and for two other occurrences of this module name