### PR TITLE
In section `trait is nodal` of typesystem.rakudoc, add link to definition of term "hyperoperator"

### DIFF
--- a/doc/Language/typesystem.rakudoc
+++ b/doc/Language/typesystem.rakudoc
@@ -326,7 +326,7 @@ C<:&attr-with-code-in-it>, and so on.
 
 =head3 trait C<is nodal>
 
-Marks a L<C<List>|/type/List> method to indicate to hyperoperator to not descend into inner
+Marks a L<C<List>|/type/List> method to indicate to L<hyperoperators|/language/operators#Hyper_operators> to not descend into inner
 L<C<Iterable>|/type/Iterable>s to call this method. This trait generally isn't
 something end users would be using, unless they're subclassing or augmenting
 core L<C<List>|/type/List> type.


### PR DESCRIPTION
Link to definition of Hyper operators, because this is the first occurence of this term in this file.