### PR TITLE
In section `Inheritance_and_multis` of `typesystem.rakudoc`, clarify wording and code example

### DIFF
--- a/doc/Language/typesystem.rakudoc
+++ b/doc/Language/typesystem.rakudoc
@@ -208,20 +208,20 @@ first argument.
 
 =head4 Inheritance and multis
 
-A normal method in a subclass does not compete with multis of a parent class.
+For a normal method in a subclass, there is no competition from multi methods in a parent class.
 
-    class A {
+    class Parent {
         multi method m(Int $i){ say 'Int' }
-        multi method m(int $i){ say 'int' }
+        multi method m(int $i){ say 'int' } # int is a subclass of Int
     }
 
-    class B is A {
-        method m(Int $i){ say 'B::Int' }
+    class Child is Parent {
+        method m(Int $i){ say 'Child::Int' }
     }
 
     my int $i;
-    B.new.m($i);
-    # OUTPUT: «B::Int␤»
+    Child.new.m($i);
+    # OUTPUT: «Child::Int␤»
 
 X«|Syntax,only method»
 =head4 Only method

--- a/doc/Language/typesystem.rakudoc
+++ b/doc/Language/typesystem.rakudoc
@@ -211,17 +211,17 @@ first argument.
 For a normal method in a subclass, there is no competition from multi methods in a parent class.
 
     class Parent {
+        multi method m(Numeric $i){ say 'Numeric' }
         multi method m(Int $i){ say 'Int' }
-        multi method m(int $i){ say 'int' } # int is a subclass of Int
     }
 
     class Child is Parent {
-        method m(Int $i){ say 'Child::Int' }
+        method m(Numeric $i){ say 'Child::Numeric' }
     }
 
-    my int $i;
+    my Int $i;
     Child.new.m($i);
-    # OUTPUT: «Child::Int␤»
+    # OUTPUT: «Child::Numeric␤»
 
 X«|Syntax,only method»
 =head4 Only method


### PR DESCRIPTION
[This is the section that's affected.](https://docs.raku.org/language/typesystem#Inheritance_and_multis)

I found it difficult to understand what is meant by the original phrase _"does not compete with"_. The replacement with _"there is no competition from"_ should be clearer and easier to parse.

In the code, change class names `A` and `B` to `Parent` and `Child`, and add comment that `int` is a subclass of `Int` (which is important to know in order to understand what goes on).
