### PR TITLE
In `operators.rakudoc#infix_.=`, clarify usage of infix & postfix operator, and add link

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -1282,16 +1282,17 @@ surrounding whitespace (before and/or after) to distinguish them.
 Calls the right-side method on the value in the left-side container,
 replacing the resulting value in the left-side container.
 
-In most cases, this behaves identically to the postfix mutator, but the
-precedence is lower:
+In most cases, this behaves identically to postfix L<C<.=>|#methodop_.=>,
+but the precedence is lower:
 
 =for code
 my $a = -5;
-say ++$a.=abs;
+say ++$a.=abs; # with postfix mutator; equivalent to ++($a.=abs)
 # OUTPUT: «6␤»
 =for code :skip-test<illustrates error>
-say ++$a .= abs;
-# OUTPUT: «Cannot modify an immutable Int␤
+my $a = -5;
+say ++$a .= abs; # with infix mutator; evaluated as -4 .= abs
+# OUTPUT: «Cannot modify an immutable Int (-4)␤
 #           in block <unit> at <tmp> line 1␤␤»
 
 =head2 infix C«.»


### PR DESCRIPTION
[The section that's affected.](https://docs.raku.org/language/operators#infix_.=)

Added a link to the postfix counterpart of infix `.=` and rephrased that sentence slightly; updated the error message generated by the second code example.

The overall code example is now slightly more verbose. I think this is justified because it's the first example in the section `Dotty infix precedence`.