### PR TITLE
In signatures.rakudoc, remark that "invocant marker" gets explained in the following section

### DIFF
--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -99,7 +99,7 @@ L<C<Signature>|/type/Signature> literals can contain string/numeric literals
     my $sig = :('Þor', Str, Int);
     say <Þor Hammer 1> ~~ $sig; # OUTPUT: «True␤»
 
-And they can also contain the invocant marker
+And they can also contain the invocant marker, explained in the next section:
 
     class Foo {
         method bar( $self: ){ "baz" }


### PR DESCRIPTION
This is the first time the novel term "invocant marker" is used in this document, so let readers know that they'll find it explained immediately hereafter.