### PR TITLE
Update faq.rakudoc -- misleading link

### DIFF
--- a/doc/Language/faq.rakudoc
+++ b/doc/Language/faq.rakudoc
@@ -352,7 +352,7 @@ say "I ❤ 🦋".encode.gist;  # OUTPUT: «utf8:0x<49 20 E2 9D A4 20 F0 9F A6 8B
 
 =head2 String: How can I remove from a string some characters by index?
 
-Use L<.comb|/routine/comb> to transform it to a L<C<Seq>|/type/Seq>, then the L<(-) infix|/language/operators#infix_-> to remove the unwanted indices:
+Use L<.comb|/routine/comb> to transform it to a L<C<Seq>|/type/Seq>, then the L<(-) infix|/language/operators#infix_(-),_infix_%E2%88%96> to remove the unwanted indices:
 
 =begin code
 say '0123456789'.comb[(^* (-) (1..3, 8).flat).keys.sort].join;  # OUTPUT: «045679␤»


### PR DESCRIPTION
text mentions set difference operator, but links to subtraction operator

## The problem

specifically, text discusses 

https://docs.raku.org/language/operators#infix_(-),_infix_%E2%88%96 

but links instead to

https://docs.raku.org/language/operators#infix_-


## Solution provided

changed to the link to the intended doc