### PR TITLE
Update Str.rakudoc (.lines & .words return Seq, not List)

### DIFF
--- a/doc/Type/Str.rakudoc
+++ b/doc/Type/Str.rakudoc
@@ -673,7 +673,7 @@ Examples:
     multi method lines(Str:D: $limit, :$chomp = True)
     multi method lines(Str:D: :$chomp = True)
 
-Returns a list of lines. By default, it chomps line endings the same as a
+Returns a L<C<Seq>|/type/Seq> of lines. By default, it chomps line endings the same as a
 call to C<$input.comb( / ^^ \N* /, $limit )> would. To keep line endings,
 set the optional named parameter C<$chomp> to C<False>.
 
@@ -708,7 +708,7 @@ Use L<elems|/routine/elems> call on the returned L<C<Seq>|/type/Seq> instead:
     multi method words(Str:D: $limit)
     multi method words(Str:D:)
 
-Returns a list of non-whitespace bits, i.e. the same as a call to
+Returns a L<C<Seq>|/type/Seq> of non-whitespace bits, i.e. the same as a call to
 C<$input.comb( / \S+ /, $limit )> would.
 
 Examples:


### PR DESCRIPTION
Change "list" to L<C<Seq>|/type/Seq> where this is relevant (.lines, .words)

## The problem

Old description of these methods as returning a "list" is now misleading.

## Solution provided

Changed "list" to  L<C<Seq>|/type/Seq> in descriptions of methods .lines, .words