### PR TITLE
Update section `method wrap` in Routine.rakudoc: Link to Re-dispatching

### DIFF
--- a/doc/Type/Routine.rakudoc
+++ b/doc/Type/Routine.rakudoc
@@ -84,8 +84,8 @@ methods, the first element of the Capture needs to be the invocant:
 Wraps (i.e. in-place modifies) the routine. That means a call to this routine
 first calls C<&wrapper>, which then can (but doesn't have to) call the
 original routine with the C<callsame>, C<callwith>, C<nextsame> and
-C<nextwith> dispatchers. The return value from the routine is also
-the return value from the wrapper.
+C<nextwith> L<dispatchers|/language/functions#Re-dispatching>. 
+The return value from the routine is also the return value from the wrapper.
 
 C<wrap> returns an instance of a private class called
 L<C<Routine::WrapHandle>|/type/Routine::WrapHandle>,


### PR DESCRIPTION
Since `callsame`, `callwith` etc. are mentioned in the text, link to where they are defined, namely to https://docs.raku.org/language/functions#Re-dispatching
