### PR TITLE
In signatures.rakudoc, remove mention of nonexistent trait `is optional`, and change `=:=` to `===`

### DIFF
--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -1002,14 +1002,15 @@ Table showing checks of whether an argument was passed for a given parameter:
 
 A parameter with a default is always I<optional>, so there is no need to mark it with a C<?>.
 
-Then you can use the C<=:=> L<container identity operator|https://docs.raku.org/language/operators#infix_=:=> in the body of the routine to check
-whether this exact default was bound to the parameter.
+Then you can use the C<===> L<value identity operator|https://docs.raku.org/language/operators#infix_===> in the body of the routine to check
+whether this exact default object was bound to the parameter. These examples use names like C<PositionalAt> to reflect that the C<.WHICH> test 
+invoked by C<===> returns an object of type L<C<ObjAt>|/type/ObjAt>.
 
 Example with a positional parameter:
 =begin code
 my constant PositionalAt = Positional.new;
 
-sub a (@list = PositionalAt) { say @list =:= PositionalAt }
+sub a (@list = PositionalAt) { say @list === PositionalAt }  # here, one can also use =:=, the container indentity operator
 a;              # OUTPUT: «True␤»
 a [1, 2, 3];    # OUTPUT: «False␤»
 =end code
@@ -1018,7 +1019,7 @@ Example with some scalar parameters:
 =begin code
 my constant AnyAt = Any.new;
 
-sub b ($x=AnyAt, :$y=AnyAt) { say $x =:= AnyAt; say $y =:= AnyAt }
+sub b ($x=AnyAt, :$y=AnyAt) { say $x === AnyAt; say $y === AnyAt }  # here, =:= would always produce False
 b 1;            # OUTPUT: «False␤True␤»
 b 1, :2y;       # OUTPUT: «False␤False␤»
 =end code
@@ -1034,9 +1035,6 @@ c;              #Omitted
 c (Int);        #Undefined
 c 42;           #Defined
 =end code
-
-The examples use names like C<PositionalAt> to reflect that the C<.WHICH> test returns an object of type L<C<ObjAt>|/type/ObjAt>,
-you are free to make up you own names.
 
 =head1 Dynamic variables
 

--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -1000,7 +1000,7 @@ Table showing checks of whether an argument was passed for a given parameter:
 
 ¹ A suitable default is an Object that has a distinct identity, as may be checked by the L<C<WHICH>|https://docs.raku.org/type/Mu#method_WHICH> method.
 
-A parameter with a default is always I<optional>, so there is no need to mark it with a C<?> or the C<is optional> trait.
+A parameter with a default is always I<optional>, so there is no need to mark it with a C<?>.
 
 Then you can use the C<=:=> L<container identity operator|https://docs.raku.org/language/operators#infix_=:=> in the body of the routine to check
 whether this exact default was bound to the parameter.

--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -1003,7 +1003,7 @@ Table showing checks of whether an argument was passed for a given parameter:
 A parameter with a default is always I<optional>, so there is no need to mark it with a C<?>.
 
 Then you can use the C<===> L<value identity operator|https://docs.raku.org/language/operators#infix_===> in the body of the routine to check
-whether this exact default object was bound to the parameter. These examples use names like C<PositionalAt> to reflect that the C<.WHICH> test 
+whether this exact default object was bound to the parameter. These examples use names like C<PositionalAt> to reflect that the C<.WHICH> test
 invoked by C<===> returns an object of type L<C<ObjAt>|/type/ObjAt>.
 
 Example with a positional parameter:


### PR DESCRIPTION
[This is the section that's affected.](https://docs.raku.org/language/signatures#Was_an_argument_passed_for_a_parameter?)

Trying to use the trait "is optional" in a function signature throws error "Can't use unknown trait" (in all of v6.c, v6.d and v6.e.PREVIEW).

Perhaps some mention should be retained, though, if that trait was present in older versions.