### PR TITLE
Update section `trait is rw` in Routine.rakudoc

### DIFF
--- a/doc/Type/Routine.rakudoc
+++ b/doc/Type/Routine.rakudoc
@@ -245,13 +245,13 @@ sub walk(\thing, *@keys) is rw {
 my %hash;
 walk(%hash, 'some', 'key', 1, 2) = 'autovivified';
 
-say %hash.raku;
+say %hash;
 =end code
 
 produces
 
 =begin code
-("some" => {"key" => [Any, [Any, Any, "autovivified"]]}).hash
+{some => {key => [(Any) [(Any) (Any) autovivified]]}}
 =end code
 
 Note that C<return> marks return values as read only; if you need an early exit


### PR DESCRIPTION
With Rakudo Star v2025.08, the output of the code example is different than currently stated in the doc page. The apparent reason is that `say %hash.raku` now produces output in a different format. In this specific example, it's

`{:some(${:key($[Any, [Any, Any, "autovivified"]])})}`

Since this is rather unwieldy, I propose changing `say %hash.raku` to `say %hash`, with which the output is

{some => {key => [(Any) [(Any) (Any) autovivified]]}}

The same output would also be produces by `say %hash.gist`.