### PR TITLE
Use the TV/Netflix analogy on Supplies also on the dedicated page /type/Supply. (Plus one other small proposal)

### DIFF
--- a/doc/Language/control.rakudoc
+++ b/doc/Language/control.rakudoc
@@ -991,7 +991,7 @@ tested again.
         say $i;
     }
 
-    my @str = "However Long".comb;          # Our very own .char routine:
+    my @str = "However Long".comb;          # Our very own .chars routine:
     loop (my $l = 0;;) {                    # Declare $l in outer scope
         last if !@str[$l++]                 # and count chars until we hit
     }                                       # an undefined element (Any)

--- a/doc/Type/Supply.rakudoc
+++ b/doc/Type/Supply.rakudoc
@@ -15,7 +15,13 @@ It is a thread-safe implementation of the
 L<Observer Pattern|https://en.wikipedia.org/wiki/Observer_pattern>,
 and central to supporting reactive programming in Raku.
 
-There are two types of Supplies: C<live> and C<on demand>. When tapping into a
+There are two types of Supplies: C<live> and C<on demand>. A C<live>
+supply is like a TV broadcast: those who tune in don't get previously emitted
+values. An C<on-demand> broadcast is like Netflix: everyone who starts streaming
+a movie (taps a supply), always starts it from the beginning (gets all the
+values), regardless of how many people are watching it right now. 
+
+Thus, when tapping into a
 C<live> supply, the tap will only see values that are flowing through the
 supply B<after> the tap has been created. Such supplies are normally infinite
 in nature, such as mouse movements. Closing such a tap does not stop mouse
@@ -26,7 +32,8 @@ A tap on an C<on demand> supply will initiate the production of values, and
 tapping the supply again may result in a new set of values. For example,
 C<Supply.interval> produces a fresh timer with the appropriate interval each
 time it is tapped. If the tap is closed, the timer simply stops emitting values
-to that tap.
+to that tap. Note that no history is kept for C<on-demand> supplies, instead, 
+the C<supply> block is run for each tap of the supply.
 
 A C<live> C<Supply> is obtained from the L<C<Supplier>|/type/Supplier>
 factory method C<Supply>. New values are emitted by calling C<emit> on

--- a/doc/Type/Supply.rakudoc
+++ b/doc/Type/Supply.rakudoc
@@ -17,10 +17,10 @@ and central to supporting reactive programming in Raku.
 
 There are two types of Supplies: C<live> and C<on demand>. A C<live>
 supply is like a TV broadcast: those who tune in don't get previously emitted
-values. An C<on-demand> broadcast is like a video streaming service: 
+values. An C<on-demand> broadcast is like a video streaming service:
 everyone who starts streaming a movie (taps a supply),
-always starts it from the beginning (gets all the values), 
-regardless of how many people are watching it right now. 
+always starts it from the beginning (gets all the values),
+regardless of how many people are watching it right now.
 
 Thus, when tapping into a
 C<live> supply, the tap will only see values that are flowing through the

--- a/doc/Type/Supply.rakudoc
+++ b/doc/Type/Supply.rakudoc
@@ -33,7 +33,7 @@ A tap on an C<on demand> supply will initiate the production of values, and
 tapping the supply again may result in a new set of values. For example,
 C<Supply.interval> produces a fresh timer with the appropriate interval each
 time it is tapped. If the tap is closed, the timer simply stops emitting values
-to that tap. Note that no history is kept for C<on-demand> supplies, instead, 
+to that tap. Note that no history is kept for C<on-demand> supplies, instead,
 the C<supply> block is run for each tap of the supply.
 
 A C<live> C<Supply> is obtained from the L<C<Supplier>|/type/Supplier>

--- a/doc/Type/Supply.rakudoc
+++ b/doc/Type/Supply.rakudoc
@@ -17,9 +17,10 @@ and central to supporting reactive programming in Raku.
 
 There are two types of Supplies: C<live> and C<on demand>. A C<live>
 supply is like a TV broadcast: those who tune in don't get previously emitted
-values. An C<on-demand> broadcast is like Netflix: everyone who starts streaming
-a movie (taps a supply), always starts it from the beginning (gets all the
-values), regardless of how many people are watching it right now. 
+values. An C<on-demand> broadcast is like a video streaming service: 
+everyone who starts streaming a movie (taps a supply),
+always starts it from the beginning (gets all the values), 
+regardless of how many people are watching it right now. 
 
 Thus, when tapping into a
 C<live> supply, the tap will only see values that are flowing through the


### PR DESCRIPTION
File `/type/Supply`: This topic was new to me when I read these docs. I struggled to understand the explanations on the page `/type/Supply` [(weblink)](https://docs.raku.org/language/concurrency#Supplies) right up until the point when I read the very good TV/Netflix analogy on `/language/concurrency`. Thus, here's a proposal to incorporate that analogy also in the dedicated page for Supplies.

File `/language/control`: Since strings have a `.chars` method rather than a `.char` method, that name looks more fitting to me here, unless I'm missing something.