### PR TITLE
In `typesystem.rakudoc`, replace ambiguous word "it" by explicit "`.bless`"

### DIFF
--- a/doc/Language/typesystem.rakudoc
+++ b/doc/Language/typesystem.rakudoc
@@ -243,7 +243,7 @@ L<.bless|/type/Mu#method_bless>. It
 is meant to set private and public attributes of a class and receives all named
 attributes passed into C<.bless>. The default
 constructor L<.new|/type/Mu#method_new> defined in L<C<Mu>|/type/Mu> is the method that
-invokes it. Given that public accessor methods are not available in C<BUILD>,
+invokes C<.bless>. Given that public accessor methods are not available in C<BUILD>,
 you must use private attribute notation instead.
 
     class C {


### PR DESCRIPTION
[This is the section that's affected.](https://docs.raku.org/language/typesystem#submethod_BUILD)

Currently the text reads (partly because the paragraph begins by stating that `BUILD` is called indirectly) as if "it" was referring to `BUILD`, which would be the reverse meaning.

Sources: 
https://docs.raku.org/type/Mu#method_bless
https://github.com/rakudo/rakudo/blob/5147b67f7abdfdec698abf2c7dd048dee5b9644f/src/core.c/Mu.rakumod#L141