### PR TITLE
Further simplify display by `say` line of `is rw` example in Routine.rakudoc

### DIFF
--- a/doc/Type/Routine.rakudoc
+++ b/doc/Type/Routine.rakudoc
@@ -245,13 +245,13 @@ sub walk(\thing, *@keys) is rw {
 my %hash;
 walk(%hash, 'some', 'key', 1, 2) = 'autovivified';
 
-say %hash;
+say %hash<some><key>[1][2];
 =end code
 
 produces
 
 =begin code :lang<output>
-{some => {key => [(Any) [(Any) (Any) autovivified]]}}
+autovivified
 =end code
 
 Note that C<return> marks return values as read only; if you need an early exit


### PR DESCRIPTION
Imo the PR by @schultzdavid that was just merged was a step in the right direction, but didn't go far enough.

## The problem

The output display for the `is rw` example for routines remains too complex for reference doc.

(I am presuming we want to have reference doc for the `is rw` trait.)

All that really matters is that the reader sees that whatever is returned by a routine marked `is rw` is a read-write variable (aka an "l-value", i.e. it can be assigned to). Or, more specifically, that walk(%hash, 'some', 'key', 1, 2) = 'autovivified'; works.

## Solution provided

The `say` line and its output change from:
```
say %hash;

{some => {key => [(Any) [(Any) (Any) autovivified]]}}
```
to:
```
say %hash<some><key>[1][2] = 'autovivified';

autovivified
```

## Notes

* I have saved a full rationale in a gist if whoever reads this (@coke?) does not agree (that the output is still too complex for good reference doc, and the change in this PR further improves the doc).

* As a tangent, the routine code in the example is _also_ too complex for good reference doc for `is rw`. But without reading some large swathe of the doc I wouldn't know whether there's a significant negative impact if we chop the code down to the tiny two liner or so it should be. So for this PR I've focused on just further improving on the good direction we agree @schultzdavid took the `say` part.
